### PR TITLE
fix: address PR #15 review follow-ups (boot-blocking config, Sentry flood, website nits)

### DIFF
--- a/packages/emitsignal-docker/.env.example
+++ b/packages/emitsignal-docker/.env.example
@@ -24,6 +24,21 @@ API_URL=https://api.yourdomain.com
 # derive the auth cookie domain (the shared parent of the website + API subdomain).
 APP_URL=https://yourdomain.com
 
+# ── Reverse proxy ─────────────────────────────────────────────────────────────
+# Which request header carries the real client IP. Rate limiting keys on it, so
+# getting this wrong is not cosmetic:
+#   none             — trust nothing; use the TCP peer address (safe default,
+#                      correct only when the server is exposed directly)
+#   cf-connecting-ip — behind Cloudflare
+#   x-real-ip        — behind Nginx with `proxy_set_header X-Real-IP $remote_addr`
+#   x-forwarded-for  — behind Traefik/ALB; the rightmost public hop is used
+#
+# Leave as `none` and every request behind a proxy shares one rate-limit bucket
+# keyed on the proxy's IP — anonymous publish/upload/SSE will 429 platform-wide.
+# Set this to whatever your proxy actually sets, and make sure the proxy
+# overwrites (not appends to) that header on inbound requests.
+TRUSTED_PROXY_HEADER=none
+
 # ── Email ─────────────────────────────────────────────────────────────────────
 EMAIL_PROVIDER=log
 EMAIL_FROM=EmitSignal <noreply@emitsignal.com>

--- a/packages/emitsignal-docker/docker-compose.yml
+++ b/packages/emitsignal-docker/docker-compose.yml
@@ -137,7 +137,7 @@ services:
             STRIPE_PRICE_PULSE_YEARLY: '${STRIPE_PRICE_PULSE_YEARLY:-}'
             STRIPE_SECRET_KEY: '${STRIPE_SECRET_KEY:-}'
             STRIPE_WEBHOOK_SECRET: '${STRIPE_WEBHOOK_SECRET:-}'
-            TRUSTED_PROXY_HEADER: '${TRUSTED_PROXY_HEADER:-}'
+            TRUSTED_PROXY_HEADER: '${TRUSTED_PROXY_HEADER:-none}'
             UPLOAD_DIR: './uploads'
         healthcheck:
             interval: 15s

