### PR TITLE
feat(mobile): add account deletion to Settings

### DIFF
--- a/packages/emitsignal-mobile/app/(tabs)/settings.tsx
+++ b/packages/emitsignal-mobile/app/(tabs)/settings.tsx
@@ -68,7 +68,7 @@ export default function SettingsScreen() {
     const { currentScheme, setTheme, theme } = useTheme();
     const { feedStyle, setFeedStyle } = useFeedStyle();
     const { sections, setSection } = useDebugSections();
-    const { signOut, user } = useSession();
+    const { deleteAccount, signOut, user } = useSession();
     const palette = palettes[currentScheme];
     const styles = useMemo(() => createStyles(palette), [palette]);
     const bottomInset = useTabBarInset();
@@ -165,24 +165,62 @@ export default function SettingsScreen() {
                 <SectionLabel>ACCOUNT</SectionLabel>
                 <View style={styles.group}>
                     {user ? (
-                        <Pressable
-                            onPress={() => {
-                                Alert.alert('Sign out', 'Are you sure you want to sign out?', [
-                                    { style: 'cancel', text: 'Cancel' },
-                                    {
-                                        onPress: async () => {
-                                            await signOut();
-                                            router.replace('/auth');
+                        <>
+                            <Pressable
+                                onPress={() => {
+                                    Alert.alert(
+                                        'Delete account',
+                                        'This permanently deletes your account and all associated data. This cannot be undone.',
+                                        [
+                                            { style: 'cancel', text: 'Cancel' },
+                                            {
+                                                onPress: async () => {
+                                                    const { error } = await deleteAccount();
+
+                                                    if (error) {
+                                                        Alert.alert(
+                                                            'Could not delete account',
+                                                            error,
+                                                        );
+                                                        return;
+                                                    }
+
+                                                    router.replace('/auth');
+                                                },
+                                                style: 'destructive',
+                                                text: 'Delete',
+                                            },
+                                        ],
+                                    );
+                                }}
+                                style={styles.row}
+                            >
+                                <Text style={[styles.rowLabel, { color: palette.red }]}>
+                                    Delete account
+                                </Text>
+                            </Pressable>
+
+                            <Pressable
+                                onPress={() => {
+                                    Alert.alert('Sign out', 'Are you sure you want to sign out?', [
+                                        { style: 'cancel', text: 'Cancel' },
+                                        {
+                                            onPress: async () => {
+                                                await signOut();
+                                                router.replace('/auth');
+                                            },
+                                            style: 'destructive',
+                                            text: 'Sign out',
                                         },
-                                        style: 'destructive',
-                                        text: 'Sign out',
-                                    },
-                                ]);
-                            }}
-                            style={[styles.row, styles.rowLast]}
-                        >
-                            <Text style={[styles.rowLabel, { color: palette.red }]}>Sign out</Text>
-                        </Pressable>
+                                    ]);
+                                }}
+                                style={[styles.row, styles.rowLast]}
+                            >
+                                <Text style={[styles.rowLabel, { color: palette.red }]}>
+                                    Sign out
+                                </Text>
+                            </Pressable>
+                        </>
                     ) : (
                         <Pressable
                             onPress={() => router.push('/auth')}

--- a/packages/emitsignal-mobile/ctx/session.tsx
+++ b/packages/emitsignal-mobile/ctx/session.tsx
@@ -11,6 +11,7 @@ const DEVICE_ID_KEY = '@emitsignal/device_id';
 const PUSH_TOKEN_KEY = '@emitsignal/push_token';
 
 export interface SessionContextValue {
+    deleteAccount: () => Promise<{ error: null | string }>;
     loading: boolean;
     signOut: () => Promise<void>;
     user: null | SessionUser;
@@ -64,6 +65,23 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     }, [data?.user?.id]);
 
     const value: SessionContextValue = {
+        deleteAccount: async () => {
+            const { error } = await authClient.deleteUser();
+
+            if (error) {
+                return { error: error.message ?? 'Deletion failed' };
+            }
+
+            setAuthToken(null);
+
+            await clearOnboardingComplete();
+
+            // Same rationale as signOut below: the identity is gone, drop every
+            // cached query so the anonymous device starts fresh.
+            queryClient.clear();
+
+            return { error: null };
+        },
         loading: isPending,
         signOut: async () => {
             await authClient.signOut();


### PR DESCRIPTION
## Summary
- Adds a `deleteAccount()` method to the mobile session context, calling Better Auth's core `deleteUser()` (already enabled server-side with storage/Stripe cleanup hooks) and clearing local auth state on success.
- Adds a "Delete account" option to the Settings > Account section, confirmed via a native destructive `Alert.alert`, matching the existing Sign out pattern.

This closes the gap causing an Apple App Store rejection under Guideline 5.1.1(v) — account creation was supported but account deletion was not available in-app.

## Test plan
- [ ] Sign in on a physical device, go to Settings > Account > Delete account, confirm the alert, verify the account is deleted and the app returns to `/auth`
- [ ] Record the flow for App Store Connect's review notes