### PR TITLE
refactor(website): audit and de-slop the landing page

### DIFF
--- a/packages/emitsignal-website/src/components/blog/blog-footer.tsx
+++ b/packages/emitsignal-website/src/components/blog/blog-footer.tsx
@@ -1,4 +1,5 @@
 import { Logo } from '#/components/ui/logo';
+import { STATUS_URL } from '#/lib/links';
 
 export function BlogFooter() {
     return (
@@ -13,7 +14,7 @@ export function BlogFooter() {
                 <span className="ml-auto flex items-center gap-1.5 font-mono text-[11px] text-dim">
                     <span className="h-1.5 w-1.5 rounded-full bg-success shadow-[0_0_6px_var(--color-success)]" />
                     all systems normal ·{' '}
-                    <a href="https://status.emitsignal.com" target="_blank">
+                    <a href={STATUS_URL} target="_blank">
                         status.emitsignal.com
                     </a>
                 </span>

--- a/packages/emitsignal-website/src/components/landing/button.tsx
+++ b/packages/emitsignal-website/src/components/landing/button.tsx
@@ -26,10 +26,14 @@ interface InternalLink extends BaseProps {
 type Variant = 'primary' | 'secondary';
 
 const BASE_CLASS =
-    'inline-flex cursor-pointer items-center gap-2 rounded-lg px-[18px] py-[11px] text-[13.5px] font-semibold no-underline transition-colors';
+    'inline-flex cursor-pointer items-center gap-2 rounded-lg px-[18px] py-[11px] text-[13.5px] font-semibold no-underline transition-colors active:translate-y-px';
+
+function isExternal(href: string): boolean {
+    return /^(https?:|mailto:)/.test(href);
+}
 
 const VARIANT_CLASS: Record<Variant, string> = {
-    primary: 'bg-accent text-bg hover:bg-accent-dim',
+    primary: 'bg-accent text-bg hover:bg-accent-hover',
     secondary: 'border border-line text-fg hover:bg-elev',
 };
 
@@ -61,8 +65,16 @@ export function Button({
             </Link>
         );
     }
+    const href = props.href ?? '#';
+    const external = isExternal(href);
+
     return (
-        <a className={className} href={props.href ?? '#'} target="_blank">
+        <a
+            className={className}
+            href={href}
+            rel={external ? 'noopener noreferrer' : undefined}
+            target={external ? '_blank' : undefined}
+        >
             {inner}
         </a>
     );

--- a/packages/emitsignal-website/src/components/landing/eyebrow.tsx
+++ b/packages/emitsignal-website/src/components/landing/eyebrow.tsx
@@ -6,8 +6,7 @@ interface EyebrowProps {
 
 export function Eyebrow({ children }: EyebrowProps) {
     return (
-        <div className="mb-3.5 flex items-center gap-2 font-mono text-[11px] uppercase tracking-[2px] text-accent">
-            <span className="h-1.5 w-1.5 rounded-full bg-accent shadow-[0_0_8px_var(--color-accent)]" />
+        <div className="mb-3.5 font-mono text-[11px] uppercase tracking-[2px] text-accent">
             {children}
         </div>
     );

--- a/packages/emitsignal-website/src/components/landing/final-cta.tsx
+++ b/packages/emitsignal-website/src/components/landing/final-cta.tsx
@@ -1,5 +1,7 @@
 import { ArrowRight, Terminal } from 'lucide-react';
 
+import { DOCS_URL } from '#/lib/links';
+
 import { Button } from './button';
 import { Section } from './section';
 
@@ -7,29 +9,21 @@ export function FinalCTA() {
     return (
         <Section className="px-5 py-16 sm:px-8 md:px-16 md:py-30">
             <div className="relative text-center">
-                <div
-                    className="pointer-events-none absolute -top-10 left-[20%] right-[20%] h-[200px] blur-3xl"
-                    style={{
-                        background:
-                            'radial-gradient(ellipse at center, rgba(167,139,250,0.2), transparent 70%)',
-                    }}
-                />
-                <div className="relative">
+                <div>
                     <h2 className="mx-auto m-0 mb-4.5 max-w-[780px] font-sans text-[32px] font-semibold leading-none tracking-[-1px] sm:text-[44px] md:text-[58px] md:tracking-[-1.8px]">
                         One pipe. Everywhere you read.
                     </h2>
                     <p className="mx-auto mb-9 max-w-[560px] text-[17px] leading-[1.55] text-muted">
-                        Free to start. No credit card. No SDK.{' '}
-                        <strong className="text-fg">Thirty seconds</strong> from{' '}
-                        <em className="not-italic text-fg">brew install</em> to your first signal.
+                        Free to start. No credit card, no SDK, no account needed for your first
+                        signal.
                     </p>
                     <div className="inline-flex flex-wrap items-center justify-center gap-3.5">
                         <Button icon={<ArrowRight size={13} />} to="/app" variant="primary">
-                            Get started · free
+                            Get started
                         </Button>
 
-                        <Button href="https://docs.emitsignal.com" icon={<Terminal size={13} />}>
-                            read the docs
+                        <Button href={DOCS_URL} icon={<Terminal size={13} />}>
+                            Read the docs
                         </Button>
                     </div>
                 </div>

--- a/packages/emitsignal-website/src/components/landing/footer.tsx
+++ b/packages/emitsignal-website/src/components/landing/footer.tsx
@@ -1,6 +1,8 @@
 import { Link } from '@tanstack/react-router';
+import { Github } from 'lucide-react';
 
 import { Logo } from '#/components/ui/logo';
+import { AUTHOR_URL, DOCS_URL, LICENSE_URL, REPO_URL, STATUS_URL } from '#/lib/links';
 
 interface FooterColumn {
     heading: string;
@@ -18,16 +20,16 @@ const COLUMNS: FooterColumn[] = [
         heading: 'product',
         links: [
             { label: 'Mobile', to: '/mobile' },
-            { href: 'https://docs.emitsignal.com/api', label: 'API' },
+            { href: `${DOCS_URL}/api`, label: 'API' },
             { label: 'Changelog', to: '/changelog' },
         ],
     },
     {
         heading: 'developers',
         links: [
-            { href: 'https://docs.emitsignal.com', label: 'Docs' },
+            { href: DOCS_URL, label: 'Docs' },
             { label: 'Blog', to: '/blog' },
-            { href: '#', label: 'Open source' },
+            { href: '/#open-source', label: 'Open source' },
         ],
     },
     {
@@ -37,38 +39,34 @@ const COLUMNS: FooterColumn[] = [
             { label: 'Terms', to: '/terms' },
             { label: 'Code of conduct', to: '/code-of-conduct' },
             {
-                href: 'https://github.com/kevenleone/emitsignal/tree/main?tab=AGPL-3.0-1-ov-file',
-                label: 'GPLv3 License',
+                href: LICENSE_URL,
+                label: 'AGPLv3 License',
             },
         ],
     },
 ];
 
-const SOCIAL_BADGES = ['gh', 'tw', 'rs', 'em'];
-
 export function Footer() {
     return (
-        <footer className="border-t border-line bg-[#0a0614] px-5 pb-8 pt-10 sm:px-8 md:px-16 md:pt-14">
+        <footer className="border-t border-line bg-deep px-5 pb-8 pt-10 sm:px-8 md:px-16 md:pt-14">
             <div className="mx-auto max-w-[1280px]">
                 <div className="mb-8 grid grid-cols-2 gap-6 sm:grid-cols-3 md:mb-12 md:grid-cols-[1.4fr_repeat(3,1fr)] md:gap-10">
                     <div className="col-span-2 sm:col-span-3 md:col-span-1">
                         <Logo pulse size={16} />
                         <p className="mt-4 max-w-[280px] text-[13px] leading-[1.6] text-muted">
-                            The dev-native pubsub layer.
+                            A pubsub layer for humans.
                             <br />
                             One curl. Everywhere you read.
                         </p>
-                        <div className="mt-4.5 flex gap-2.5">
-                            {SOCIAL_BADGES.map((badge) => (
-                                <a
-                                    className="flex h-7 w-7 items-center justify-center rounded-md border border-line bg-elev font-mono text-[10px] text-muted no-underline hover:text-fg"
-                                    href="#"
-                                    key={badge}
-                                >
-                                    {badge}
-                                </a>
-                            ))}
-                        </div>
+                        <a
+                            className="mt-4.5 inline-flex items-center gap-2 rounded-lg border border-line px-3 py-1.5 font-mono text-[11.5px] text-muted no-underline hover:bg-elev hover:text-fg"
+                            href={REPO_URL}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                        >
+                            <Github size={13} />
+                            GitHub
+                        </a>
                     </div>
 
                     {COLUMNS.map((col) => (
@@ -91,7 +89,12 @@ export function Footer() {
                                             <a
                                                 className="text-[13px] text-muted no-underline hover:text-fg"
                                                 href={link.href}
-                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                target={
+                                                    link.href?.startsWith('http')
+                                                        ? '_blank'
+                                                        : undefined
+                                                }
                                             >
                                                 {link.label}
                                             </a>
@@ -105,20 +108,24 @@ export function Footer() {
 
                 <div className="flex flex-col gap-2 border-t border-line pt-5.5 font-mono text-[11px] text-dim sm:flex-row sm:items-center sm:gap-4">
                     <span>
-                        © {new Date().getFullYear()} EmitSignal · Built by{' '}
+                        © {new Date().getFullYear()} EmitSignal. Built by{' '}
                         <a
                             className="text-muted hover:text-fg"
-                            href="https://github.com/kevenleone"
+                            href={AUTHOR_URL}
+                            rel="noopener noreferrer"
                             target="_blank"
                         >
                             Keven Leone
                         </a>
                     </span>
-                    <span className="flex items-center gap-1.5 sm:ml-auto">
-                        <span className="h-1.5 w-1.5 rounded-full bg-success shadow-[0_0_6px_var(--color-success)]" />
-                        all systems normal ·{' '}
-                        <a href="https://status.emitsignal.com" target="_blank">
-                            status.emitsignal.com
+                    <span className="sm:ml-auto">
+                        <a
+                            className="text-muted hover:text-fg"
+                            href={STATUS_URL}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                        >
+                            System status
                         </a>
                     </span>
                 </div>

--- a/packages/emitsignal-website/src/components/landing/hero.tsx
+++ b/packages/emitsignal-website/src/components/landing/hero.tsx
@@ -1,7 +1,11 @@
-import { ArrowRight, Terminal } from 'lucide-react';
+import { ArrowRight } from 'lucide-react';
+
+import { CopyButton } from '#/components/ui/copy-button';
 
 import { Button } from './button';
 import { HeroTerminal } from './hero-terminal';
+
+const TRY_IT_COMMAND = 'curl -d "hi from the marketing site" emitsignal.com/me-tryout';
 
 export function Hero() {
     return (
@@ -18,66 +22,39 @@ export function Hero() {
 
 function HeroBackground() {
     return (
-        <>
-            <div
-                className="pointer-events-none absolute inset-0 opacity-35"
-                style={{
-                    backgroundImage:
-                        'linear-gradient(var(--color-line) 1px, transparent 1px), linear-gradient(90deg, var(--color-line) 1px, transparent 1px)',
-                    backgroundSize: '64px 64px',
-                    maskImage: 'radial-gradient(ellipse at 30% 40%, black 0%, transparent 70%)',
-                    WebkitMaskImage:
-                        'radial-gradient(ellipse at 30% 40%, black 0%, transparent 70%)',
-                }}
-            />
-
-            <div
-                className="pointer-events-none absolute left-[-10%] top-[20%] h-[600px] w-[600px] blur-3xl"
-                style={{
-                    background: 'radial-gradient(circle, rgba(91,33,182,0.4), transparent 60%)',
-                }}
-            />
-        </>
+        <div
+            className="pointer-events-none absolute inset-0 opacity-35"
+            style={{
+                backgroundImage:
+                    'linear-gradient(var(--color-line) 1px, transparent 1px), linear-gradient(90deg, var(--color-line) 1px, transparent 1px)',
+                backgroundSize: '64px 64px',
+                maskImage: 'radial-gradient(ellipse at 30% 40%, black 0%, transparent 70%)',
+                WebkitMaskImage: 'radial-gradient(ellipse at 30% 40%, black 0%, transparent 70%)',
+            }}
+        />
     );
 }
 
 function HeroCopy() {
     return (
         <div>
-            <h1 className="m-0 font-sans text-[44px] font-semibold leading-[0.98] tracking-[-1.6px] text-fg sm:text-[56px] sm:tracking-[-2px] md:text-[76px] md:tracking-[-2.6px]">
-                Push&nbsp;notifications
-                <br />
-                with{' '}
-                <span
-                    className="font-mono font-medium text-accent"
-                    style={{
-                        background:
-                            'linear-gradient(180deg, var(--color-accent), var(--color-accent-dim))',
-                        WebkitBackgroundClip: 'text',
-                        WebkitTextFillColor: 'transparent',
-                    }}
-                >
-                    one curl
-                </span>
-                .
+            <h1 className="m-0 font-sans text-[40px] font-semibold leading-[1.02] tracking-[-1.6px] text-fg sm:text-[48px] sm:tracking-[-2px] md:text-[56px] md:tracking-[-2.2px]">
+                Push notifications with{' '}
+                <span className="font-mono font-medium text-accent">one curl</span>.
             </h1>
 
-            <p className="mb-9 mt-7 max-w-[520px] font-sans text-[19px] leading-[1.55] text-muted">
-                A pubsub layer for humans. Pipe anything into a topic from your shell, CI, cron, or
-                a webhook — get it on your phone, terminal, slack, or email. No SDK. No account to
-                start.
+            <p className="mb-8 mt-6 max-w-[520px] font-sans text-[19px] leading-[1.55] text-muted">
+                Pipe anything into a topic from your shell, CI, or cron. Read it on your phone,
+                terminal, or inbox.
             </p>
 
             <TryItNowCurl />
 
             <div className="flex flex-wrap items-center gap-3">
                 <Button icon={<ArrowRight size={13} />} to="/app" variant="primary">
-                    Get started · free
+                    Get started
                 </Button>
-                <Button href="#how" icon={<Terminal size={13} />}>
-                    brew install emitsignal
-                </Button>
-                <span className="font-mono text-[12.5px] text-dim">· 30s setup</span>
+                <Button href="#how">How it works</Button>
             </div>
         </div>
     );
@@ -85,16 +62,13 @@ function HeroCopy() {
 
 function TryItNowCurl() {
     return (
-        <div className="mb-5.5 rounded-xl border border-line bg-deep px-4 py-3.5 font-mono text-[14px] leading-[1.5]">
-            <p className="mb-2 text-[10px] tracking-[1.4px] text-dim">
-                TRY IT NOW · NO ACCOUNT NEEDED
-            </p>
-
-            <div className="text-fg">
+        <div className="mb-6 flex items-center gap-3 rounded-xl border border-line bg-deep px-4 py-3.5">
+            <code className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-mono text-[13.5px] leading-[1.5]">
                 <span className="text-success">$</span> <span className="text-dim">curl -d</span>{' '}
                 <span className="text-warn">"hi from the marketing site"</span>{' '}
                 <span className="text-accent">emitsignal.com/me-tryout</span>
-            </div>
+            </code>
+            <CopyButton className="shrink-0" value={TRY_IT_COMMAND} />
         </div>
     );
 }

--- a/packages/emitsignal-website/src/components/landing/how-it-works.tsx
+++ b/packages/emitsignal-website/src/components/landing/how-it-works.tsx
@@ -1,9 +1,10 @@
+import { cn } from '#/lib/cn';
+
 import { Eyebrow } from './eyebrow';
 import { Section } from './section';
 
 interface Step {
     code: string;
-    stepNumber: string;
     subtitle: string;
     title: string;
 }
@@ -18,8 +19,7 @@ $ curl emitsignal.com/ci/web -d "build #4821 passed"
 
 # from anywhere
 $ pg_dump prod | gzip > /tmp/bak.gz && \\
-    emitsignal publish cron/backup "$(date) ✓"`,
-        stepNumber: '01',
+    emitsignal publish cron/backup "$(date)"`,
         subtitle:
             'Curl, the CLI, a webhook, GitHub Actions, a python script, or a one-line shell pipe. If it can hit an HTTP endpoint, it can publish.',
         title: 'Publish from anywhere.',
@@ -31,10 +31,9 @@ priority:4            → push + slack #alerts
 priority:<=3          → inbox only
 tag:sev2              → page on-call rotation
 tag:resolved          → silence
-hour:between(0,7)     → batch · digest at 08:00`,
-        stepNumber: '02',
+hour:between(0,7)     → batch, digest at 08:00`,
         subtitle:
-            'Per-channel rules: priority, tags, regex, deliver-window. Everything is a topic; topics are free-form strings; rules cascade.',
+            'Per-channel rules: priority, tags, regex, deliver-window. Everything is a topic, topics are free-form strings, and rules cascade.',
         title: 'Route with filters.',
     },
     {
@@ -47,10 +46,9 @@ $ emitsignal tui
 # read in a script
 $ emitsignal listen --format json | jq -r .title
 
-# read on your phone, web, slack — automatic`,
-        stepNumber: '03',
+# read on your phone, web, or slack automatically`,
         subtitle:
-            'Phone, terminal, web inbox, slack, email, webhook, RSS. Read once syncs everywhere. End-to-end in <300ms p99.',
+            'Phone, terminal, web inbox, slack, email, webhook, RSS. Read once and it syncs everywhere.',
         title: 'Deliver wherever you read.',
     },
 ];
@@ -58,37 +56,44 @@ $ emitsignal listen --format json | jq -r .title
 export function HowItWorks() {
     return (
         <Section id="how">
-            <Eyebrow>HOW IT WORKS</Eyebrow>
+            <Eyebrow>How it works</Eyebrow>
             <h2 className="m-0 mb-4 max-w-[780px] text-[28px] font-semibold leading-[1.05] tracking-[-1px] text-fg sm:text-[36px] md:text-[44px] md:tracking-[-1.4px]">
                 One verb. Three steps. Zero SDKs.
             </h2>
             <p className="mb-10 max-w-[620px] font-sans text-[17px] leading-[1.55] text-muted">
-                Topics are strings. Subscriptions are URLs. Routing is plain English (well — plain
-                expressions). That's the entire mental model.
+                Topics are strings. Subscriptions are URLs. Routing is a short expression. That is
+                the entire mental model.
             </p>
 
             <div className="grid gap-[18px]">
-                {STEPS.map((step) => (
-                    <StepCard key={step.stepNumber} step={step} />
+                {STEPS.map((step, index) => (
+                    <StepCard key={step.title} reversed={index % 2 === 1} step={step} />
                 ))}
             </div>
         </Section>
     );
 }
 
-function StepCard({ step }: { step: Step }) {
+function StepCard({ reversed, step }: { reversed: boolean; step: Step }) {
     return (
-        <div className="grid grid-cols-1 items-center gap-6 rounded-2xl border border-line bg-elev px-5 py-6 md:grid-cols-[1fr_1.4fr] md:gap-10 md:px-9 md:py-8">
-            <div>
-                <p className="mb-2.5 font-mono text-[13px] font-semibold text-accent">
-                    {step.stepNumber}
-                </p>
+        <div
+            className={cn(
+                'grid grid-cols-1 items-center gap-6 rounded-xl border border-line bg-elev px-5 py-6 md:gap-10 md:px-9 md:py-8',
+                reversed ? 'md:grid-cols-[1.4fr_1fr]' : 'md:grid-cols-[1fr_1.4fr]',
+            )}
+        >
+            <div className={cn(reversed && 'md:order-2')}>
                 <h3 className="m-0 mb-3 text-[26px] font-semibold leading-[1.1] tracking-[-0.7px]">
                     {step.title}
                 </h3>
                 <p className="m-0 text-[15px] leading-[1.55] text-muted">{step.subtitle}</p>
             </div>
-            <pre className="m-0 whitespace-pre-wrap rounded-xl border border-line bg-deep px-4.5 py-4 font-mono text-[12.5px] leading-[1.7] text-fg">
+            <pre
+                className={cn(
+                    'm-0 overflow-x-auto rounded-xl bg-deep px-4.5 py-4 font-mono text-[12.5px] leading-[1.7] text-fg',
+                    reversed && 'md:order-1',
+                )}
+            >
                 {step.code}
             </pre>
         </div>

--- a/packages/emitsignal-website/src/components/landing/nav.tsx
+++ b/packages/emitsignal-website/src/components/landing/nav.tsx
@@ -1,65 +1,94 @@
-import type { ReactNode } from 'react';
-
 import { Link } from '@tanstack/react-router';
+import { Menu, X } from 'lucide-react';
+import { useState } from 'react';
 
 import { Logo } from '#/components/ui/logo';
+import { DOCS_URL } from '#/lib/links';
 
 interface NavLink {
     href?: string;
-    label: ReactNode;
+    label: string;
     to?: string;
 }
 
 const LINKS: NavLink[] = [
     { label: 'Blog', to: '/blog' },
-    { href: '#how', label: 'Docs' },
+    { href: DOCS_URL, label: 'Docs' },
     { href: '#pricing', label: 'Pricing' },
-    { href: '/changelog', label: 'Changelog' },
+    { label: 'Changelog', to: '/changelog' },
 ];
 
+const LINK_CLASS = 'text-muted no-underline hover:text-fg';
+
 export function Nav() {
+    const [open, setOpen] = useState(false);
+
+    const close = () => setOpen(false);
+
     return (
-        <nav className="sticky top-0 z-10 flex items-center gap-4 border-b border-line bg-bg/85 px-4 py-3.5 font-mono text-[12.5px] backdrop-blur-md sm:gap-7 sm:px-8">
-            <Link className="text-fg no-underline" to="/">
-                <Logo pulse />
-            </Link>
-            <div className="ml-4 hidden gap-[22px] md:flex">
-                {LINKS.map((link, index) =>
-                    link.to ? (
-                        <Link
-                            className="text-muted no-underline hover:text-fg"
-                            key={index}
-                            to={link.to}
-                        >
-                            {link.label}
-                        </Link>
-                    ) : (
-                        <a
-                            className="text-muted no-underline hover:text-fg"
-                            href={link.href}
-                            key={index}
-                        >
-                            {link.label}
-                        </a>
-                    ),
-                )}
-            </div>
-
-            <div className="ml-auto flex items-center gap-3">
-                <Link
-                    className="hidden text-muted no-underline hover:text-fg sm:inline"
-                    to="/sign-in"
-                >
-                    Sign in
+        <nav className="sticky top-0 z-10 border-b border-line bg-bg/85 font-mono text-[12.5px] backdrop-blur-md">
+            <div className="flex items-center gap-4 px-4 py-3.5 sm:gap-7 sm:px-8">
+                <Link className="text-fg no-underline" onClick={close} to="/">
+                    <Logo pulse />
                 </Link>
 
-                <Link
-                    className="rounded-md bg-accent px-3.5 py-1.5 font-semibold text-bg no-underline hover:bg-accent-dim"
-                    to="/sign-in"
-                >
-                    Get started
-                </Link>
+                <div className="ml-4 hidden gap-[22px] md:flex">
+                    <NavLinks />
+                </div>
+
+                <div className="ml-auto flex items-center gap-3">
+                    <Link
+                        className="hidden text-muted no-underline hover:text-fg sm:inline"
+                        to="/sign-in"
+                    >
+                        Sign in
+                    </Link>
+
+                    <Link
+                        className="rounded-lg bg-accent px-3.5 py-1.5 font-semibold text-bg no-underline hover:bg-accent-hover active:translate-y-px"
+                        to="/sign-in"
+                    >
+                        Get started
+                    </Link>
+
+                    <button
+                        aria-controls="nav-menu"
+                        aria-expanded={open}
+                        aria-label={open ? 'Close menu' : 'Open menu'}
+                        className="-mr-1 cursor-pointer border-none bg-transparent p-1 text-muted hover:text-fg md:hidden"
+                        onClick={() => setOpen(!open)}
+                        type="button"
+                    >
+                        {open ? <X size={18} /> : <Menu size={18} />}
+                    </button>
+                </div>
             </div>
+
+            {open && (
+                <div
+                    className="flex flex-col gap-4 border-t border-line px-4 pb-5 pt-4 md:hidden"
+                    id="nav-menu"
+                >
+                    <NavLinks onNavigate={close} />
+                    <Link className={`${LINK_CLASS} sm:hidden`} onClick={close} to="/sign-in">
+                        Sign in
+                    </Link>
+                </div>
+            )}
         </nav>
+    );
+}
+
+function NavLinks({ onNavigate }: { onNavigate?: () => void }) {
+    return LINKS.map((link) =>
+        link.to ? (
+            <Link className={LINK_CLASS} key={link.label} onClick={onNavigate} to={link.to}>
+                {link.label}
+            </Link>
+        ) : (
+            <a className={LINK_CLASS} href={link.href} key={link.label} onClick={onNavigate}>
+                {link.label}
+            </a>
+        ),
     );
 }

--- a/packages/emitsignal-website/src/components/landing/open-source.tsx
+++ b/packages/emitsignal-website/src/components/landing/open-source.tsx
@@ -2,12 +2,10 @@ import type { LucideIcon } from 'lucide-react';
 
 import { Boxes, Github, Scale, ShieldCheck } from 'lucide-react';
 
-import { Button } from './button';
-import { Eyebrow } from './eyebrow';
-import { Section } from './section';
+import { LICENSE_URL, REPO_URL } from '#/lib/links';
 
-const REPO_URL = 'https://github.com/kevenleone/emitsignal';
-const LICENSE_URL = `${REPO_URL}/tree/main?tab=AGPL-3.0-1-ov-file`;
+import { Button } from './button';
+import { Section } from './section';
 
 interface Feature {
     desc: string;
@@ -15,40 +13,33 @@ interface Feature {
     title: string;
 }
 
-const FEATURES: Feature[] = [
+const [LEAD_FEATURE, ...SUPPORTING_FEATURES]: Feature[] = [
     {
-        desc: 'Run the whole platform on your own infrastructure — server, workers, database, and queues. No vendor lock-in.',
+        desc: 'Run the whole platform on your own infrastructure: server, workers, database, and queues. No vendor lock-in.',
         icon: Boxes,
         title: 'Self-host the whole stack',
     },
     {
-        desc: 'Licensed under the GNU AGPLv3. Free to use, study, modify, and share — as long as your changes stay open too.',
+        desc: 'Licensed under the GNU AGPLv3. Free to use, study, modify, and share, as long as your changes stay open too.',
         icon: Scale,
         title: 'AGPLv3 licensed',
     },
     {
-        desc: 'Every line is on GitHub. Read exactly how your messages are routed, stored, and delivered — no black boxes.',
+        desc: 'Every line is on GitHub. Read exactly how your messages are routed, stored, and delivered.',
         icon: ShieldCheck,
         title: 'No black boxes',
     },
 ];
 
-interface FeatureCardProps {
-    desc: string;
-    icon: LucideIcon;
-    title: string;
-}
-
 export function OpenSource() {
     return (
         <Section id="open-source">
-            <Eyebrow>OPEN-SOURCE</Eyebrow>
             <h2 className="m-0 mb-4 max-w-[820px] text-[28px] font-semibold leading-[1.05] tracking-[-1px] text-fg sm:text-[36px] md:text-[44px] md:tracking-[-1.4px]">
                 Yours to run, inspect, and extend.
             </h2>
             <p className="mb-8 max-w-[620px] font-sans text-[17px] leading-[1.55] text-muted">
                 EmitSignal is fully open-source. Host it yourself, audit the delivery path, or send
-                a pull request — the entire platform lives in the open.
+                a pull request. The entire platform lives in the open.
             </p>
 
             <div className="mb-12 inline-flex flex-wrap items-center gap-3.5">
@@ -57,32 +48,46 @@ export function OpenSource() {
                 </Button>
 
                 <Button href={LICENSE_URL} icon={<Scale size={13} />}>
-                    Read the license · AGPLv3
+                    Read the license
                 </Button>
             </div>
 
-            <div className="grid grid-cols-1 gap-[18px] md:grid-cols-3">
-                {FEATURES.map((feature) => (
-                    <FeatureCard
-                        desc={feature.desc}
-                        icon={feature.icon}
-                        key={feature.title}
-                        title={feature.title}
-                    />
-                ))}
+            <div className="grid grid-cols-1 gap-[18px] md:grid-cols-[1.35fr_1fr]">
+                <FeatureBlock feature={LEAD_FEATURE} lead />
+                <div className="grid gap-[18px]">
+                    {SUPPORTING_FEATURES.map((feature) => (
+                        <FeatureBlock feature={feature} key={feature.title} />
+                    ))}
+                </div>
             </div>
         </Section>
     );
 }
 
-function FeatureCard({ desc, icon: Icon, title }: FeatureCardProps) {
+function FeatureBlock({ feature, lead = false }: { feature: Feature; lead?: boolean }) {
+    const { desc, icon: Icon, title } = feature;
+
     return (
-        <div className="rounded-2xl border border-line bg-elev p-7">
-            <div className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-accent/35 text-accent">
-                <Icon size={16} />
-            </div>
-            <p className="mt-4 m-0 text-[18px] font-semibold tracking-[-0.4px] text-fg">{title}</p>
-            <p className="mt-2 m-0 text-[14px] leading-[1.6] text-muted">{desc}</p>
+        <div className="flex h-full flex-col justify-center rounded-xl border border-line bg-elev p-7">
+            <Icon className="text-accent" size={lead ? 22 : 18} />
+            <p
+                className={
+                    lead
+                        ? 'mt-5 m-0 text-[26px] font-semibold leading-[1.15] tracking-[-0.7px] text-fg'
+                        : 'mt-4 m-0 text-[18px] font-semibold tracking-[-0.4px] text-fg'
+                }
+            >
+                {title}
+            </p>
+            <p
+                className={
+                    lead
+                        ? 'mt-3 m-0 max-w-[42ch] text-[15px] leading-[1.6] text-muted'
+                        : 'mt-2 m-0 text-[14px] leading-[1.6] text-muted'
+                }
+            >
+                {desc}
+            </p>
         </div>
     );
 }

--- a/packages/emitsignal-website/src/components/landing/pricing.tsx
+++ b/packages/emitsignal-website/src/components/landing/pricing.tsx
@@ -34,7 +34,7 @@ function planTier(plan: PlanDefinition): Tier {
 
     if (plan.name === 'free') {
         return {
-            cta: 'Start free',
+            cta: 'Get started',
             description: plan.description,
             features,
             href: '/sign-in',
@@ -52,7 +52,7 @@ function planTier(plan: PlanDefinition): Tier {
         href: '/app/settings/billing',
         name: plan.label,
         price: `$${plan.priceMonthlyUsd}`,
-        priceSubtitle: `/ month · $${plan.priceYearlyUsd}/yr`,
+        priceSubtitle: `/ month, or $${plan.priceYearlyUsd}/yr`,
         tag: plan.name === 'pulse' ? 'most popular' : undefined,
     };
 }
@@ -63,15 +63,17 @@ export function Pricing() {
     return (
         <Section
             id="pricing"
-            style={{ background: 'linear-gradient(180deg, transparent, rgba(26,22,37,0.33))' }}
+            style={{
+                background:
+                    'linear-gradient(180deg, transparent, color-mix(in srgb, var(--color-elev) 55%, transparent))',
+            }}
         >
-            <Eyebrow>PRICING</Eyebrow>
+            <Eyebrow>Pricing</Eyebrow>
             <h2 className="m-0 mb-4 max-w-[780px] text-[28px] font-semibold leading-[1.05] tracking-[-1px] text-fg sm:text-[36px] md:text-[44px] md:tracking-[-1.4px]">
                 Pay for what you push.
             </h2>
             <p className="mb-10 max-w-[620px] font-sans text-[17px] leading-[1.55] text-muted">
-                No per-seat tax. No SDK to license. Pay yearly and get 2 months free. The free tier
-                is real — many people stay on it.
+                No per-seat tax. No SDK to license. Pay yearly and get 2 months free.
             </p>
 
             <div className="grid grid-cols-1 gap-[18px] md:grid-cols-3">
@@ -83,8 +85,8 @@ export function Pricing() {
             <div className="mt-8 flex items-center gap-4 rounded-xl border border-dashed border-line px-5 py-4 font-mono text-[12px] text-muted">
                 <AlertTriangle className="text-warn shrink-0" size={14} />
                 <span>
-                    A message = one published signal. Receiving is free — same signal to 200
-                    subscribers still counts as 1. Daily limits reset at midnight UTC.
+                    A message is one published signal. Receiving is free, so the same signal sent to
+                    200 subscribers still counts as 1. Daily limits reset at midnight UTC.
                 </span>
             </div>
         </Section>
@@ -95,10 +97,8 @@ function TierCard({ tier }: { tier: Tier }) {
     return (
         <div
             className={cn(
-                'relative rounded-2xl border px-7 py-8',
-                tier.highlighted
-                    ? 'border-accent bg-elev shadow-[0_0_0_4px_rgba(167,139,250,0.1)]'
-                    : 'border-line bg-transparent',
+                'relative flex h-full flex-col rounded-xl border px-7 py-8',
+                tier.highlighted ? 'border-accent bg-elev' : 'border-line bg-transparent',
             )}
         >
             {tier.tag && (
@@ -113,10 +113,8 @@ function TierCard({ tier }: { tier: Tier }) {
                 <span className="text-[44px] font-semibold tracking-[-1.4px]">{tier.price}</span>
                 <span className="font-mono text-[12.5px] text-dim">{tier.priceSubtitle}</span>
             </div>
-            <p className="min-h-[42px] m-0 mb-5.5 text-[14px] leading-[1.5] text-muted">
-                {tier.description}
-            </p>
-            <ul className="m-0 mb-6.5 flex list-none flex-col gap-2.5 p-0">
+            <p className="m-0 mb-5.5 text-[14px] leading-[1.5] text-muted">{tier.description}</p>
+            <ul className="m-0 mb-6.5 flex flex-1 list-none flex-col gap-2.5 p-0">
                 {tier.features.map((feature) => (
                     <li className="flex items-start gap-2.5 text-[13px] text-muted" key={feature}>
                         <span className="font-mono leading-[1.5] text-accent">→</span>
@@ -126,9 +124,9 @@ function TierCard({ tier }: { tier: Tier }) {
             </ul>
             <a
                 className={cn(
-                    'block rounded-lg px-4 py-3 text-center font-mono text-[13px] font-semibold no-underline',
+                    'block rounded-lg px-4 py-3 text-center font-mono text-[13px] font-semibold no-underline active:translate-y-px',
                     tier.highlighted
-                        ? 'bg-accent text-bg hover:bg-accent-dim'
+                        ? 'bg-accent text-bg hover:bg-accent-hover'
                         : 'border border-line text-fg hover:bg-elev',
                 )}
                 href={tier.href}

--- a/packages/emitsignal-website/src/components/landing/use-cases.tsx
+++ b/packages/emitsignal-website/src/components/landing/use-cases.tsx
@@ -1,13 +1,9 @@
-import { Dot } from '#/components/ui/dot';
-
-import { Eyebrow } from './eyebrow';
 import { Section } from './section';
 
 interface UseCase {
     channel: string;
     code: string;
     color: string;
-    priority: number;
     title: string;
 }
 
@@ -16,42 +12,36 @@ const CASES: UseCase[] = [
         channel: 'alerts/prod',
         code: 'priority:5 → sms + push + slack',
         color: 'text-danger',
-        priority: 5,
         title: 'On-call paging without PagerDuty.',
     },
     {
         channel: 'deploy/prod',
         code: 'CI → emitsignal publish deploy/prod',
         color: 'text-accent',
-        priority: 4,
         title: 'Deploys announced everywhere.',
     },
     {
         channel: 'cron/backup',
         code: 'emitsignal run "pg_dump | gzip > /tmp"',
         color: 'text-warn',
-        priority: 3,
-        title: 'Cron jobs that tell you they’re alive.',
+        title: 'Cron jobs that tell you they ran.',
     },
     {
         channel: 'errors/web',
         code: 'tag:new AND p>=4 → page',
         color: 'text-danger',
-        priority: 5,
-        title: 'Sentry-grade firehose, your routing.',
+        title: 'Error firehose, your routing rules.',
     },
     {
         channel: 'me/personal',
         code: 'echo "$THING" | emitsignal publish me',
         color: 'text-info',
-        priority: 2,
         title: 'A pager for your own life.',
     },
     {
         channel: 'github/repo',
         code: 'event:review_requested → push',
         color: 'text-info',
-        priority: 2,
         title: 'Filter the noise out of GitHub.',
     },
 ];
@@ -59,42 +49,35 @@ const CASES: UseCase[] = [
 export function UseCases() {
     return (
         <Section id="use-cases">
-            <Eyebrow>USE CASES</Eyebrow>
             <h2 className="m-0 mb-4 max-w-[820px] text-[28px] font-semibold leading-[1.05] tracking-[-1px] text-fg sm:text-[36px] md:text-[44px] md:tracking-[-1.4px]">
                 Anything that emits a status line.
             </h2>
             <p className="mb-10 max-w-[620px] font-sans text-[17px] leading-[1.55] text-muted">
-                People ship deploys with us. They watch their freezer. They get paged at 4am when
-                the API forgets how to count. Topics are strings — go wild.
+                Deploys, backups, error spikes, a sensor in your garage. Topics are free-form
+                strings, so the list is up to you.
             </p>
 
-            <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2 md:grid-cols-3">
-                {CASES.map((useCase, index) => (
-                    <UseCaseCard key={index} useCase={useCase} />
+            <div className="grid grid-cols-1 gap-x-12 gap-y-9 sm:grid-cols-2">
+                {CASES.map((useCase) => (
+                    <UseCaseItem key={useCase.channel} useCase={useCase} />
                 ))}
             </div>
         </Section>
     );
 }
 
-function UseCaseCard({ useCase }: { useCase: UseCase }) {
+function UseCaseItem({ useCase }: { useCase: UseCase }) {
     return (
-        <div className="rounded-xl border border-line bg-elev p-5.5">
-            <div className="mb-3.5 flex items-center gap-2">
-                <Dot level={useCase.priority} />
-                <span className={`font-mono text-[11.5px] font-semibold ${useCase.color}`}>
-                    {useCase.channel}
-                </span>
-                <span className="ml-auto font-mono text-[10.5px] text-faint">
-                    p{useCase.priority}
-                </span>
-            </div>
-            <p className="m-0 mb-4 text-[18px] font-semibold leading-[1.25] tracking-[-0.3px]">
+        <div className="border-l border-line pl-5">
+            <span className={`font-mono text-[11.5px] font-semibold ${useCase.color}`}>
+                {useCase.channel}
+            </span>
+            <p className="m-0 mb-3 mt-2 text-[18px] font-semibold leading-[1.25] tracking-[-0.3px]">
                 {useCase.title}
             </p>
-            <div className="rounded-md border border-line bg-deep px-3 py-2 font-mono text-[11.5px] text-muted">
+            <code className="block overflow-x-auto whitespace-nowrap font-mono text-[11.5px] text-dim">
                 {useCase.code}
-            </div>
+            </code>
         </div>
     );
 }

--- a/packages/emitsignal-website/src/components/ui/logo.tsx
+++ b/packages/emitsignal-website/src/components/ui/logo.tsx
@@ -19,7 +19,7 @@ export function Logo({ className, label = 'EmitSignal', pulse = false, size = 14
                     pulse && 'animate-[signal-pulse_2s_ease-in-out_infinite]',
                 )}
                 style={{
-                    boxShadow: `0 0 ${size * 0.6}px var(--color-accent)`,
+                    boxShadow: pulse ? `0 0 ${size * 0.6}px var(--color-accent)` : undefined,
                     height: size * 0.55,
                     width: size * 0.55,
                 }}

--- a/packages/emitsignal-website/src/lib/blog.ts
+++ b/packages/emitsignal-website/src/lib/blog.ts
@@ -1,3 +1,5 @@
+import { AUTHOR_URL } from '#/lib/links';
+
 export interface Author {
     bio: string;
     handle: string;
@@ -46,7 +48,7 @@ export const AUTHORS: Record<AuthorId, Author> = {
         handle: '@kevenleone',
         id: 'keven',
         name: 'Keven Leone',
-        photo: 'https://github.com/kevenleone.png',
+        photo: `${AUTHOR_URL}.png`,
         role: 'Project Maintainer',
     },
     team: {

--- a/packages/emitsignal-website/src/lib/links.ts
+++ b/packages/emitsignal-website/src/lib/links.ts
@@ -1,0 +1,9 @@
+export const REPO_URL = 'https://github.com/kevenleone/emitsignal';
+
+export const LICENSE_URL = `${REPO_URL}/tree/main?tab=AGPL-3.0-1-ov-file`;
+
+export const AUTHOR_URL = 'https://github.com/kevenleone';
+
+export const DOCS_URL = 'https://docs.emitsignal.com';
+
+export const STATUS_URL = 'https://status.emitsignal.com';

--- a/packages/emitsignal-website/src/routes/__root.tsx
+++ b/packages/emitsignal-website/src/routes/__root.tsx
@@ -15,8 +15,8 @@ export interface RouterContext {
 
 const SITE_URL = import.meta.env.VITE_SITE_URL ?? 'https://emitsignal.com';
 const DEFAULT_DESCRIPTION =
-    'A pubsub layer for humans. Pipe anything into a topic from your shell, CI, cron, or a webhook — get it on your phone, terminal, slack, or email.';
-const DEFAULT_TITLE = 'EmitSignal — push notifications with one curl';
+    'A pubsub layer for humans. Pipe anything into a topic from your shell, CI, or cron, then read it on your phone, terminal, or inbox.';
+const DEFAULT_TITLE = 'EmitSignal: push notifications with one curl';
 const DEFAULT_OG_IMAGE = `${SITE_URL}/og-default.png`;
 
 export const Route = createRootRouteWithContext<RouterContext>()({

--- a/packages/emitsignal-website/src/routes/changelog.tsx
+++ b/packages/emitsignal-website/src/routes/changelog.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from '@tanstack/react-router';
 
 import { Footer } from '#/components/landing/footer';
 import { Nav } from '#/components/landing/nav';
+import { DOCS_URL } from '#/lib/links';
 
 export const Route = createFileRoute('/changelog')({ component: ChangelogPage });
 
@@ -230,7 +231,7 @@ export default function ChangelogPage() {
                                     listen, and subscribe from the terminal{' '}
                                     <a
                                         className="text-accent no-underline"
-                                        href="https://docs.emitsignal.com/cli"
+                                        href={`${DOCS_URL}/cli`}
                                         target="_blank"
                                     >
                                         (docs)

--- a/packages/emitsignal-website/src/styles.css
+++ b/packages/emitsignal-website/src/styles.css
@@ -13,13 +13,14 @@
     /* Text */
     --color-fg: #f5f0ff;
     --color-muted: #b8a9d9;
-    --color-dim: #7a6d99;
+    --color-dim: #8b7db0;
     --color-faint: #4a4166;
 
     /* Accent (violet) */
     --color-accent: #a78bfa;
     --color-accent-dim: #7c3aed;
     --color-accent-deep: #5b21b6;
+    --color-accent-hover: #c4b5fd;
 
     /* Semantic */
     --color-success: #4ade80;
@@ -64,6 +65,7 @@
     --color-accent: #7c3aed;
     --color-accent-dim: #6d28d9;
     --color-accent-deep: #5b21b6;
+    --color-accent-hover: #6d28d9;
 
     /* Semantic */
     --color-success: #16a34a;
@@ -104,6 +106,18 @@
     }
     to {
         transform: translateY(-50%);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-delay: -1ms !important;
+        animation-duration: 1ms !important;
+        animation-iteration-count: 1 !important;
+        scroll-behavior: auto !important;
+        transition-duration: 1ms !important;
     }
 }
 


### PR DESCRIPTION
Audits the public landing page (`src/routes/index.tsx` + `src/components/landing/*`) for generic AI-generated design patterns, and fixes what the audit turned up. Five of the findings were not taste calls but genuine defects.

## Defects fixed

- **A CTA opened a blank tab.** `button.tsx` set `target="_blank"` on every `href`, and the hero passed the on-page anchor `#how`, so the button opened `about:blank#how`. External links now also carry `rel="noopener noreferrer"`.
- **The nav was unusable on mobile.** All four links were `hidden md:flex` with no fallback, so Blog / Docs / Pricing / Changelog were unreachable below 768px. Adds a disclosure menu with `aria-expanded` / `aria-controls`.
- **Two contrast failures.** `--color-dim` measured 4.14:1 (needs 4.5:1) and was used at 10-12.5px; it now measures 5.25:1. The primary button dropped to **3.42:1 on hover**, because `--color-accent-dim` is darker than `--color-accent` while the label stays near-black. A new `--color-accent-hover` token goes lighter in dark mode (10.5:1) and darker in light mode, where the label is near-white.
- **No `prefers-reduced-motion` handling anywhere in the package.** Three infinite animations ran unconditionally. Now gated globally.
- **The footer contradicted itself.** It linked "GPLv3 License" while the project is AGPL-3.0-only, rendered a hardcoded "all systems normal" indicator next to a real status page, pointed "Open source" at `href="#"`, and shipped four dead two-letter social badges.

## Design changes

- Eyebrow labels reduced from 5 to 2, and the decorative glow dots removed from them
- Neon `shadow-[0_0_…]` glows, the two radial gradient blobs, and the gradient-filled headline word removed (the last also dropped `WebkitTextFillColor: transparent`, which made the word vanish in forced-colors mode)
- `OpenSource` moves off three identical cards to an asymmetric lead-plus-two; `UseCases` becomes a borderless two-column list; `HowItWorks` alternates its rows. Four of six sections previously used one identical template.
- Hero brought inside budget: 4 text elements, subtext 43 → 19 words, headline 76px → 56px with no `<br>` / `&nbsp;` hacks, and the curl block gained a working copy button
- Corner radii locked to three values, nested card borders un-nested
- Copy pass: em-dashes removed, CTA labels unified to one per intent, `acme` / `maya` placeholders and invented precision replaced, and the nav "Docs" link now points at the real docs site instead of an on-page anchor

## Also

- Centralises `REPO_URL`, `LICENSE_URL`, `AUTHOR_URL`, `DOCS_URL` and `STATUS_URL` into `src/lib/links.ts`. `REPO_URL` was declared twice and the license URL derived twice.
- Removes three hardcoded colours that bypassed the token system (`bg-[#0a0614]`, an inline `rgba()` gradient, and `priorityHex()`, which returns hardcoded violet from `@emitsignal/shared` and ignores the `--color-p*` tokens).

## Deliberately not changed

- **`hero-terminal.tsx` is untouched.** The div-built terminal is the most recognisable AI-design tell, but it is wanted as-is. Replacing it properly needs a real asset (an asciinema recording, a dashboard screenshot, or a live SSE demo topic).
- **The violet accent stays.** It is shared with the mobile app, the dashboard and the light theme.
- The page still has no real imagery, and `styles.css` still loads Geist through a render-blocking Google Fonts `@import` that hurts LCP. Both need assets vendored in.
- `--color-accent-dim` is unchanged, so surfaces outside the landing page still hover to the darker shade and retain the same latent contrast issue.

## Test plan

- `bunx tsc --noEmit` clean
- `bun run test` in `packages/emitsignal-website` — 10/10 passing
- `eslint` clean on every changed file
- `prettier --check` clean, so no `chore: Source Format` commit was needed
- Homepage rendered and links verified; nav checked at 375px

🤖 Generated with [Claude Code](https://claude.com/claude-code)