--- a/packages/emitsignal-server/README.md
+++ b/packages/emitsignal-server/README.md
@@ -92,6 +92,28 @@ data: {"id":"…","title":"…","body":"…","priority":4,"tags":[…],"actions"
 | `EMAIL_FROM`            | `EmitSignal <noreply@…>`    | Sender address                                   |
 | `FILE_STORAGE_PROVIDER` | `local`                     | `local` \| `s3`                                  |
 | `UPLOAD_DIR`            | `./uploads`                 | Directory for local file uploads                 |
+| `TRUSTED_PROXY_HEADER`  | `none`                      | Header carrying the real client IP — see below   |
+
+### Running behind a reverse proxy
+
+Rate limiting keys on the client IP, so the server has to know where that IP comes
+from. `TRUSTED_PROXY_HEADER` selects the one header it will believe:
+
+| Value              | Use when                                                           |
+| ------------------ | ------------------------------------------------------------------ |
+| `none` (default)   | The server is exposed directly; the TCP peer address is the client |
+| `cf-connecting-ip` | Behind Cloudflare                                                  |
+| `x-real-ip`        | Behind Nginx with `proxy_set_header X-Real-IP $remote_addr`        |
+| `x-forwarded-for`  | Behind Traefik/ALB; the rightmost public hop in the list is used   |
+
+Every other header is ignored, so a client cannot spoof its way into a fresh
+rate-limit bucket. **The flip side matters just as much:** leave this at `none`
+while running behind a proxy and every anonymous request keys on the proxy's IP,
+which drains the shared anonymous publish/upload/SSE budgets platform-wide. The
+server logs a warning at startup when it sees `none` in production.
+
+Whichever header you pick, the proxy must _overwrite_ it on inbound requests
+rather than append to a client-supplied value.
 
 ### SMTP (when `EMAIL_PROVIDER=smtp`)
 

--- a/packages/emitsignal-server/src/http/plugins/rate-limit-plugin.ts
+++ b/packages/emitsignal-server/src/http/plugins/rate-limit-plugin.ts
@@ -10,6 +10,13 @@ import { resolveUserId } from '../auth/plugin';
 
 const LIMITER_UNAVAILABLE_RETRY_SECONDS = 30;
 
+// A limiter outage fails every request, so reporting per-request would emit
+// thousands of identical events and burn the Sentry quota during the exact
+// incident the alert is for. One event per window is enough to page someone.
+const LIMITER_ERROR_REPORT_INTERVAL_MS = 60_000;
+
+let lastLimiterErrorReportedAt = 0;
+
 export interface ConsumeLimitOptions {
     // reject rather than allow when the limiter backend is
     // unreachable. Set this on anonymous write paths, where the rate limiter is
@@ -74,7 +81,7 @@ export async function consumeLimit(
         // on every route. Surface it as an exception so it actually pages someone,
         // instead of only landing in a log nobody is watching.
         logger.error({ error, failClosed: options.failClosed === true, key }, 'rate limiter error');
-        Sentry.captureException(error, { tags: { component: 'rate-limiter' } });
+        reportLimiterError(error);
 
         if (options.failClosed) {
             set.headers['retry-after'] = String(LIMITER_UNAVAILABLE_RETRY_SECONDS);
@@ -105,6 +112,18 @@ export function fixedKeyBeforeHandle<TBody = unknown>(
     }) => {
         return consumeLimit(limiter, getKey({ body, request, server }), set);
     };
+}
+
+function reportLimiterError(error: unknown): void {
+    const now = Date.now();
+
+    if (now - lastLimiterErrorReportedAt < LIMITER_ERROR_REPORT_INTERVAL_MS) {
+        return;
+    }
+
+    lastLimiterErrorReportedAt = now;
+
+    Sentry.captureException(error, { tags: { component: 'rate-limiter' } });
 }
 
 export const rateLimitPlugin = new Elysia({ name: 'rate-limit' })

--- a/packages/emitsignal-server/src/index.ts
+++ b/packages/emitsignal-server/src/index.ts
@@ -124,6 +124,17 @@ logger.info(
         `(env: ${environment.NODE_ENV}, trusted proxy header: ${environment.TRUSTED_PROXY_HEADER})`,
 );
 
+// Almost every production deployment sits behind a proxy. Leaving this unset
+// there collapses every anonymous caller onto the proxy's IP, so the shared
+// rate-limit buckets exhaust platform-wide instead of per client.
+if (isProduction && environment.TRUSTED_PROXY_HEADER === 'none') {
+    logger.warn(
+        'TRUSTED_PROXY_HEADER is "none" in production: client IPs come from the TCP peer address. ' +
+            'If this server is behind a proxy or CDN, set it to the header your proxy sets ' +
+            '(cf-connecting-ip, x-real-ip, or x-forwarded-for) or all anonymous traffic will share one rate-limit bucket.',
+    );
+}
+
 let isShuttingDown = false;
 
 async function shutdown() {

--- a/packages/emitsignal-server/src/schema/__tests__/environment.spec.ts
+++ b/packages/emitsignal-server/src/schema/__tests__/environment.spec.ts
@@ -1,0 +1,39 @@
+import { Value } from '@sinclair/typebox/value';
+import { describe, expect, it } from 'bun:test';
+
+import { environmentSchema } from '../environment';
+
+// The schema runs at import time, so anything it rejects is a boot failure with
+// no route to a health check. These cases all reached production configs before.
+describe('environmentSchema', () => {
+    it('defaults TRUSTED_PROXY_HEADER to none when the variable is absent', () => {
+        const parsed = Value.Parse(environmentSchema, {});
+
+        expect(parsed.TRUSTED_PROXY_HEADER).toBe('none');
+    });
+
+    it('rejects an empty TRUSTED_PROXY_HEADER', () => {
+        // TypeBox applies `default` only for absent keys, so a compose file
+        // written as `${TRUSTED_PROXY_HEADER:-}` passes '' and throws. Callers
+        // must supply a real literal — see docker-compose.yml.
+        expect(() => Value.Parse(environmentSchema, { TRUSTED_PROXY_HEADER: '' })).toThrow();
+    });
+
+    it('accepts every documented proxy header', () => {
+        for (const header of ['none', 'cf-connecting-ip', 'x-real-ip', 'x-forwarded-for']) {
+            expect(Value.Parse(environmentSchema, { TRUSTED_PROXY_HEADER: header })).toMatchObject({
+                TRUSTED_PROXY_HEADER: header,
+            });
+        }
+    });
+
+    it('accepts a NODE_ENV outside the three well-known values', () => {
+        const parsed = Value.Parse(environmentSchema, { NODE_ENV: 'staging' });
+
+        expect(parsed.NODE_ENV).toBe('staging');
+    });
+
+    it('defaults NODE_ENV to development', () => {
+        expect(Value.Parse(environmentSchema, {}).NODE_ENV).toBe('development');
+    });
+});

--- a/packages/emitsignal-server/src/schema/environment.ts
+++ b/packages/emitsignal-server/src/schema/environment.ts
@@ -6,7 +6,7 @@ import { Value } from '@sinclair/typebox/value';
 // BETTER_AUTH_SECRET is set to something other than this value.
 const DEV_BETTER_AUTH_SECRET = 'emitsignal-dev-better-auth-secret-32chars!!';
 
-const environmentSchema = Type.Object({
+export const environmentSchema = Type.Object({
     API_URL: Type.String({ default: 'http://localhost:5001' }),
     APP_URL: Type.String({ default: 'http://localhost:5002' }),
 
@@ -44,10 +44,11 @@ const environmentSchema = Type.Object({
     GITHUB_CLIENT_ID: Type.Optional(Type.String()),
     GITHUB_CLIENT_SECRET: Type.Optional(Type.String()),
 
-    NODE_ENV: Type.Union(
-        [Type.Literal('development'), Type.Literal('production'), Type.Literal('test')],
-        { default: 'development' },
-    ),
+    // Deliberately not a closed union: deployments legitimately use values like
+    // "staging" or "ci", and refusing to boot on an unrecognized NODE_ENV would
+    // be a regression. Only "production" and "test" carry behavior — see
+    // isProduction / isTest below.
+    NODE_ENV: Type.String({ default: 'development' }),
 
     OTEL_ENABLED: Type.Boolean({ default: false }),
     OTEL_EXPORTER_OTLP_ENDPOINT: Type.Optional(Type.String()),

--- a/packages/emitsignal-website/src/lib/cookies.ts
+++ b/packages/emitsignal-website/src/lib/cookies.ts
@@ -1,7 +1,9 @@
 const ONE_YEAR_SECONDS = 31536000;
 
 export function setPreferenceCookie(name: string, value: string): void {
-    const secure = window.location.protocol === 'https:' ? '; secure' : '';
+    // Read the protocol off `document`, not `window`: callers guard on
+    // `typeof document !== 'undefined'`, so anything else escapes that check.
+    const secure = document.location.protocol === 'https:' ? '; secure' : '';
 
     document.cookie = `${name}=${value}; path=/; max-age=${ONE_YEAR_SECONDS}; samesite=lax${secure}`;
 }

--- a/packages/emitsignal-website/src/routeTree.gen.ts
+++ b/packages/emitsignal-website/src/routeTree.gen.ts
@@ -9,92 +9,42 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as IndexRouteImport } from './routes/index'
-import { Route as ApiRouteImport } from './routes/api'
-import { Route as AppRouteImport } from './routes/app'
-import { Route as BlogRouteImport } from './routes/blog'
-import { Route as ChangelogRouteImport } from './routes/changelog'
-import { Route as CodeOfConductRouteImport } from './routes/code-of-conduct'
-import { Route as DashboardRouteImport } from './routes/dashboard'
-import { Route as MobileRouteImport } from './routes/mobile'
-import { Route as OnboardingRouteImport } from './routes/onboarding'
-import { Route as PrivacyRouteImport } from './routes/privacy'
-import { Route as SignInRouteImport } from './routes/sign-in'
-import { Route as TermsRouteImport } from './routes/terms'
 import { Route as VerifyRouteImport } from './routes/verify'
-import { Route as ApiOgRouteImport } from './routes/api/og'
-import { Route as AppIndexRouteImport } from './routes/app/index'
-import { Route as AppChannelsRouteImport } from './routes/app/channels'
-import { Route as AppKeysRouteImport } from './routes/app/keys'
-import { Route as AppPublishRouteImport } from './routes/app/publish'
-import { Route as AppSettingsRouteImport } from './routes/app/settings'
+import { Route as TermsRouteImport } from './routes/terms'
+import { Route as SignInRouteImport } from './routes/sign-in'
+import { Route as PrivacyRouteImport } from './routes/privacy'
+import { Route as OnboardingRouteImport } from './routes/onboarding'
+import { Route as MobileRouteImport } from './routes/mobile'
+import { Route as DashboardRouteImport } from './routes/dashboard'
+import { Route as CodeOfConductRouteImport } from './routes/code-of-conduct'
+import { Route as ChangelogRouteImport } from './routes/changelog'
+import { Route as BlogRouteImport } from './routes/blog'
+import { Route as AppRouteImport } from './routes/app'
+import { Route as ApiRouteImport } from './routes/api'
+import { Route as IndexRouteImport } from './routes/index'
 import { Route as BlogIndexRouteImport } from './routes/blog/index'
+import { Route as AppIndexRouteImport } from './routes/app/index'
 import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
-import { Route as AppInboxIndexRouteImport } from './routes/app/inbox/index'
-import { Route as AppInboxMessageIdRouteImport } from './routes/app/inbox/$messageId'
-import { Route as AppSettingsIndexRouteImport } from './routes/app/settings/index'
-import { Route as AppSettingsAccountRouteImport } from './routes/app/settings/account'
-import { Route as AppSettingsAdvancedRouteImport } from './routes/app/settings/advanced'
-import { Route as AppSettingsBillingRouteImport } from './routes/app/settings/billing'
-import { Route as AppSettingsProfileRouteImport } from './routes/app/settings/profile'
+import { Route as AppSettingsRouteImport } from './routes/app/settings'
+import { Route as AppPublishRouteImport } from './routes/app/publish'
+import { Route as AppKeysRouteImport } from './routes/app/keys'
+import { Route as AppChannelsRouteImport } from './routes/app/channels'
+import { Route as ApiOgRouteImport } from './routes/api/og'
 import { Route as AppWebhooksIndexRouteImport } from './routes/app/webhooks/index'
-import { Route as AppWebhooksWebhookIdRouteImport } from './routes/app/webhooks/$webhookId'
+import { Route as AppSettingsIndexRouteImport } from './routes/app/settings/index'
+import { Route as AppInboxIndexRouteImport } from './routes/app/inbox/index'
 import { Route as AppWebhooksNewRouteImport } from './routes/app/webhooks/new'
+import { Route as AppWebhooksWebhookIdRouteImport } from './routes/app/webhooks/$webhookId'
+import { Route as AppSettingsProfileRouteImport } from './routes/app/settings/profile'
+import { Route as AppSettingsBillingRouteImport } from './routes/app/settings/billing'
+import { Route as AppSettingsAdvancedRouteImport } from './routes/app/settings/advanced'
+import { Route as AppSettingsAccountRouteImport } from './routes/app/settings/account'
+import { Route as AppInboxMessageIdRouteImport } from './routes/app/inbox/$messageId'
 import { Route as AppWebhooksWebhookIdEditRouteImport } from './routes/app/webhooks/$webhookId.edit'
 
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiRoute = ApiRouteImport.update({
-  id: '/api',
-  path: '/api',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const AppRoute = AppRouteImport.update({
-  id: '/app',
-  path: '/app',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const BlogRoute = BlogRouteImport.update({
-  id: '/blog',
-  path: '/blog',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ChangelogRoute = ChangelogRouteImport.update({
-  id: '/changelog',
-  path: '/changelog',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const CodeOfConductRoute = CodeOfConductRouteImport.update({
-  id: '/code-of-conduct',
-  path: '/code-of-conduct',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const DashboardRoute = DashboardRouteImport.update({
-  id: '/dashboard',
-  path: '/dashboard',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const MobileRoute = MobileRouteImport.update({
-  id: '/mobile',
-  path: '/mobile',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const OnboardingRoute = OnboardingRouteImport.update({
-  id: '/onboarding',
-  path: '/onboarding',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const PrivacyRoute = PrivacyRouteImport.update({
-  id: '/privacy',
-  path: '/privacy',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const SignInRoute = SignInRouteImport.update({
-  id: '/sign-in',
-  path: '/sign-in',
+const VerifyRoute = VerifyRouteImport.update({
+  id: '/verify',
+  path: '/verify',
   getParentRoute: () => rootRouteImport,
 } as any)
 const TermsRoute = TermsRouteImport.update({
@@ -102,29 +52,79 @@ const TermsRoute = TermsRouteImport.update({
   path: '/terms',
   getParentRoute: () => rootRouteImport,
 } as any)
-const VerifyRoute = VerifyRouteImport.update({
-  id: '/verify',
-  path: '/verify',
+const SignInRoute = SignInRouteImport.update({
+  id: '/sign-in',
+  path: '/sign-in',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiOgRoute = ApiOgRouteImport.update({
-  id: '/og',
-  path: '/og',
-  getParentRoute: () => ApiRoute,
+const PrivacyRoute = PrivacyRouteImport.update({
+  id: '/privacy',
+  path: '/privacy',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OnboardingRoute = OnboardingRouteImport.update({
+  id: '/onboarding',
+  path: '/onboarding',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MobileRoute = MobileRouteImport.update({
+  id: '/mobile',
+  path: '/mobile',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DashboardRoute = DashboardRouteImport.update({
+  id: '/dashboard',
+  path: '/dashboard',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CodeOfConductRoute = CodeOfConductRouteImport.update({
+  id: '/code-of-conduct',
+  path: '/code-of-conduct',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ChangelogRoute = ChangelogRouteImport.update({
+  id: '/changelog',
+  path: '/changelog',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BlogRoute = BlogRouteImport.update({
+  id: '/blog',
+  path: '/blog',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AppRoute = AppRouteImport.update({
+  id: '/app',
+  path: '/app',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiRoute = ApiRouteImport.update({
+  id: '/api',
+  path: '/api',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BlogIndexRoute = BlogIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => BlogRoute,
 } as any)
 const AppIndexRoute = AppIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AppRoute,
 } as any)
-const AppChannelsRoute = AppChannelsRouteImport.update({
-  id: '/channels',
-  path: '/channels',
-  getParentRoute: () => AppRoute,
+const BlogSlugRoute = BlogSlugRouteImport.update({
+  id: '/$slug',
+  path: '/$slug',
+  getParentRoute: () => BlogRoute,
 } as any)
-const AppKeysRoute = AppKeysRouteImport.update({
-  id: '/keys',
-  path: '/keys',
+const AppSettingsRoute = AppSettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
   getParentRoute: () => AppRoute,
 } as any)
 const AppPublishRoute = AppPublishRouteImport.update({
@@ -132,29 +132,24 @@ const AppPublishRoute = AppPublishRouteImport.update({
   path: '/publish',
   getParentRoute: () => AppRoute,
 } as any)
-const AppSettingsRoute = AppSettingsRouteImport.update({
-  id: '/settings',
-  path: '/settings',
+const AppKeysRoute = AppKeysRouteImport.update({
+  id: '/keys',
+  path: '/keys',
   getParentRoute: () => AppRoute,
 } as any)
-const BlogIndexRoute = BlogIndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => BlogRoute,
-} as any)
-const BlogSlugRoute = BlogSlugRouteImport.update({
-  id: '/$slug',
-  path: '/$slug',
-  getParentRoute: () => BlogRoute,
-} as any)
-const AppInboxIndexRoute = AppInboxIndexRouteImport.update({
-  id: '/inbox/',
-  path: '/inbox/',
+const AppChannelsRoute = AppChannelsRouteImport.update({
+  id: '/channels',
+  path: '/channels',
   getParentRoute: () => AppRoute,
 } as any)
-const AppInboxMessageIdRoute = AppInboxMessageIdRouteImport.update({
-  id: '/inbox/$messageId',
-  path: '/inbox/$messageId',
+const ApiOgRoute = ApiOgRouteImport.update({
+  id: '/og',
+  path: '/og',
+  getParentRoute: () => ApiRoute,
+} as any)
+const AppWebhooksIndexRoute = AppWebhooksIndexRouteImport.update({
+  id: '/webhooks/',
+  path: '/webhooks/',
   getParentRoute: () => AppRoute,
 } as any)
 const AppSettingsIndexRoute = AppSettingsIndexRouteImport.update({
@@ -162,29 +157,14 @@ const AppSettingsIndexRoute = AppSettingsIndexRouteImport.update({
   path: '/',
   getParentRoute: () => AppSettingsRoute,
 } as any)
-const AppSettingsAccountRoute = AppSettingsAccountRouteImport.update({
-  id: '/account',
-  path: '/account',
-  getParentRoute: () => AppSettingsRoute,
+const AppInboxIndexRoute = AppInboxIndexRouteImport.update({
+  id: '/inbox/',
+  path: '/inbox/',
+  getParentRoute: () => AppRoute,
 } as any)
-const AppSettingsAdvancedRoute = AppSettingsAdvancedRouteImport.update({
-  id: '/advanced',
-  path: '/advanced',
-  getParentRoute: () => AppSettingsRoute,
-} as any)
-const AppSettingsBillingRoute = AppSettingsBillingRouteImport.update({
-  id: '/billing',
-  path: '/billing',
-  getParentRoute: () => AppSettingsRoute,
-} as any)
-const AppSettingsProfileRoute = AppSettingsProfileRouteImport.update({
-  id: '/profile',
-  path: '/profile',
-  getParentRoute: () => AppSettingsRoute,
-} as any)
-const AppWebhooksIndexRoute = AppWebhooksIndexRouteImport.update({
-  id: '/webhooks/',
-  path: '/webhooks/',
+const AppWebhooksNewRoute = AppWebhooksNewRouteImport.update({
+  id: '/webhooks/new',
+  path: '/webhooks/new',
   getParentRoute: () => AppRoute,
 } as any)
 const AppWebhooksWebhookIdRoute = AppWebhooksWebhookIdRouteImport.update({
@@ -192,9 +172,29 @@ const AppWebhooksWebhookIdRoute = AppWebhooksWebhookIdRouteImport.update({
   path: '/webhooks/$webhookId',
   getParentRoute: () => AppRoute,
 } as any)
-const AppWebhooksNewRoute = AppWebhooksNewRouteImport.update({
-  id: '/webhooks/new',
-  path: '/webhooks/new',
+const AppSettingsProfileRoute = AppSettingsProfileRouteImport.update({
+  id: '/profile',
+  path: '/profile',
+  getParentRoute: () => AppSettingsRoute,
+} as any)
+const AppSettingsBillingRoute = AppSettingsBillingRouteImport.update({
+  id: '/billing',
+  path: '/billing',
+  getParentRoute: () => AppSettingsRoute,
+} as any)
+const AppSettingsAdvancedRoute = AppSettingsAdvancedRouteImport.update({
+  id: '/advanced',
+  path: '/advanced',
+  getParentRoute: () => AppSettingsRoute,
+} as any)
+const AppSettingsAccountRoute = AppSettingsAccountRouteImport.update({
+  id: '/account',
+  path: '/account',
+  getParentRoute: () => AppSettingsRoute,
+} as any)
+const AppInboxMessageIdRoute = AppInboxMessageIdRouteImport.update({
+  id: '/inbox/$messageId',
+  path: '/inbox/$messageId',
   getParentRoute: () => AppRoute,
 } as any)
 const AppWebhooksWebhookIdEditRoute =
@@ -424,81 +424,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api': {
-      id: '/api'
-      path: '/api'
-      fullPath: '/api'
-      preLoaderRoute: typeof ApiRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/app': {
-      id: '/app'
-      path: '/app'
-      fullPath: '/app'
-      preLoaderRoute: typeof AppRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/blog': {
-      id: '/blog'
-      path: '/blog'
-      fullPath: '/blog'
-      preLoaderRoute: typeof BlogRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/changelog': {
-      id: '/changelog'
-      path: '/changelog'
-      fullPath: '/changelog'
-      preLoaderRoute: typeof ChangelogRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/code-of-conduct': {
-      id: '/code-of-conduct'
-      path: '/code-of-conduct'
-      fullPath: '/code-of-conduct'
-      preLoaderRoute: typeof CodeOfConductRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/dashboard': {
-      id: '/dashboard'
-      path: '/dashboard'
-      fullPath: '/dashboard'
-      preLoaderRoute: typeof DashboardRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/mobile': {
-      id: '/mobile'
-      path: '/mobile'
-      fullPath: '/mobile'
-      preLoaderRoute: typeof MobileRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/onboarding': {
-      id: '/onboarding'
-      path: '/onboarding'
-      fullPath: '/onboarding'
-      preLoaderRoute: typeof OnboardingRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/privacy': {
-      id: '/privacy'
-      path: '/privacy'
-      fullPath: '/privacy'
-      preLoaderRoute: typeof PrivacyRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/sign-in': {
-      id: '/sign-in'
-      path: '/sign-in'
-      fullPath: '/sign-in'
-      preLoaderRoute: typeof SignInRouteImport
+    '/verify': {
+      id: '/verify'
+      path: '/verify'
+      fullPath: '/verify'
+      preLoaderRoute: typeof VerifyRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/terms': {
@@ -508,19 +438,89 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof TermsRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/verify': {
-      id: '/verify'
-      path: '/verify'
-      fullPath: '/verify'
-      preLoaderRoute: typeof VerifyRouteImport
+    '/sign-in': {
+      id: '/sign-in'
+      path: '/sign-in'
+      fullPath: '/sign-in'
+      preLoaderRoute: typeof SignInRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/og': {
-      id: '/api/og'
-      path: '/og'
-      fullPath: '/api/og'
-      preLoaderRoute: typeof ApiOgRouteImport
-      parentRoute: typeof ApiRoute
+    '/privacy': {
+      id: '/privacy'
+      path: '/privacy'
+      fullPath: '/privacy'
+      preLoaderRoute: typeof PrivacyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/onboarding': {
+      id: '/onboarding'
+      path: '/onboarding'
+      fullPath: '/onboarding'
+      preLoaderRoute: typeof OnboardingRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/mobile': {
+      id: '/mobile'
+      path: '/mobile'
+      fullPath: '/mobile'
+      preLoaderRoute: typeof MobileRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/dashboard': {
+      id: '/dashboard'
+      path: '/dashboard'
+      fullPath: '/dashboard'
+      preLoaderRoute: typeof DashboardRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/code-of-conduct': {
+      id: '/code-of-conduct'
+      path: '/code-of-conduct'
+      fullPath: '/code-of-conduct'
+      preLoaderRoute: typeof CodeOfConductRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/changelog': {
+      id: '/changelog'
+      path: '/changelog'
+      fullPath: '/changelog'
+      preLoaderRoute: typeof ChangelogRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/blog': {
+      id: '/blog'
+      path: '/blog'
+      fullPath: '/blog'
+      preLoaderRoute: typeof BlogRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/app': {
+      id: '/app'
+      path: '/app'
+      fullPath: '/app'
+      preLoaderRoute: typeof AppRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api': {
+      id: '/api'
+      path: '/api'
+      fullPath: '/api'
+      preLoaderRoute: typeof ApiRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/blog/': {
+      id: '/blog/'
+      path: '/'
+      fullPath: '/blog/'
+      preLoaderRoute: typeof BlogIndexRouteImport
+      parentRoute: typeof BlogRoute
     }
     '/app/': {
       id: '/app/'
@@ -529,18 +529,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppIndexRouteImport
       parentRoute: typeof AppRoute
     }
-    '/app/channels': {
-      id: '/app/channels'
-      path: '/channels'
-      fullPath: '/app/channels'
-      preLoaderRoute: typeof AppChannelsRouteImport
-      parentRoute: typeof AppRoute
+    '/blog/$slug': {
+      id: '/blog/$slug'
+      path: '/$slug'
+      fullPath: '/blog/$slug'
+      preLoaderRoute: typeof BlogSlugRouteImport
+      parentRoute: typeof BlogRoute
     }
-    '/app/keys': {
-      id: '/app/keys'
-      path: '/keys'
-      fullPath: '/app/keys'
-      preLoaderRoute: typeof AppKeysRouteImport
+    '/app/settings': {
+      id: '/app/settings'
+      path: '/settings'
+      fullPath: '/app/settings'
+      preLoaderRoute: typeof AppSettingsRouteImport
       parentRoute: typeof AppRoute
     }
     '/app/publish': {
@@ -550,39 +550,32 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppPublishRouteImport
       parentRoute: typeof AppRoute
     }
-    '/app/settings': {
-      id: '/app/settings'
-      path: '/settings'
-      fullPath: '/app/settings'
-      preLoaderRoute: typeof AppSettingsRouteImport
+    '/app/keys': {
+      id: '/app/keys'
+      path: '/keys'
+      fullPath: '/app/keys'
+      preLoaderRoute: typeof AppKeysRouteImport
       parentRoute: typeof AppRoute
     }
-    '/blog/': {
-      id: '/blog/'
-      path: '/'
-      fullPath: '/blog/'
-      preLoaderRoute: typeof BlogIndexRouteImport
-      parentRoute: typeof BlogRoute
-    }
-    '/blog/$slug': {
-      id: '/blog/$slug'
-      path: '/$slug'
-      fullPath: '/blog/$slug'
-      preLoaderRoute: typeof BlogSlugRouteImport
-      parentRoute: typeof BlogRoute
-    }
-    '/app/inbox/': {
-      id: '/app/inbox/'
-      path: '/inbox'
-      fullPath: '/app/inbox/'
-      preLoaderRoute: typeof AppInboxIndexRouteImport
+    '/app/channels': {
+      id: '/app/channels'
+      path: '/channels'
+      fullPath: '/app/channels'
+      preLoaderRoute: typeof AppChannelsRouteImport
       parentRoute: typeof AppRoute
     }
-    '/app/inbox/$messageId': {
-      id: '/app/inbox/$messageId'
-      path: '/inbox/$messageId'
-      fullPath: '/app/inbox/$messageId'
-      preLoaderRoute: typeof AppInboxMessageIdRouteImport
+    '/api/og': {
+      id: '/api/og'
+      path: '/og'
+      fullPath: '/api/og'
+      preLoaderRoute: typeof ApiOgRouteImport
+      parentRoute: typeof ApiRoute
+    }
+    '/app/webhooks/': {
+      id: '/app/webhooks/'
+      path: '/webhooks'
+      fullPath: '/app/webhooks/'
+      preLoaderRoute: typeof AppWebhooksIndexRouteImport
       parentRoute: typeof AppRoute
     }
     '/app/settings/': {
@@ -592,39 +585,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppSettingsIndexRouteImport
       parentRoute: typeof AppSettingsRoute
     }
-    '/app/settings/account': {
-      id: '/app/settings/account'
-      path: '/account'
-      fullPath: '/app/settings/account'
-      preLoaderRoute: typeof AppSettingsAccountRouteImport
-      parentRoute: typeof AppSettingsRoute
+    '/app/inbox/': {
+      id: '/app/inbox/'
+      path: '/inbox'
+      fullPath: '/app/inbox/'
+      preLoaderRoute: typeof AppInboxIndexRouteImport
+      parentRoute: typeof AppRoute
     }
-    '/app/settings/advanced': {
-      id: '/app/settings/advanced'
-      path: '/advanced'
-      fullPath: '/app/settings/advanced'
-      preLoaderRoute: typeof AppSettingsAdvancedRouteImport
-      parentRoute: typeof AppSettingsRoute
-    }
-    '/app/settings/billing': {
-      id: '/app/settings/billing'
-      path: '/billing'
-      fullPath: '/app/settings/billing'
-      preLoaderRoute: typeof AppSettingsBillingRouteImport
-      parentRoute: typeof AppSettingsRoute
-    }
-    '/app/settings/profile': {
-      id: '/app/settings/profile'
-      path: '/profile'
-      fullPath: '/app/settings/profile'
-      preLoaderRoute: typeof AppSettingsProfileRouteImport
-      parentRoute: typeof AppSettingsRoute
-    }
-    '/app/webhooks/': {
-      id: '/app/webhooks/'
-      path: '/webhooks'
-      fullPath: '/app/webhooks/'
-      preLoaderRoute: typeof AppWebhooksIndexRouteImport
+    '/app/webhooks/new': {
+      id: '/app/webhooks/new'
+      path: '/webhooks/new'
+      fullPath: '/app/webhooks/new'
+      preLoaderRoute: typeof AppWebhooksNewRouteImport
       parentRoute: typeof AppRoute
     }
     '/app/webhooks/$webhookId': {
@@ -634,11 +606,39 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppWebhooksWebhookIdRouteImport
       parentRoute: typeof AppRoute
     }
-    '/app/webhooks/new': {
-      id: '/app/webhooks/new'
-      path: '/webhooks/new'
-      fullPath: '/app/webhooks/new'
-      preLoaderRoute: typeof AppWebhooksNewRouteImport
+    '/app/settings/profile': {
+      id: '/app/settings/profile'
+      path: '/profile'
+      fullPath: '/app/settings/profile'
+      preLoaderRoute: typeof AppSettingsProfileRouteImport
+      parentRoute: typeof AppSettingsRoute
+    }
+    '/app/settings/billing': {
+      id: '/app/settings/billing'
+      path: '/billing'
+      fullPath: '/app/settings/billing'
+      preLoaderRoute: typeof AppSettingsBillingRouteImport
+      parentRoute: typeof AppSettingsRoute
+    }
+    '/app/settings/advanced': {
+      id: '/app/settings/advanced'
+      path: '/advanced'
+      fullPath: '/app/settings/advanced'
+      preLoaderRoute: typeof AppSettingsAdvancedRouteImport
+      parentRoute: typeof AppSettingsRoute
+    }
+    '/app/settings/account': {
+      id: '/app/settings/account'
+      path: '/account'
+      fullPath: '/app/settings/account'
+      preLoaderRoute: typeof AppSettingsAccountRouteImport
+      parentRoute: typeof AppSettingsRoute
+    }
+    '/app/inbox/$messageId': {
+      id: '/app/inbox/$messageId'
+      path: '/inbox/$messageId'
+      fullPath: '/app/inbox/$messageId'
+      preLoaderRoute: typeof AppInboxMessageIdRouteImport
       parentRoute: typeof AppRoute
     }
     '/app/webhooks/$webhookId/edit': {

--- a/packages/emitsignal-website/src/routes/api/og.tsx
+++ b/packages/emitsignal-website/src/routes/api/og.tsx
@@ -560,7 +560,7 @@ export const Route = createFileRoute('/api/og')({
                         999,
                         Math.max(0, Number(searchParams.get('readTime') ?? '5') || 0),
                     ),
-                    title: bounded(searchParams.get('title'), 32) ?? 'EmitSignal Blog',
+                    title: bounded(searchParams.get('title'), 120) ?? 'EmitSignal Blog',
                 };
 
                 const template = searchParams.get('template') ?? 'editorial';


### PR DESCRIPTION
Follow-ups to the review of #15. Fixes the three boot/deploy blockers plus the smaller items, with a regression test pinning the config traps.

## Blockers

**1. Compose passed an empty string, crashing the server on boot** — `TRUSTED_PROXY_HEADER: '${TRUSTED_PROXY_HEADER:-}'` yields `''`, and Compose *sets* the variable rather than omitting it. TypeBox `default` only applies when a key is absent, so `''` hit the union and threw. Every existing Docker deployment that hadn't set the variable would have failed to start. Now `:-none}`, matching the file's own convention (`EMAIL_PROVIDER:-log`, `FILE_STORAGE_PROVIDER:-local`), plus a documented `TRUSTED_PROXY_HEADER` block in `.env.example` under a new "Reverse proxy" section.

**2. `NODE_ENV` had become a strict 3-value union** — `NODE_ENV=staging` crashed on boot. Previously the value was only ever compared against `'production'`, so anything was tolerated. Relaxed to `Type.String({ default: 'development' })`; `isProduction` / `isTest` derive from it unchanged.

**3. `TRUSTED_PROXY_HEADER` default of `none` silently collapses rate limiting behind a proxy** — `getClientIP` now ignores `cf-connecting-ip` / `x-real-ip` / `x-forwarded-for` unless opted in, so anyone behind nginx or Cloudflare keys every anonymous request on the *proxy's* IP: 100 req/min globally, 10 anonymous publishes/min, 5 uploads/hour, 3 concurrent SSE listeners — platform-wide, not per-user.

I deliberately **left the default at `none`.** Flipping it to trust `x-forwarded-for` would hand back the spoofing hole #15 closed. Instead the failure mode is now loud: a startup `logger.warn` when `isProduction && TRUSTED_PROXY_HEADER === 'none'`, and a "Running behind a reverse proxy" section in the server README with the per-proxy value table and a warning about proxies that append rather than overwrite. Say the word if you'd rather flip the default.

## Also in here

- **Sentry flood** — `rate-limit-plugin.ts` captured one exception per failed request. A Redis outage at 500 rps burns the quota during the exact incident you need Sentry for. Now one captured event per 60s window.
- **`cookies.ts`** reads `document.location` instead of `window.location`, so the callers' `typeof document !== 'undefined'` guard actually covers it.
- **`og.tsx`** title bound 32 → 120. Bounding untrusted input is right, but 32 visibly chopped real blog titles.
- **`routeTree.gen.ts` reverted** (+251/−251). The file is in `.prettierignore:4` and its own header says to exclude it from formatters; something re-sorted its imports anyway. Diffed both versions sorted — byte-identical, pure reordering, and the next TanStack codegen would clobber it.
- **New `src/schema/__tests__/environment.spec.ts`** (5 cases) pins the empty-string trap and the permissive `NODE_ENV`. Required exporting the schema.

## Verification at `b2c9e89`

- `bun test` (server) — **349 pass / 0 fail**, 45 files
- `bun format:check` — clean
- `bun lint` — clean
- `bunx tsc --noEmit` — only pre-existing errors in `subscriptions/__tests__/update.spec.ts`, nothing touched here

Unrelated: **`emitsignal-website` has 5 failing tests in `src/hooks/use-sse.test.ts`.** Confirmed pre-existing by re-running at bare `origin/main` — same 0 pass / 5 fail. Not from this branch or #15, but worth a separate look.

## Not addressed

The `listen-multi.ts` findings from the review are **still open** — the connect-time topic snapshot (`resolveOwnTopicNames()` subscribes to a fixed list, so a user who creates or subscribes to a topic mid-connection silently receives nothing until reconnect) and anonymous `GET /listen` with no `?topics=` returning 400 instead of streaming. There's an in-flight SSE refactor rewriting that exact file locally, so touching it here would only create conflicts. The snapshot one is the substantive of the two.

Remaining judgment calls from the review, left as-is intentionally: fail-closed on anonymous publish/upload trading availability for safety, the `EXTENSION_BY_MIME_TYPE` / `AVATAR_EXTENSION_BY_MIME` duplication, the extra DB round-trip in `canPublishToTopicName` on the webhook receive path, and `canPublish || isSender` letting any topic publisher attach to someone else's message.
