### PR TITLE
feat(webhooks): deliver and preview the template link as a view action

### DIFF
--- a/packages/emitsignal-server/src/__tests__/mocks.ts
+++ b/packages/emitsignal-server/src/__tests__/mocks.ts
@@ -155,6 +155,14 @@ export const prismaMock = {
                 topicName: 'deploys',
             }),
         ),
+        findUnique: mock<(args?: Record<string, unknown>) => Promise<null | object>>(() =>
+            Promise.resolve(null),
+        ),
+    },
+    webhookDelivery: {
+        create: mock<(args: { data: Record<string, unknown> }) => Promise<object>>(() =>
+            Promise.resolve({ createdAt: new Date(), id: 'whd-1' }),
+        ),
     },
 };
 

--- a/packages/emitsignal-server/src/http/webhooks/__tests__/receive.spec.ts
+++ b/packages/emitsignal-server/src/http/webhooks/__tests__/receive.spec.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { Elysia } from 'elysia';
+
+import { prismaMock } from '../../../__tests__/mocks';
+
+const mockBus = { publish: mock(), publishWebhookDelivery: mock(), subscribe: mock() };
+const mockPushQueue = { add: mock(() => Promise.resolve()) };
+
+mock.module('../../../lib/prisma', () => ({ prisma: prismaMock }));
+mock.module('../../../lib/event-bus', () => ({ bus: mockBus }));
+mock.module('../../../lib/queue', () => ({
+    pushQueue: mockPushQueue,
+    scheduleQueue: { add: mock(() => Promise.resolve()) },
+}));
+// Header-driven so a leak into other test files behaves like the real module
+// (no test header → anonymous).
+mock.module('../../auth/plugin', () => ({
+    resolveUserId: ({ headers }: { headers: Record<string, string | undefined> }) =>
+        Promise.resolve(headers['x-test-user-id'] ?? null),
+}));
+
+import { receiveWebhook } from '../receive';
+
+describe('POST /h/:slug link → view action', () => {
+    const app = new Elysia().use(receiveWebhook);
+
+    function withTemplateLink(link: string) {
+        prismaMock.webhook.findUnique.mockResolvedValue({
+            id: 'wh-1',
+            source: 'custom',
+            status: 'active',
+            template: JSON.stringify({ link, title: '{{event.name}}' }),
+            topicName: 'deploys',
+            userId: null,
+        });
+    }
+
+    function request(payload: unknown) {
+        return new Request('http://localhost/h/cw_abc1234', {
+            body: JSON.stringify(payload),
+            headers: { 'Content-Type': 'application/json' },
+            method: 'POST',
+        });
+    }
+
+    // The actions column is written as a JSON string; read back what the route stored.
+    function storedActions() {
+        const calls = prismaMock.message.create.mock.calls;
+        const lastCall = calls[calls.length - 1] as unknown as [{ data: Record<string, unknown> }];
+
+        return JSON.parse(lastCall[0].data.actions as string) as unknown[];
+    }
+
+    beforeEach(() => {
+        prismaMock.message.create.mockClear();
+        mockPushQueue.add.mockClear();
+        prismaMock.topic.findUnique.mockResolvedValue({
+            displayName: 'deploys',
+            id: 'topic-1',
+            name: 'deploys',
+        });
+    });
+
+    it('stores a single view action for an http(s) link', async () => {
+        withTemplateLink('https://status.dev/{{event.id}}');
+
+        const res = await app.handle(request({ event: { id: '42', name: 'deploy' } }));
+
+        expect(res.status).toBe(200);
+        expect(storedActions()).toEqual([
+            { label: 'View', type: 'view', url: 'https://status.dev/42' },
+        ]);
+    });
+
+    it('drops a javascript: link but still delivers the message', async () => {
+        withTemplateLink('javascript:alert(1)');
+
+        const res = await app.handle(request({ event: { name: 'deploy' } }));
+
+        expect(res.status).toBe(200);
+        expect(storedActions()).toEqual([]);
+    });
+
+    it('drops a relative link but still delivers the message', async () => {
+        withTemplateLink('/repos/acme/api');
+
+        const res = await app.handle(request({ event: { name: 'deploy' } }));
+
+        expect(res.status).toBe(200);
+        expect(storedActions()).toEqual([]);
+    });
+
+    it('stores no action when the link template does not resolve', async () => {
+        withTemplateLink('{{event.url}}');
+
+        const res = await app.handle(request({ event: { name: 'deploy' } }));
+
+        expect(res.status).toBe(200);
+        expect(storedActions()).toEqual([]);
+    });
+
+    it('stores no action when the template has no link at all', async () => {
+        prismaMock.webhook.findUnique.mockResolvedValue({
+            id: 'wh-1',
+            source: 'custom',
+            status: 'active',
+            template: JSON.stringify({ title: '{{event.name}}' }),
+            topicName: 'deploys',
+            userId: null,
+        });
+
+        const res = await app.handle(request({ event: { name: 'deploy' } }));
+
+        expect(res.status).toBe(200);
+        expect(storedActions()).toEqual([]);
+    });
+
+    it('stores no action for an untemplated passthrough delivery', async () => {
+        prismaMock.webhook.findUnique.mockResolvedValue({
+            id: 'wh-1',
+            source: 'custom',
+            status: 'active',
+            template: null,
+            topicName: 'deploys',
+            userId: null,
+        });
+
+        const res = await app.handle(request({ event: { name: 'deploy' } }));
+
+        expect(res.status).toBe(200);
+        expect(storedActions()).toEqual([]);
+    });
+
+    it('forwards the same action to the push job', async () => {
+        withTemplateLink('https://status.dev/run');
+
+        await app.handle(request({ event: { name: 'deploy' } }));
+
+        const calls = mockPushQueue.add.mock.calls;
+        const lastCall = calls[calls.length - 1] as unknown as [string, Record<string, unknown>];
+
+        expect(lastCall[0]).toBe('push-message');
+        expect(lastCall[1].actions).toEqual([
+            { label: 'View', type: 'view', url: 'https://status.dev/run' },
+        ]);
+    });
+});

