### PR TITLE
feat(webhooks): customizable link button label

### DIFF
--- a/packages/emitsignal-server/src/http/webhooks/__tests__/receive.spec.ts
+++ b/packages/emitsignal-server/src/http/webhooks/__tests__/receive.spec.ts
@@ -25,11 +25,15 @@ describe('POST /h/:slug link → view action', () => {
     const app = new Elysia().use(receiveWebhook);
 
     function withTemplateLink(link: string) {
+        withTemplate({ link, title: '{{event.name}}' });
+    }
+
+    function withTemplate(template: Record<string, string>) {
         prismaMock.webhook.findUnique.mockResolvedValue({
             id: 'wh-1',
             source: 'custom',
             status: 'active',
-            template: JSON.stringify({ link, title: '{{event.name}}' }),
+            template: JSON.stringify(template),
             topicName: 'deploys',
             userId: null,
         });
@@ -143,5 +147,46 @@ describe('POST /h/:slug link → view action', () => {
         expect(lastCall[1].actions).toEqual([
             { label: 'View', type: 'view', url: 'https://status.dev/run' },
         ]);
+    });
+
+    it('uses a templated link label as the button text', async () => {
+        withTemplate({ link: 'https://status.dev/run', linkLabel: 'Open {{event.name}}' });
+
+        const res = await app.handle(request({ event: { name: 'deploy' } }));
+
+        expect(res.status).toBe(200);
+        expect(storedActions()).toEqual([
+            { label: 'Open deploy', type: 'view', url: 'https://status.dev/run' },
+        ]);
+    });
+
+    it('falls back to View when the label template does not resolve', async () => {
+        withTemplate({ link: 'https://status.dev/run', linkLabel: '{{event.label}}' });
+
+        await app.handle(request({ event: { name: 'deploy' } }));
+
+        expect(storedActions()).toEqual([
+            { label: 'View', type: 'view', url: 'https://status.dev/run' },
+        ]);
+    });
+
+    it('collapses and caps a label the payload blew up', async () => {
+        withTemplate({ link: 'https://status.dev/run', linkLabel: '{{event.name}}' });
+
+        const res = await app.handle(request({ event: { name: `a\n${'b'.repeat(200)}` } }));
+
+        const [action] = storedActions() as [{ label: string }];
+
+        expect(res.status).toBe(200);
+        expect(action.label).toBe(`a ${'b'.repeat(38)}`);
+    });
+
+    it('ignores a label when the link itself is dropped', async () => {
+        withTemplate({ link: 'javascript:alert(1)', linkLabel: 'Open dashboard' });
+
+        const res = await app.handle(request({ event: { name: 'deploy' } }));
+
+        expect(res.status).toBe(200);
+        expect(storedActions()).toEqual([]);
     });
 });

--- a/packages/emitsignal-server/src/http/webhooks/receive.ts
+++ b/packages/emitsignal-server/src/http/webhooks/receive.ts
@@ -67,7 +67,7 @@ export const receiveWebhook = new Elysia().post(
         if (template) {
             const rendered = renderTemplate(template, payload);
 
-            actions = viewActionFor(rendered.link);
+            actions = viewActionFor(rendered.link, rendered.linkLabel);
             messageBody = rendered.body;
             priority = rendered.priority;
             tags = rendered.tags;
@@ -161,12 +161,14 @@ export const receiveWebhook = new Elysia().post(
 // is untrusted: run it through the same validator `POST /topic/:name` uses so
 // only http(s) URLs are ever stored. Unlike publish, a link we cannot use never
 // fails the delivery — the notification still goes out, just without a button.
-function viewActionFor(link: string): Action[] {
+function viewActionFor(link: string, label: string): Action[] {
     if (!link) {
         return [];
     }
 
-    const validation = validateActions([{ type: 'view', url: link }]);
+    const validation = validateActions([
+        label ? { label, type: 'view', url: link } : { type: 'view', url: link },
+    ]);
 
     return 'ok' in validation ? validation.actions : [];
 }

--- a/packages/emitsignal-shared/src/api.ts
+++ b/packages/emitsignal-shared/src/api.ts
@@ -140,6 +140,7 @@ export interface WebhookDelivery {
 export interface WebhookTemplate {
     body?: string;
     link?: string;
+    linkLabel?: string;
     priority?: string;
     tags?: string;
     title?: string;

--- a/packages/emitsignal-shared/src/webhook-template.test.ts
+++ b/packages/emitsignal-shared/src/webhook-template.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'bun:test';
 
-import { applyTemplate, renderTemplate } from './webhook-template.ts';
+import {
+    applyTemplate,
+    MAX_LINK_LABEL_LENGTH,
+    normalizeLinkLabel,
+    renderTemplate,
+} from './webhook-template.ts';
 
 const payload = {
     heartbeat: {
@@ -83,6 +88,60 @@ describe('renderTemplate link', () => {
     test('trims surrounding whitespace', () => {
         expect(renderTemplate({ link: '  https://status.dev  ' }, payload).link).toBe(
             'https://status.dev',
+        );
+    });
+});
+
+describe('renderTemplate linkLabel', () => {
+    test('resolves a label template against the payload', () => {
+        const rendered = renderTemplate(
+            { link: 'https://status.dev', linkLabel: 'Open {{monitor.name}}' },
+            payload,
+        );
+        expect(rendered.linkLabel).toBe('Open EmitSignal');
+    });
+
+    test('returns an empty label when the template has none', () => {
+        expect(renderTemplate({ link: 'https://status.dev' }, payload).linkLabel).toBe('');
+    });
+
+    test('returns an empty label when the template path does not resolve', () => {
+        expect(
+            renderTemplate({ link: 'https://status.dev', linkLabel: '{{monitor.nope}}' }, payload)
+                .linkLabel,
+        ).toBe('');
+    });
+
+    test('ignores the label when there is no link to attach it to', () => {
+        expect(renderTemplate({ linkLabel: 'Open dashboard' }, payload).linkLabel).toBe('');
+    });
+
+    test('collapses whitespace injected by the payload', () => {
+        expect(
+            renderTemplate(
+                { link: 'https://status.dev', linkLabel: '  Open\n\t{{monitor.name}}  ' },
+                payload,
+            ).linkLabel,
+        ).toBe('Open EmitSignal');
+    });
+
+    test('caps an over-long label at MAX_LINK_LABEL_LENGTH', () => {
+        const rendered = renderTemplate(
+            { link: 'https://status.dev', linkLabel: 'x'.repeat(200) },
+            payload,
+        );
+        expect(rendered.linkLabel).toBe('x'.repeat(MAX_LINK_LABEL_LENGTH));
+    });
+});
+
+describe('normalizeLinkLabel', () => {
+    test('returns an empty string for whitespace-only input', () => {
+        expect(normalizeLinkLabel('   \n  ')).toBe('');
+    });
+
+    test('does not leave a trailing space when the cap lands mid-word', () => {
+        expect(normalizeLinkLabel(`${'x'.repeat(MAX_LINK_LABEL_LENGTH - 1)} tail`)).toBe(
+            'x'.repeat(MAX_LINK_LABEL_LENGTH - 1),
         );
     });
 });

--- a/packages/emitsignal-shared/src/webhook-template.ts
+++ b/packages/emitsignal-shared/src/webhook-template.ts
@@ -1,9 +1,16 @@
 import type { WebhookTemplate } from './api.ts';
 
+// Labels interpolate payload values on a public endpoint, so the text is untrusted.
+export const MAX_LINK_LABEL_LENGTH = 40;
+
 export function applyTemplate(input: string, payload: unknown, defaultValue = ''): string {
     return input.replace(/\{\{\s*([^}]+)\s*\}\}/g, (_, path: string) =>
         formatValue(resolvePath(payload, path.trim().split('.')), defaultValue),
     );
+}
+
+export function normalizeLinkLabel(label: string): string {
+    return label.replace(/\s+/g, ' ').trim().slice(0, MAX_LINK_LABEL_LENGTH).trim();
 }
 
 export function parseTemplate(raw: null | string): null | WebhookTemplate {
@@ -24,6 +31,7 @@ export function renderTemplate(
 ): {
     body: string;
     link: string;
+    linkLabel: string;
     priority: number;
     tags: string[];
     title: string;
@@ -33,6 +41,10 @@ export function renderTemplate(
     // An unset link, or one whose template path does not resolve, renders to ''.
     // Callers treat that as "no action" — a link is never required for delivery.
     const link = template.link ? applyTemplate(template.link, payload).trim() : '';
+    const linkLabel =
+        link && template.linkLabel
+            ? normalizeLinkLabel(applyTemplate(template.linkLabel, payload))
+            : '';
     const rawTags = template.tags ? applyTemplate(template.tags, payload) : '';
     const tags = rawTags
         ? rawTags
@@ -43,7 +55,7 @@ export function renderTemplate(
 
     const priority = Math.min(5, Math.max(1, parseInt(template.priority ?? '3', 10))) || 3;
 
-    return { body, link, priority, tags, title };
+    return { body, link, linkLabel, priority, tags, title };
 }
 
 function formatValue(value: unknown, emptyValue: string): string {

--- a/packages/emitsignal-website/src/components/app/webhooks/deliveries-log.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/deliveries-log.tsx
@@ -1,3 +1,4 @@
+import { applyTemplate as applyTemplateExact } from '@emitsignal/shared/webhook-template';
 import { useNavigate } from '@tanstack/react-router';
 import { Copy, Edit, RefreshCw } from 'lucide-react';
 import { useState } from 'react';
@@ -83,6 +84,7 @@ export function DeliveriesLog({ webhookId }: { webhookId: string }) {
                 body: applyTemplate(template.body ?? '', delivery.payload),
                 channel: delivery.channel,
                 link: applyTemplate(template.link ?? '', delivery.payload).trim(),
+                linkLabel: applyTemplateExact(template.linkLabel ?? '', delivery.payload),
                 priority: Number(template.priority ?? '3'),
                 tags: applyTemplate(template.tags ?? '', delivery.payload),
                 title: applyTemplate(template.title ?? '', delivery.payload),

--- a/packages/emitsignal-website/src/components/app/webhooks/notif-preview.test.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/notif-preview.test.tsx
@@ -3,9 +3,16 @@ import { describe, expect, test } from 'vitest';
 
 import { NotifPreview } from './notif-preview';
 
-function renderPreview(link?: string) {
+function renderPreview(link?: string, linkLabel?: string) {
     return render(
-        <NotifPreview body="body" channel="deploys" link={link} priority={3} title="title" />,
+        <NotifPreview
+            body="body"
+            channel="deploys"
+            link={link}
+            linkLabel={linkLabel}
+            priority={3}
+            title="title"
+        />,
     );
 }
 
@@ -42,5 +49,32 @@ describe('NotifPreview link', () => {
 
         expect(screen.queryByText('View')).toBeNull();
         expect(screen.queryByText('View · dropped')).toBeNull();
+    });
+});
+
+describe('NotifPreview link label', () => {
+    test('renders a custom label on the button', () => {
+        renderPreview('https://status.dev/run/42', 'Open run');
+
+        expect(screen.getByText('Open run')).toBeDefined();
+        expect(screen.queryByText('View')).toBeNull();
+    });
+
+    test('falls back to View for an empty label', () => {
+        renderPreview('https://status.dev/run/42', '   ');
+
+        expect(screen.getByText('View')).toBeDefined();
+    });
+
+    test('renders the capped label the server will deliver', () => {
+        renderPreview('https://status.dev/run/42', 'x'.repeat(60));
+
+        expect(screen.getByText('x'.repeat(40))).toBeDefined();
+    });
+
+    test('labels the dropped state with the custom label too', () => {
+        renderPreview('/repos/acme/api', 'Open repo');
+
+        expect(screen.getByText('Open repo · dropped')).toBeDefined();
     });
 });

--- a/packages/emitsignal-website/src/components/app/webhooks/notif-preview.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/notif-preview.tsx
@@ -1,3 +1,5 @@
+import { normalizeLinkLabel } from '@emitsignal/shared/webhook-template';
+
 import { Avatar } from '#/components/ui/avatar';
 import { priorityHex } from '#/lib/priority';
 
@@ -6,6 +8,7 @@ interface NotifPreviewProps {
     channel: string;
     compact?: boolean;
     link?: string;
+    linkLabel?: string;
     priority: number | string;
     tags?: string | string[];
     title: string;
@@ -16,6 +19,7 @@ export function NotifPreview({
     channel,
     compact = false,
     link = '',
+    linkLabel = '',
     priority,
     tags = [],
     title,
@@ -35,6 +39,7 @@ export function NotifPreview({
     // so a template that renders an unusable link is visible before it ships.
     const deliverableLink = isDeliverableLink(link);
     const droppedLink = link !== '' && !deliverableLink;
+    const buttonLabel = normalizeLinkLabel(linkLabel) || 'View';
 
     return (
         <div
@@ -79,7 +84,7 @@ export function NotifPreview({
                                 className="inline-block rounded-md border border-line bg-elev px-3.5 py-2 text-[12.5px] text-fg"
                                 title={link}
                             >
-                                View
+                                {buttonLabel}
                             </span>
                         </div>
                     )}
@@ -89,7 +94,7 @@ export function NotifPreview({
                                 className="inline-block rounded-md border border-dashed border-line bg-elev px-3.5 py-2 text-[12.5px] text-dim"
                                 title="Not an http(s) URL — this link is dropped and no button is delivered."
                             >
-                                View · dropped
+                                {buttonLabel} · dropped
                             </span>
                         </div>
                     )}

--- a/packages/emitsignal-website/src/components/app/webhooks/webhook-create.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/webhook-create.tsx
@@ -1,3 +1,4 @@
+import { applyTemplate as applyTemplateExact } from '@emitsignal/shared/webhook-template';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { ChevronDown, Copy } from 'lucide-react';
@@ -36,6 +37,7 @@ const SOURCE_DATA: Record<
         template: {
             body: '{{pusher.name}} · {{head_commit.message}}',
             link: '{{head_commit.url}}',
+            linkLabel: 'View commit',
             priority: '3',
             tags: 'git, push, {{repository.name}}',
             title: 'Push to {{repository.full_name}}',
@@ -102,7 +104,14 @@ const GLYPH: Record<Source, string> = {
     vercel: 'VC',
 };
 
-const EMPTY_TEMPLATE: WebhookTemplate = { body: '', link: '', priority: '3', tags: '', title: '' };
+const EMPTY_TEMPLATE: WebhookTemplate = {
+    body: '',
+    link: '',
+    linkLabel: '',
+    priority: '3',
+    tags: '',
+    title: '',
+};
 
 // ── Props ─────────────────────────────────────────────────────────────────────
 
@@ -169,6 +178,7 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
         body: applyTemplate(templateFields.body ?? '', activePayload),
         channel: topicName || `${source}/channel`,
         link: applyTemplate(templateFields.link ?? '', activePayload).trim(),
+        linkLabel: applyTemplateExact(templateFields.linkLabel ?? '', activePayload),
         priority: Number(templateFields.priority ?? '3'),
         tags: applyTemplate(templateFields.tags ?? '', activePayload),
         title: applyTemplate(templateFields.title ?? '', activePayload),
@@ -488,6 +498,25 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
                                 />
                             </div>
                         ))}
+
+                        {(templateFields.link ?? '') !== '' && (
+                            <div className="mb-2.5">
+                                <div className="mb-1 flex items-baseline gap-2 font-mono text-[10px] uppercase tracking-[1px] text-dim">
+                                    Button label
+                                    <span className="normal-case tracking-normal text-faint">
+                                        optional · defaults to “View”
+                                    </span>
+                                </div>
+                                <input
+                                    className="w-full rounded-lg border border-line bg-elev px-3 py-2 font-mono text-[12.5px] text-fg outline-none placeholder:text-faint focus:border-accent/50"
+                                    onChange={(e) =>
+                                        handleTemplateFieldChange('linkLabel', e.target.value)
+                                    }
+                                    placeholder="View"
+                                    value={templateFields.linkLabel ?? ''}
+                                />
+                            </div>
+                        )}
 
                         <div className="mb-2.5">
                             <div className="mb-1 font-mono text-[10px] uppercase tracking-[1px] text-dim">

--- a/packages/emitsignal-website/src/routeTree.gen.ts
+++ b/packages/emitsignal-website/src/routeTree.gen.ts
@@ -9,92 +9,42 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as VerifyRouteImport } from './routes/verify'
-import { Route as TermsRouteImport } from './routes/terms'
-import { Route as SignInRouteImport } from './routes/sign-in'
-import { Route as PrivacyRouteImport } from './routes/privacy'
-import { Route as OnboardingRouteImport } from './routes/onboarding'
-import { Route as MobileRouteImport } from './routes/mobile'
-import { Route as DashboardRouteImport } from './routes/dashboard'
-import { Route as CodeOfConductRouteImport } from './routes/code-of-conduct'
-import { Route as ChangelogRouteImport } from './routes/changelog'
-import { Route as BlogRouteImport } from './routes/blog'
-import { Route as AppRouteImport } from './routes/app'
-import { Route as ApiRouteImport } from './routes/api'
 import { Route as IndexRouteImport } from './routes/index'
-import { Route as BlogIndexRouteImport } from './routes/blog/index'
-import { Route as AppIndexRouteImport } from './routes/app/index'
-import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
-import { Route as AppSettingsRouteImport } from './routes/app/settings'
-import { Route as AppPublishRouteImport } from './routes/app/publish'
-import { Route as AppKeysRouteImport } from './routes/app/keys'
-import { Route as AppChannelsRouteImport } from './routes/app/channels'
+import { Route as ApiRouteImport } from './routes/api'
+import { Route as AppRouteImport } from './routes/app'
+import { Route as BlogRouteImport } from './routes/blog'
+import { Route as ChangelogRouteImport } from './routes/changelog'
+import { Route as CodeOfConductRouteImport } from './routes/code-of-conduct'
+import { Route as DashboardRouteImport } from './routes/dashboard'
+import { Route as MobileRouteImport } from './routes/mobile'
+import { Route as OnboardingRouteImport } from './routes/onboarding'
+import { Route as PrivacyRouteImport } from './routes/privacy'
+import { Route as SignInRouteImport } from './routes/sign-in'
+import { Route as TermsRouteImport } from './routes/terms'
+import { Route as VerifyRouteImport } from './routes/verify'
 import { Route as ApiOgRouteImport } from './routes/api/og'
-import { Route as AppWebhooksIndexRouteImport } from './routes/app/webhooks/index'
-import { Route as AppSettingsIndexRouteImport } from './routes/app/settings/index'
+import { Route as AppIndexRouteImport } from './routes/app/index'
+import { Route as AppChannelsRouteImport } from './routes/app/channels'
+import { Route as AppKeysRouteImport } from './routes/app/keys'
+import { Route as AppPublishRouteImport } from './routes/app/publish'
+import { Route as AppSettingsRouteImport } from './routes/app/settings'
+import { Route as BlogIndexRouteImport } from './routes/blog/index'
+import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
 import { Route as AppInboxIndexRouteImport } from './routes/app/inbox/index'
-import { Route as AppWebhooksNewRouteImport } from './routes/app/webhooks/new'
-import { Route as AppWebhooksWebhookIdRouteImport } from './routes/app/webhooks/$webhookId'
-import { Route as AppSettingsProfileRouteImport } from './routes/app/settings/profile'
-import { Route as AppSettingsBillingRouteImport } from './routes/app/settings/billing'
-import { Route as AppSettingsAdvancedRouteImport } from './routes/app/settings/advanced'
-import { Route as AppSettingsAccountRouteImport } from './routes/app/settings/account'
 import { Route as AppInboxMessageIdRouteImport } from './routes/app/inbox/$messageId'
+import { Route as AppSettingsIndexRouteImport } from './routes/app/settings/index'
+import { Route as AppSettingsAccountRouteImport } from './routes/app/settings/account'
+import { Route as AppSettingsAdvancedRouteImport } from './routes/app/settings/advanced'
+import { Route as AppSettingsBillingRouteImport } from './routes/app/settings/billing'
+import { Route as AppSettingsProfileRouteImport } from './routes/app/settings/profile'
+import { Route as AppWebhooksIndexRouteImport } from './routes/app/webhooks/index'
+import { Route as AppWebhooksWebhookIdRouteImport } from './routes/app/webhooks/$webhookId'
+import { Route as AppWebhooksNewRouteImport } from './routes/app/webhooks/new'
 import { Route as AppWebhooksWebhookIdEditRouteImport } from './routes/app/webhooks/$webhookId.edit'
 
-const VerifyRoute = VerifyRouteImport.update({
-  id: '/verify',
-  path: '/verify',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const TermsRoute = TermsRouteImport.update({
-  id: '/terms',
-  path: '/terms',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const SignInRoute = SignInRouteImport.update({
-  id: '/sign-in',
-  path: '/sign-in',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const PrivacyRoute = PrivacyRouteImport.update({
-  id: '/privacy',
-  path: '/privacy',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const OnboardingRoute = OnboardingRouteImport.update({
-  id: '/onboarding',
-  path: '/onboarding',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const MobileRoute = MobileRouteImport.update({
-  id: '/mobile',
-  path: '/mobile',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const DashboardRoute = DashboardRouteImport.update({
-  id: '/dashboard',
-  path: '/dashboard',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const CodeOfConductRoute = CodeOfConductRouteImport.update({
-  id: '/code-of-conduct',
-  path: '/code-of-conduct',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ChangelogRoute = ChangelogRouteImport.update({
-  id: '/changelog',
-  path: '/changelog',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const BlogRoute = BlogRouteImport.update({
-  id: '/blog',
-  path: '/blog',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const AppRoute = AppRouteImport.update({
-  id: '/app',
-  path: '/app',
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiRoute = ApiRouteImport.update({
@@ -102,39 +52,69 @@ const ApiRoute = ApiRouteImport.update({
   path: '/api',
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+const AppRoute = AppRouteImport.update({
+  id: '/app',
+  path: '/app',
   getParentRoute: () => rootRouteImport,
 } as any)
-const BlogIndexRoute = BlogIndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => BlogRoute,
+const BlogRoute = BlogRouteImport.update({
+  id: '/blog',
+  path: '/blog',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ChangelogRoute = ChangelogRouteImport.update({
+  id: '/changelog',
+  path: '/changelog',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CodeOfConductRoute = CodeOfConductRouteImport.update({
+  id: '/code-of-conduct',
+  path: '/code-of-conduct',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DashboardRoute = DashboardRouteImport.update({
+  id: '/dashboard',
+  path: '/dashboard',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MobileRoute = MobileRouteImport.update({
+  id: '/mobile',
+  path: '/mobile',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OnboardingRoute = OnboardingRouteImport.update({
+  id: '/onboarding',
+  path: '/onboarding',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PrivacyRoute = PrivacyRouteImport.update({
+  id: '/privacy',
+  path: '/privacy',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SignInRoute = SignInRouteImport.update({
+  id: '/sign-in',
+  path: '/sign-in',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const TermsRoute = TermsRouteImport.update({
+  id: '/terms',
+  path: '/terms',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const VerifyRoute = VerifyRouteImport.update({
+  id: '/verify',
+  path: '/verify',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiOgRoute = ApiOgRouteImport.update({
+  id: '/og',
+  path: '/og',
+  getParentRoute: () => ApiRoute,
 } as any)
 const AppIndexRoute = AppIndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => AppRoute,
-} as any)
-const BlogSlugRoute = BlogSlugRouteImport.update({
-  id: '/$slug',
-  path: '/$slug',
-  getParentRoute: () => BlogRoute,
-} as any)
-const AppSettingsRoute = AppSettingsRouteImport.update({
-  id: '/settings',
-  path: '/settings',
-  getParentRoute: () => AppRoute,
-} as any)
-const AppPublishRoute = AppPublishRouteImport.update({
-  id: '/publish',
-  path: '/publish',
-  getParentRoute: () => AppRoute,
-} as any)
-const AppKeysRoute = AppKeysRouteImport.update({
-  id: '/keys',
-  path: '/keys',
   getParentRoute: () => AppRoute,
 } as any)
 const AppChannelsRoute = AppChannelsRouteImport.update({
@@ -142,14 +122,39 @@ const AppChannelsRoute = AppChannelsRouteImport.update({
   path: '/channels',
   getParentRoute: () => AppRoute,
 } as any)
-const ApiOgRoute = ApiOgRouteImport.update({
-  id: '/og',
-  path: '/og',
-  getParentRoute: () => ApiRoute,
+const AppKeysRoute = AppKeysRouteImport.update({
+  id: '/keys',
+  path: '/keys',
+  getParentRoute: () => AppRoute,
 } as any)
-const AppWebhooksIndexRoute = AppWebhooksIndexRouteImport.update({
-  id: '/webhooks/',
-  path: '/webhooks/',
+const AppPublishRoute = AppPublishRouteImport.update({
+  id: '/publish',
+  path: '/publish',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppSettingsRoute = AppSettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => AppRoute,
+} as any)
+const BlogIndexRoute = BlogIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => BlogRoute,
+} as any)
+const BlogSlugRoute = BlogSlugRouteImport.update({
+  id: '/$slug',
+  path: '/$slug',
+  getParentRoute: () => BlogRoute,
+} as any)
+const AppInboxIndexRoute = AppInboxIndexRouteImport.update({
+  id: '/inbox/',
+  path: '/inbox/',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppInboxMessageIdRoute = AppInboxMessageIdRouteImport.update({
+  id: '/inbox/$messageId',
+  path: '/inbox/$messageId',
   getParentRoute: () => AppRoute,
 } as any)
 const AppSettingsIndexRoute = AppSettingsIndexRouteImport.update({
@@ -157,29 +162,9 @@ const AppSettingsIndexRoute = AppSettingsIndexRouteImport.update({
   path: '/',
   getParentRoute: () => AppSettingsRoute,
 } as any)
-const AppInboxIndexRoute = AppInboxIndexRouteImport.update({
-  id: '/inbox/',
-  path: '/inbox/',
-  getParentRoute: () => AppRoute,
-} as any)
-const AppWebhooksNewRoute = AppWebhooksNewRouteImport.update({
-  id: '/webhooks/new',
-  path: '/webhooks/new',
-  getParentRoute: () => AppRoute,
-} as any)
-const AppWebhooksWebhookIdRoute = AppWebhooksWebhookIdRouteImport.update({
-  id: '/webhooks/$webhookId',
-  path: '/webhooks/$webhookId',
-  getParentRoute: () => AppRoute,
-} as any)
-const AppSettingsProfileRoute = AppSettingsProfileRouteImport.update({
-  id: '/profile',
-  path: '/profile',
-  getParentRoute: () => AppSettingsRoute,
-} as any)
-const AppSettingsBillingRoute = AppSettingsBillingRouteImport.update({
-  id: '/billing',
-  path: '/billing',
+const AppSettingsAccountRoute = AppSettingsAccountRouteImport.update({
+  id: '/account',
+  path: '/account',
   getParentRoute: () => AppSettingsRoute,
 } as any)
 const AppSettingsAdvancedRoute = AppSettingsAdvancedRouteImport.update({
@@ -187,14 +172,29 @@ const AppSettingsAdvancedRoute = AppSettingsAdvancedRouteImport.update({
   path: '/advanced',
   getParentRoute: () => AppSettingsRoute,
 } as any)
-const AppSettingsAccountRoute = AppSettingsAccountRouteImport.update({
-  id: '/account',
-  path: '/account',
+const AppSettingsBillingRoute = AppSettingsBillingRouteImport.update({
+  id: '/billing',
+  path: '/billing',
   getParentRoute: () => AppSettingsRoute,
 } as any)
-const AppInboxMessageIdRoute = AppInboxMessageIdRouteImport.update({
-  id: '/inbox/$messageId',
-  path: '/inbox/$messageId',
+const AppSettingsProfileRoute = AppSettingsProfileRouteImport.update({
+  id: '/profile',
+  path: '/profile',
+  getParentRoute: () => AppSettingsRoute,
+} as any)
+const AppWebhooksIndexRoute = AppWebhooksIndexRouteImport.update({
+  id: '/webhooks/',
+  path: '/webhooks/',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppWebhooksWebhookIdRoute = AppWebhooksWebhookIdRouteImport.update({
+  id: '/webhooks/$webhookId',
+  path: '/webhooks/$webhookId',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppWebhooksNewRoute = AppWebhooksNewRouteImport.update({
+  id: '/webhooks/new',
+  path: '/webhooks/new',
   getParentRoute: () => AppRoute,
 } as any)
 const AppWebhooksWebhookIdEditRoute =
@@ -424,81 +424,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/verify': {
-      id: '/verify'
-      path: '/verify'
-      fullPath: '/verify'
-      preLoaderRoute: typeof VerifyRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/terms': {
-      id: '/terms'
-      path: '/terms'
-      fullPath: '/terms'
-      preLoaderRoute: typeof TermsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/sign-in': {
-      id: '/sign-in'
-      path: '/sign-in'
-      fullPath: '/sign-in'
-      preLoaderRoute: typeof SignInRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/privacy': {
-      id: '/privacy'
-      path: '/privacy'
-      fullPath: '/privacy'
-      preLoaderRoute: typeof PrivacyRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/onboarding': {
-      id: '/onboarding'
-      path: '/onboarding'
-      fullPath: '/onboarding'
-      preLoaderRoute: typeof OnboardingRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/mobile': {
-      id: '/mobile'
-      path: '/mobile'
-      fullPath: '/mobile'
-      preLoaderRoute: typeof MobileRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/dashboard': {
-      id: '/dashboard'
-      path: '/dashboard'
-      fullPath: '/dashboard'
-      preLoaderRoute: typeof DashboardRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/code-of-conduct': {
-      id: '/code-of-conduct'
-      path: '/code-of-conduct'
-      fullPath: '/code-of-conduct'
-      preLoaderRoute: typeof CodeOfConductRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/changelog': {
-      id: '/changelog'
-      path: '/changelog'
-      fullPath: '/changelog'
-      preLoaderRoute: typeof ChangelogRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/blog': {
-      id: '/blog'
-      path: '/blog'
-      fullPath: '/blog'
-      preLoaderRoute: typeof BlogRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/app': {
-      id: '/app'
-      path: '/app'
-      fullPath: '/app'
-      preLoaderRoute: typeof AppRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api': {
@@ -508,53 +438,95 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
+    '/app': {
+      id: '/app'
+      path: '/app'
+      fullPath: '/app'
+      preLoaderRoute: typeof AppRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/blog/': {
-      id: '/blog/'
-      path: '/'
-      fullPath: '/blog/'
-      preLoaderRoute: typeof BlogIndexRouteImport
-      parentRoute: typeof BlogRoute
+    '/blog': {
+      id: '/blog'
+      path: '/blog'
+      fullPath: '/blog'
+      preLoaderRoute: typeof BlogRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/changelog': {
+      id: '/changelog'
+      path: '/changelog'
+      fullPath: '/changelog'
+      preLoaderRoute: typeof ChangelogRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/code-of-conduct': {
+      id: '/code-of-conduct'
+      path: '/code-of-conduct'
+      fullPath: '/code-of-conduct'
+      preLoaderRoute: typeof CodeOfConductRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/dashboard': {
+      id: '/dashboard'
+      path: '/dashboard'
+      fullPath: '/dashboard'
+      preLoaderRoute: typeof DashboardRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/mobile': {
+      id: '/mobile'
+      path: '/mobile'
+      fullPath: '/mobile'
+      preLoaderRoute: typeof MobileRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/onboarding': {
+      id: '/onboarding'
+      path: '/onboarding'
+      fullPath: '/onboarding'
+      preLoaderRoute: typeof OnboardingRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/privacy': {
+      id: '/privacy'
+      path: '/privacy'
+      fullPath: '/privacy'
+      preLoaderRoute: typeof PrivacyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/sign-in': {
+      id: '/sign-in'
+      path: '/sign-in'
+      fullPath: '/sign-in'
+      preLoaderRoute: typeof SignInRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/terms': {
+      id: '/terms'
+      path: '/terms'
+      fullPath: '/terms'
+      preLoaderRoute: typeof TermsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/verify': {
+      id: '/verify'
+      path: '/verify'
+      fullPath: '/verify'
+      preLoaderRoute: typeof VerifyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/og': {
+      id: '/api/og'
+      path: '/og'
+      fullPath: '/api/og'
+      preLoaderRoute: typeof ApiOgRouteImport
+      parentRoute: typeof ApiRoute
     }
     '/app/': {
       id: '/app/'
       path: '/'
       fullPath: '/app/'
       preLoaderRoute: typeof AppIndexRouteImport
-      parentRoute: typeof AppRoute
-    }
-    '/blog/$slug': {
-      id: '/blog/$slug'
-      path: '/$slug'
-      fullPath: '/blog/$slug'
-      preLoaderRoute: typeof BlogSlugRouteImport
-      parentRoute: typeof BlogRoute
-    }
-    '/app/settings': {
-      id: '/app/settings'
-      path: '/settings'
-      fullPath: '/app/settings'
-      preLoaderRoute: typeof AppSettingsRouteImport
-      parentRoute: typeof AppRoute
-    }
-    '/app/publish': {
-      id: '/app/publish'
-      path: '/publish'
-      fullPath: '/app/publish'
-      preLoaderRoute: typeof AppPublishRouteImport
-      parentRoute: typeof AppRoute
-    }
-    '/app/keys': {
-      id: '/app/keys'
-      path: '/keys'
-      fullPath: '/app/keys'
-      preLoaderRoute: typeof AppKeysRouteImport
       parentRoute: typeof AppRoute
     }
     '/app/channels': {
@@ -564,18 +536,53 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppChannelsRouteImport
       parentRoute: typeof AppRoute
     }
-    '/api/og': {
-      id: '/api/og'
-      path: '/og'
-      fullPath: '/api/og'
-      preLoaderRoute: typeof ApiOgRouteImport
-      parentRoute: typeof ApiRoute
+    '/app/keys': {
+      id: '/app/keys'
+      path: '/keys'
+      fullPath: '/app/keys'
+      preLoaderRoute: typeof AppKeysRouteImport
+      parentRoute: typeof AppRoute
     }
-    '/app/webhooks/': {
-      id: '/app/webhooks/'
-      path: '/webhooks'
-      fullPath: '/app/webhooks/'
-      preLoaderRoute: typeof AppWebhooksIndexRouteImport
+    '/app/publish': {
+      id: '/app/publish'
+      path: '/publish'
+      fullPath: '/app/publish'
+      preLoaderRoute: typeof AppPublishRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/app/settings': {
+      id: '/app/settings'
+      path: '/settings'
+      fullPath: '/app/settings'
+      preLoaderRoute: typeof AppSettingsRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/blog/': {
+      id: '/blog/'
+      path: '/'
+      fullPath: '/blog/'
+      preLoaderRoute: typeof BlogIndexRouteImport
+      parentRoute: typeof BlogRoute
+    }
+    '/blog/$slug': {
+      id: '/blog/$slug'
+      path: '/$slug'
+      fullPath: '/blog/$slug'
+      preLoaderRoute: typeof BlogSlugRouteImport
+      parentRoute: typeof BlogRoute
+    }
+    '/app/inbox/': {
+      id: '/app/inbox/'
+      path: '/inbox'
+      fullPath: '/app/inbox/'
+      preLoaderRoute: typeof AppInboxIndexRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/app/inbox/$messageId': {
+      id: '/app/inbox/$messageId'
+      path: '/inbox/$messageId'
+      fullPath: '/app/inbox/$messageId'
+      preLoaderRoute: typeof AppInboxMessageIdRouteImport
       parentRoute: typeof AppRoute
     }
     '/app/settings/': {
@@ -585,39 +592,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppSettingsIndexRouteImport
       parentRoute: typeof AppSettingsRoute
     }
-    '/app/inbox/': {
-      id: '/app/inbox/'
-      path: '/inbox'
-      fullPath: '/app/inbox/'
-      preLoaderRoute: typeof AppInboxIndexRouteImport
-      parentRoute: typeof AppRoute
-    }
-    '/app/webhooks/new': {
-      id: '/app/webhooks/new'
-      path: '/webhooks/new'
-      fullPath: '/app/webhooks/new'
-      preLoaderRoute: typeof AppWebhooksNewRouteImport
-      parentRoute: typeof AppRoute
-    }
-    '/app/webhooks/$webhookId': {
-      id: '/app/webhooks/$webhookId'
-      path: '/webhooks/$webhookId'
-      fullPath: '/app/webhooks/$webhookId'
-      preLoaderRoute: typeof AppWebhooksWebhookIdRouteImport
-      parentRoute: typeof AppRoute
-    }
-    '/app/settings/profile': {
-      id: '/app/settings/profile'
-      path: '/profile'
-      fullPath: '/app/settings/profile'
-      preLoaderRoute: typeof AppSettingsProfileRouteImport
-      parentRoute: typeof AppSettingsRoute
-    }
-    '/app/settings/billing': {
-      id: '/app/settings/billing'
-      path: '/billing'
-      fullPath: '/app/settings/billing'
-      preLoaderRoute: typeof AppSettingsBillingRouteImport
+    '/app/settings/account': {
+      id: '/app/settings/account'
+      path: '/account'
+      fullPath: '/app/settings/account'
+      preLoaderRoute: typeof AppSettingsAccountRouteImport
       parentRoute: typeof AppSettingsRoute
     }
     '/app/settings/advanced': {
@@ -627,18 +606,39 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppSettingsAdvancedRouteImport
       parentRoute: typeof AppSettingsRoute
     }
-    '/app/settings/account': {
-      id: '/app/settings/account'
-      path: '/account'
-      fullPath: '/app/settings/account'
-      preLoaderRoute: typeof AppSettingsAccountRouteImport
+    '/app/settings/billing': {
+      id: '/app/settings/billing'
+      path: '/billing'
+      fullPath: '/app/settings/billing'
+      preLoaderRoute: typeof AppSettingsBillingRouteImport
       parentRoute: typeof AppSettingsRoute
     }
-    '/app/inbox/$messageId': {
-      id: '/app/inbox/$messageId'
-      path: '/inbox/$messageId'
-      fullPath: '/app/inbox/$messageId'
-      preLoaderRoute: typeof AppInboxMessageIdRouteImport
+    '/app/settings/profile': {
+      id: '/app/settings/profile'
+      path: '/profile'
+      fullPath: '/app/settings/profile'
+      preLoaderRoute: typeof AppSettingsProfileRouteImport
+      parentRoute: typeof AppSettingsRoute
+    }
+    '/app/webhooks/': {
+      id: '/app/webhooks/'
+      path: '/webhooks'
+      fullPath: '/app/webhooks/'
+      preLoaderRoute: typeof AppWebhooksIndexRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/app/webhooks/$webhookId': {
+      id: '/app/webhooks/$webhookId'
+      path: '/webhooks/$webhookId'
+      fullPath: '/app/webhooks/$webhookId'
+      preLoaderRoute: typeof AppWebhooksWebhookIdRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/app/webhooks/new': {
+      id: '/app/webhooks/new'
+      path: '/webhooks/new'
+      fullPath: '/app/webhooks/new'
+      preLoaderRoute: typeof AppWebhooksNewRouteImport
       parentRoute: typeof AppRoute
     }
     '/app/webhooks/$webhookId/edit': {


### PR DESCRIPTION
Follow-up to #18. The webhook `link` always delivered a button labelled **View**; the template can now name it.

## What changed

**Delivery** — `WebhookTemplate` gains `linkLabel`. `renderTemplate()` renders it through the same template engine as the other fields, and `receiveWebhook` attaches it to the `view` action. An unset label, one whose path does not resolve, or a whitespace-only one is left off so `validateActions` applies its existing `View` default — behaviour for every template saved before this change is unchanged.

**Untrusted input** — the label interpolates payload values, and `/h/:slug` is public, so a label is not free text from a trusted source. `normalizeLinkLabel()` collapses whitespace (a payload can inject newlines into a one-line button) and caps at 40 characters. A label attached to a link the server drops goes nowhere, since the whole action is dropped.

**Builder** — the *Button label* field appears once a link is set, since without a link there is no button to name. The GitHub sample template now ships `View commit` to make the field discoverable.

**Preview** — the create page and delivery log both render the delivered label, normalized through the same shared helper the server uses, including in the `· dropped` state. Deliberately not a second implementation: the previous PR nearly shipped a preview that promised a button the server would drop, and the same trap applies to label text.

## Verification at `eb92cc9`

- `emitsignal-shared`: 21 pass / 0 fail
- `emitsignal-server`: 375 pass / 0 fail (47 files)
- `emitsignal-website`: 14 pass / 0 fail
- `bun lint` and `bun format:check` clean

New coverage: templated label, unresolved label falls back to `View`, payload-injected newlines/overlong label collapsed and capped, label ignored when the link is dropped, label ignored with no link at all, plus four preview tests including the capped rendering.

`tsc --noEmit` on the server still reports the 4 pre-existing errors in `subscriptions/__tests__/update.spec.ts` — present on `origin/main`, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)