--- a/packages/emitsignal-server/src/http/webhooks/receive.ts
+++ b/packages/emitsignal-server/src/http/webhooks/receive.ts
@@ -1,7 +1,10 @@
 import { parseTemplate, renderTemplate } from '@emitsignal/shared/webhook-template';
 import Elysia, { t } from 'elysia';
 
+import type { Action } from '../../lib/actions';
+
 import { consumeLimit } from '../../http/plugins/rate-limit-plugin';
+import { validateActions } from '../../lib/actions';
 import { getUserPlan } from '../../lib/billing/get-user-plan';
 import { messageExpiresAt, messageRetentionDays } from '../../lib/billing/retention';
 import { bus } from '../../lib/event-bus';
@@ -55,6 +58,7 @@ export const receiveWebhook = new Elysia().post(
         const template = parseTemplate(webhook.template);
         const templated = !!template;
 
+        let actions: Action[] = [];
         let messageBody: string;
         let priority: number;
         let tags: string[];
@@ -63,6 +67,7 @@ export const receiveWebhook = new Elysia().post(
         if (template) {
             const rendered = renderTemplate(template, payload);
 
+            actions = viewActionFor(rendered.link);
             messageBody = rendered.body;
             priority = rendered.priority;
             tags = rendered.tags;
@@ -89,7 +94,7 @@ export const receiveWebhook = new Elysia().post(
 
         const message = await prisma.message.create({
             data: {
-                actions: '[]',
+                actions: JSON.stringify(actions),
                 body: messageBody,
                 deliveredAt,
                 expiresAt: messageExpiresAt(deliveredAt, messageRetentionDays(plan)),
@@ -106,7 +111,7 @@ export const receiveWebhook = new Elysia().post(
         bus.publish(topic.name, { ...event, topicName: topic.name });
 
         pushQueue.add('push-message', {
-            actions: [],
+            actions,
             body: messageBody,
             messageId: message.id,
             priority,
@@ -151,3 +156,17 @@ export const receiveWebhook = new Elysia().post(
         body: t.Unknown(),
     },
 );
+
+// The rendered link comes from the caller's payload on a public endpoint, so it
+// is untrusted: run it through the same validator `POST /topic/:name` uses so
+// only http(s) URLs are ever stored. Unlike publish, a link we cannot use never
+// fails the delivery — the notification still goes out, just without a button.
+function viewActionFor(link: string): Action[] {
+    if (!link) {
+        return [];
+    }
+
+    const validation = validateActions([{ type: 'view', url: link }]);
+
+    return 'ok' in validation ? validation.actions : [];
+}

--- a/packages/emitsignal-shared/src/webhook-template.test.ts
+++ b/packages/emitsignal-shared/src/webhook-template.test.ts
@@ -65,3 +65,24 @@ describe('renderTemplate with wildcard tags', () => {
         expect(rendered.title).toBe('EmitSignal');
     });
 });
+
+describe('renderTemplate link', () => {
+    test('resolves a link template against the payload', () => {
+        const rendered = renderTemplate({ link: 'https://status.dev/{{monitor.id}}' }, payload);
+        expect(rendered.link).toBe('https://status.dev/42');
+    });
+
+    test('returns an empty link when the template has none', () => {
+        expect(renderTemplate({ title: '{{monitor.name}}' }, payload).link).toBe('');
+    });
+
+    test('returns an empty link when the template path does not resolve', () => {
+        expect(renderTemplate({ link: '{{monitor.nope}}' }, payload).link).toBe('');
+    });
+
+    test('trims surrounding whitespace', () => {
+        expect(renderTemplate({ link: '  https://status.dev  ' }, payload).link).toBe(
+            'https://status.dev',
+        );
+    });
+});

--- a/packages/emitsignal-shared/src/webhook-template.ts
+++ b/packages/emitsignal-shared/src/webhook-template.ts
@@ -23,12 +23,16 @@ export function renderTemplate(
     payload: unknown,
 ): {
     body: string;
+    link: string;
     priority: number;
     tags: string[];
     title: string;
 } {
     const title = template.title ? applyTemplate(template.title, payload) : 'Webhook delivery';
     const body = template.body ? applyTemplate(template.body, payload) : '';
+    // An unset link, or one whose template path does not resolve, renders to ''.
+    // Callers treat that as "no action" — a link is never required for delivery.
+    const link = template.link ? applyTemplate(template.link, payload).trim() : '';
     const rawTags = template.tags ? applyTemplate(template.tags, payload) : '';
     const tags = rawTags
         ? rawTags
@@ -39,7 +43,7 @@ export function renderTemplate(
 
     const priority = Math.min(5, Math.max(1, parseInt(template.priority ?? '3', 10))) || 3;
 
-    return { body, priority, tags, title };
+    return { body, link, priority, tags, title };
 }
 
 function formatValue(value: unknown, emptyValue: string): string {

--- a/packages/emitsignal-website/src/components/app/webhooks/deliveries-log.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/deliveries-log.tsx
@@ -82,6 +82,7 @@ export function DeliveriesLog({ webhookId }: { webhookId: string }) {
             return {
                 body: applyTemplate(template.body ?? '', delivery.payload),
                 channel: delivery.channel,
+                link: applyTemplate(template.link ?? '', delivery.payload).trim(),
                 priority: Number(template.priority ?? '3'),
                 tags: applyTemplate(template.tags ?? '', delivery.payload),
                 title: applyTemplate(template.title ?? '', delivery.payload),

--- a/packages/emitsignal-website/src/components/app/webhooks/notif-preview.test.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/notif-preview.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import { NotifPreview } from './notif-preview';
+
+function renderPreview(link?: string) {
+    return render(
+        <NotifPreview body="body" channel="deploys" link={link} priority={3} title="title" />,
+    );
+}
+
+describe('NotifPreview link', () => {
+    test('renders a view button for an http(s) link', () => {
+        renderPreview('https://status.dev/run/42');
+
+        expect(screen.getByText('View')).toBeDefined();
+        expect(screen.queryByText('View · dropped')).toBeNull();
+    });
+
+    test('renders the dropped state for a relative link', () => {
+        renderPreview('/repos/acme/api');
+
+        expect(screen.getByText('View · dropped')).toBeDefined();
+    });
+
+    test('renders the dropped state for a javascript: link', () => {
+        renderPreview('javascript:alert(1)');
+
+        expect(screen.getByText('View · dropped')).toBeDefined();
+    });
+
+    // The server's isValidHref is http(s)-only, so a mailto: link is dropped on
+    // delivery even though it is a "safe" URL for rendering purposes.
+    test('renders the dropped state for a mailto: link', () => {
+        renderPreview('mailto:ops@acme.dev');
+
+        expect(screen.getByText('View · dropped')).toBeDefined();
+    });
+
+    test('renders no button at all when there is no link', () => {
+        renderPreview('');
+
+        expect(screen.queryByText('View')).toBeNull();
+        expect(screen.queryByText('View · dropped')).toBeNull();
+    });
+});

--- a/packages/emitsignal-website/src/components/app/webhooks/notif-preview.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/notif-preview.tsx
@@ -5,6 +5,7 @@ interface NotifPreviewProps {
     body: string;
     channel: string;
     compact?: boolean;
+    link?: string;
     priority: number | string;
     tags?: string | string[];
     title: string;
@@ -14,6 +15,7 @@ export function NotifPreview({
     body,
     channel,
     compact = false,
+    link = '',
     priority,
     tags = [],
     title,
@@ -27,6 +29,12 @@ export function NotifPreview({
 
     const priorityValue = Number(priority);
     const priColor = priorityHex(priorityValue);
+
+    // The server drops any link that is not http(s) — relative paths included —
+    // and delivers the notification without a button. Preview that outcome too,
+    // so a template that renders an unusable link is visible before it ships.
+    const deliverableLink = isDeliverableLink(link);
+    const droppedLink = link !== '' && !deliverableLink;
 
     return (
         <div
@@ -65,8 +73,42 @@ export function NotifPreview({
                             ))}
                         </div>
                     )}
+                    {deliverableLink && (
+                        <div className="mt-2.5">
+                            <span
+                                className="inline-block rounded-md border border-line bg-elev px-3.5 py-2 text-[12.5px] text-fg"
+                                title={link}
+                            >
+                                View
+                            </span>
+                        </div>
+                    )}
+                    {droppedLink && (
+                        <div className="mt-2.5">
+                            <span
+                                className="inline-block rounded-md border border-dashed border-line bg-elev px-3.5 py-2 text-[12.5px] text-dim"
+                                title="Not an http(s) URL — this link is dropped and no button is delivered."
+                            >
+                                View · dropped
+                            </span>
+                        </div>
+                    )}
                 </div>
             </div>
         </div>
     );
+}
+
+// Mirrors the server's `isValidHref` (lib/media-refs.ts), which is what decides
+// whether a rendered template link survives into a delivered action. Deliberately
+// not `safeExternalUrl` from shared: that one also accepts `mailto:`, so it would
+// preview a button the server goes on to drop.
+function isDeliverableLink(link: string): boolean {
+    try {
+        const { protocol } = new URL(link);
+
+        return protocol === 'http:' || protocol === 'https:';
+    } catch {
+        return false;
+    }
 }

--- a/packages/emitsignal-website/src/components/app/webhooks/webhook-create.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/webhook-create.tsx
@@ -168,6 +168,7 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
     const rendered = {
         body: applyTemplate(templateFields.body ?? '', activePayload),
         channel: topicName || `${source}/channel`,
+        link: applyTemplate(templateFields.link ?? '', activePayload).trim(),
         priority: Number(templateFields.priority ?? '3'),
         tags: applyTemplate(templateFields.tags ?? '', activePayload),
         title: applyTemplate(templateFields.title ?? '', activePayload),


### PR DESCRIPTION
Implements part 1 of the webhook `link` spec: the template `link` field was accepted by the create page and saved into the template JSON, but never rendered, never previewed, and never delivered.

## Delivery

- `renderTemplate()` now renders `template.link` and returns it alongside the other fields (`webhook-template.ts`).
- `receiveWebhook` turns that link into `actions: [{ type: 'view', url }]` instead of the hardcoded `'[]'`, and forwards the same actions to the push job so the button appears in the push notification and not only in-app.

The rendered link is interpolated from the caller's payload, and `/h/:slug` is public and unauthenticated — so the URL is untrusted input. It goes through the same `validateActions` used by `POST /topic/:name`, which restricts stored URLs to http(s). Unlike publish, a link we cannot use never fails the delivery: the notification still goes out, just without a button. Empty links short-circuit before the validator so the common case does not run through an error path.

## Preview

The create page and the delivery log both forwarded every template field except `link`, so both previewed a notification the recipient never actually received. Both now pass it through, and `NotifPreview` renders the resulting button.

Links the server will drop — relative paths like `/repos/acme/api`, `javascript:` schemes, `mailto:` — render as an explicit `View · dropped` state rather than silently vanishing. `isDeliverableLink` deliberately mirrors the server's `isValidHref` rather than reusing `safeExternalUrl` from shared: that helper also accepts `mailto:`, which would have previewed a button the server goes on to drop.

## Tests

`receive.ts` had no spec at all before this. Added `receive.spec.ts` covering valid link, `javascript:` scheme, relative path, unresolved template field, no link, untemplated passthrough, and push-job forwarding — plus `renderTemplate` link cases and `NotifPreview` render states.

Required two additions to the shared Prisma mock (`webhook.findUnique`, `webhookDelivery.create`) that the route needs and no existing spec exercised.

## Verification

Run at `90546c0`:

- `packages/emitsignal-server`: 371 pass, 0 fail (47 files)
- `packages/emitsignal-shared`: 13 pass, 0 fail
- `packages/emitsignal-website`: 10 pass, 0 fail (2 files)
- `bun lint` and `bun format:check` clean

`tsc --noEmit` on the server reports 4 pre-existing errors in `subscriptions/__tests__/update.spec.ts`, a file this branch does not touch; they are present on `origin/main`. The website typechecks clean.

## Not in this PR

Part 2 of the spec — capturing request headers on webhook delivery for auth debugging — is still awaiting a product decision on redaction and retention. Relevant finding from the review: `WebhookDelivery` rows are never purged (the purge worker only handles attachments and messages), so any header capture needs a retention story before it ships.