### PR TITLE
feat(mobile): push-driven widget updates via a notification service extension

### DIFF
--- a/packages/emitsignal-mobile/hooks/use-foreground-notifications.ts
+++ b/packages/emitsignal-mobile/hooks/use-foreground-notifications.ts
@@ -6,6 +6,7 @@ import { Platform } from 'react-native';
 import { useDevice } from '@/ctx/device';
 import { api } from '@/lib/api';
 import { openExternalUrl } from '@/lib/open-external';
+import { requestWidgetSync } from '@/lib/widget-snapshot';
 
 Notifications.setNotificationHandler({
     handleNotification: async () => ({
@@ -43,6 +44,11 @@ export function useForegroundNotifications() {
                 if (__DEV__) {
                     console.log('Notification received in foreground:', notification);
                 }
+
+                // Safety net for foreground pushes SSE might miss: the full
+                // rebuild also wins over the notification service extension's
+                // concurrent approximate patch.
+                requestWidgetSync();
             },
         );
 

--- a/packages/emitsignal-mobile/hooks/use-widget-sync.ts
+++ b/packages/emitsignal-mobile/hooks/use-widget-sync.ts
@@ -5,7 +5,11 @@ import { AppState, Platform } from 'react-native';
 import { useDevice } from '@/ctx/device';
 import { useSession } from '@/ctx/session';
 import { queryClient } from '@/lib/query-client';
-import { syncWidgetSnapshot } from '@/lib/widget-snapshot';
+import {
+    subscribeWidgetSyncRequests,
+    syncWidgetSnapshot,
+    type WidgetSyncMode,
+} from '@/lib/widget-snapshot';
 import { subscribeReadIds } from '@/storage/read-messages';
 
 const SYNC_DEBOUNCE_MS = 500;
@@ -14,8 +18,11 @@ const SYNCED_QUERY_DOMAINS = new Set(['feed', 'subscription-metrics', 'subscript
 
 // Keeps the iOS home-screen widgets in sync with the app: whenever the feed,
 // subscriptions, or metrics caches change (initial load, pull-to-refresh, SSE
-// inserts), a message is marked read, the session changes, or the app
-// backgrounds, the widget snapshot is rebuilt and the timelines reloaded.
+// inserts), a message is marked read, the session changes, a sync is requested
+// (foreground push received), or the app foregrounds/backgrounds, the widget
+// snapshot is rebuilt and the timelines reloaded. The foreground sync also
+// reconciles the approximate patches the notification service extension
+// applies while the app is not running.
 export function useWidgetSync(): void {
     const { deviceId } = useDevice();
     const { loading: sessionLoading, user } = useSession();
@@ -33,8 +40,8 @@ export function useWidgetSync(): void {
             return;
         }
 
-        const runSync = () => {
-            syncWidgetSnapshot(syncOptions.current).catch(() => {});
+        const runSync = (mode: WidgetSyncMode = 'full') => {
+            syncWidgetSnapshot({ ...syncOptions.current, mode }).catch(() => {});
         };
 
         const scheduleSync = () => {
@@ -60,13 +67,23 @@ export function useWidgetSync(): void {
 
         const unsubscribeReadIds = subscribeReadIds(scheduleSync);
 
+        const unsubscribeSyncRequests = subscribeWidgetSyncRequests(scheduleSync);
+
         const appStateSubscription = AppState.addEventListener('change', (state) => {
+            if (state === 'active') {
+                scheduleSync();
+
+                return;
+            }
+
             if (state === 'background') {
                 if (debounceTimer.current) {
                     clearTimeout(debounceTimer.current);
                 }
 
-                runSync();
+                // Cached-only: a network fetch here could be cut short by iOS
+                // suspending the app before the snapshot is written.
+                runSync('cached-only');
             }
         });
 
@@ -77,6 +94,7 @@ export function useWidgetSync(): void {
 
             unsubscribeQueryCache();
             unsubscribeReadIds();
+            unsubscribeSyncRequests();
             appStateSubscription.remove();
         };
     }, []);

--- a/packages/emitsignal-mobile/lib/widget-snapshot-builder.ts
+++ b/packages/emitsignal-mobile/lib/widget-snapshot-builder.ts
@@ -1,9 +1,11 @@
 import type { Message, Subscription, SubscriptionMetricsMap } from '@emitsignal/shared/api';
 
-// Mirrors WidgetSnapshot in targets/widgets/Snapshot.swift. Bump schemaVersion
-// on breaking changes; the widget falls back to its placeholder when the
-// versions disagree. Kept free of react-native imports so it can run under
-// `bun test`.
+// Mirrors WidgetSnapshot in targets/_shared/widget-snapshot-shared.swift. Every
+// field added here MUST be mirrored there: the notification service extension
+// decodes and re-encodes the snapshot, silently dropping unknown JSON keys.
+// Bump schemaVersion on breaking changes; the widget falls back to its
+// placeholder when the versions disagree. Kept free of react-native imports so
+// it can run under `bun test`.
 
 export interface BuildWidgetSnapshotInput {
     messages: Message[];

--- a/packages/emitsignal-mobile/lib/widget-snapshot.ts
+++ b/packages/emitsignal-mobile/lib/widget-snapshot.ts
@@ -23,15 +23,40 @@ export { buildWidgetSnapshot } from '@/lib/widget-snapshot-builder';
 
 export interface SyncWidgetSnapshotOptions {
     deviceId: null | string;
+    mode?: WidgetSyncMode;
     scheme: string;
     scope: string;
     userId: null | string;
 }
 
+// 'cached-only' skips the metrics network fetch so the snapshot write cannot
+// be cut short by iOS suspending the app (used when the app backgrounds).
+export type WidgetSyncMode = 'cached-only' | 'full';
+
+type WidgetSyncListener = () => void;
+
+const widgetSyncListeners = new Set<WidgetSyncListener>();
+
+// Lets non-hook code (e.g. the notification received listener) ask the mounted
+// useWidgetSync hook for a debounced re-sync.
+export function requestWidgetSync(): void {
+    for (const listener of widgetSyncListeners) {
+        listener();
+    }
+}
+
+export function subscribeWidgetSyncRequests(listener: WidgetSyncListener): () => void {
+    widgetSyncListeners.add(listener);
+
+    return () => {
+        widgetSyncListeners.delete(listener);
+    };
+}
+
 // Assembles a snapshot from the react-query cache (feed + subscriptions) plus
 // a metrics fetch (cached 180s), then hands it to the widget extension.
 export async function syncWidgetSnapshot(options: SyncWidgetSnapshotOptions): Promise<void> {
-    const { deviceId, scheme, scope, userId } = options;
+    const { deviceId, mode = 'full', scheme, scope, userId } = options;
 
     if (!scope) {
         return;
@@ -46,7 +71,12 @@ export async function syncWidgetSnapshot(options: SyncWidgetSnapshotOptions): Pr
 
     let metrics: SubscriptionMetricsMap = {};
 
-    if (subscriptions.length > 0) {
+    if (mode === 'cached-only') {
+        metrics =
+            queryClient.getQueryData<SubscriptionMetricsMap>(
+                queryKeys.subscriptionMetrics(scope),
+            ) ?? {};
+    } else if (subscriptions.length > 0) {
         try {
             metrics = await queryClient.fetchQuery({
                 queryFn: () =>

--- a/packages/emitsignal-mobile/targets/_shared/widget-snapshot-shared.swift
+++ b/packages/emitsignal-mobile/targets/_shared/widget-snapshot-shared.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+// Mirrors WidgetSnapshot in lib/widget-snapshot-builder.ts. The app serializes
+// this JSON into the app-group UserDefaults under `widget_snapshot`; the widgets
+// render it offline and the notification service extension patches it on push.
+//
+// Contract: any field added to the TypeScript snapshot MUST be mirrored here —
+// the notification service extension decodes and re-encodes the snapshot, so
+// unknown JSON keys are silently dropped.
+//
+// Compiled into the app target and every extension target (targets/_shared),
+// so keep this file pure Foundation — no WidgetKit or SwiftUI imports.
+struct WidgetSnapshot: Codable {
+    struct Channel: Codable {
+        var count24h: Int
+        var id: String
+        var name: String
+        var topPriority: Int
+        var unread: Int
+    }
+
+    struct Message: Codable {
+        var createdAt: Double
+        var id: String
+        var priority: Int
+        var title: String
+        var topicName: String
+        var unread: Bool
+
+        var date: Date {
+            Date(timeIntervalSince1970: createdAt / 1000)
+        }
+    }
+
+    struct Volume: Codable {
+        var buckets12: [Int]
+        var total24h: Int
+        var trendPct: Double?
+    }
+
+    var channelCount: Int
+    var channels: [Channel]
+    var hasData: Bool
+    var live: Bool
+    var primaryTopic: String?
+    var recent: [Message]
+    var schemaVersion: Int
+    var scheme: String
+    var todayMoreCount: Int
+    var unreadCount: Int
+    var updatedAt: Double
+    var volume: Volume
+}
+
+enum SharedStore {
+    static let snapshotKey = "widget_snapshot"
+
+    // group.<app bundle id>; extensions (widgets, nse) append exactly one
+    // dotted component to the app bundle id, so inside an .appex the last
+    // component is dropped to recover the app id for every APP_MODE variant.
+    static var appGroup: String {
+        var bundleIdentifier = Bundle.main.bundleIdentifier ?? "com.emitsignal"
+
+        if Bundle.main.bundlePath.hasSuffix(".appex"),
+           let lastDot = bundleIdentifier.lastIndex(of: ".") {
+            bundleIdentifier = String(bundleIdentifier[..<lastDot])
+        }
+
+        return "group." + bundleIdentifier
+    }
+
+    static func load() -> WidgetSnapshot? {
+        guard
+            let raw = UserDefaults(suiteName: appGroup)?.string(forKey: snapshotKey),
+            let data = raw.data(using: .utf8),
+            let snapshot = try? JSONDecoder().decode(WidgetSnapshot.self, from: data),
+            snapshot.schemaVersion == 1
+        else {
+            return nil
+        }
+
+        return snapshot
+    }
+
+    static func save(_ snapshot: WidgetSnapshot) {
+        guard
+            let data = try? JSONEncoder().encode(snapshot),
+            let raw = String(data: data, encoding: .utf8)
+        else {
+            return
+        }
+
+        UserDefaults(suiteName: appGroup)?.set(raw, forKey: snapshotKey)
+    }
+}

--- a/packages/emitsignal-mobile/targets/nse/DEBUGGING.md
+++ b/packages/emitsignal-mobile/targets/nse/DEBUGGING.md
@@ -1,0 +1,104 @@
+# NSE widget-sync — status and how to resume debugging
+
+## What this branch contains
+
+Push-driven widget updates for iOS. A Notification Service Extension (NSE)
+runs for every visible push (`mutable-content: 1`), patches the shared widget
+snapshot in the app-group `UserDefaults`, and reloads the widget timelines —
+so widgets update while the app is backgrounded or terminated.
+
+- `targets/nse/` — the extension (`NotificationService.swift`, target config).
+- `targets/_shared/widget-snapshot-shared.swift` — `WidgetSnapshot` model and
+  `SharedStore`, compiled into the app, the widgets, and the NSE. Any field
+  added to the TypeScript snapshot (`lib/widget-snapshot-builder.ts`) MUST be
+  mirrored here, or the NSE's decode→re-encode silently drops it.
+- `targets/widgets/Snapshot.swift` — slimmed to widget-only presentation.
+- `lib/widget-snapshot.ts`, `hooks/use-widget-sync.ts`,
+  `hooks/use-foreground-notifications.ts` — sync-trigger fixes: full re-sync on
+  foreground (reconciles NSE approximations), network-free `cached-only` sync
+  on background, debounced sync when a push arrives in the foreground.
+
+The server side (already on `main`, commit `06cdf1c`) sets
+`mutableContent: true` and adds `createdAt`/`priority` to the push `data`.
+
+## Current status (2026-08-04)
+
+Verified on a physical iPhone (preview build):
+
+- The `nse` target builds, is provisioned (`com.emitsignal.preview.nse`), and
+  **launches on push** — device Console shows
+  `[com.emitsignal.preview.nse] Extension started`.
+- BUT the widget snapshot is **not** patched: the extension bails somewhere
+  inside `patchSnapshot` without visible errors. The previous build had no
+  logging, so the bail point is unknown.
+- `NotificationService.swift` has since been instrumented with `os_log`
+  (subsystem `com.emitsignal.nse`) on every exit path, and the payload parsing
+  was hardened (data under `body` as dict, as JSON string, or root-level).
+  **No build with this instrumentation has been tested on a device yet.**
+
+Ruled out already — do not re-investigate:
+
+- Xcode wiring (entitlements, `_shared` membership in all three targets,
+  generated Info.plist principal class) — verified correct via clean
+  `npx expo prebuild -p ios --clean`.
+- Push delivery: pushes arrive with `mutableContent: YES` (confirmed in device
+  logs) and the extension launches.
+- Simulator repro: **impossible** — `xcrun simctl push` displays notifications
+  but never invokes service extensions. Do not waste time there; only the
+  snapshot-patch logic could be unit-tested off-device.
+
+## How to resume
+
+1. Build and install: `eas build --platform ios --profile preview`.
+2. On the Mac: Console.app → select the iPhone → Start streaming → filter
+   `com.emitsignal.nse`.
+3. Send a test push (bypasses the server; use the current token from the
+   `PushToken` table and any subscribed topic):
+
+   ```bash
+   curl -sS -X POST https://exp.host/--/api/v2/push/send \
+     -H "Authorization: Bearer $EXPO_ACCESS_TOKEN" \
+     -H 'Content-Type: application/json' \
+     -d '{
+       "to": "ExponentPushToken[...]",
+       "title": "device/two",
+       "subtitle": "NSE debug",
+       "body": "test",
+       "mutableContent": true,
+       "priority": "high",
+       "data": {
+         "messageId": "debug-'$(date +%s)'",
+         "topicId": "<topic id>",
+         "topicName": "device/two",
+         "priority": 5,
+         "createdAt": '$(date +%s000)'
+       }
+     }'
+   ```
+
+   `EXPO_ACCESS_TOKEN` lives in `packages/emitsignal-server/.env`. Use a fresh
+   `messageId` each time — the NSE dedups by id.
+
+4. Read the log line and apply the mapped fix:
+
+   | Log line | Meaning / fix |
+   | --- | --- |
+   | `no data payload; userInfo keys: ...` | Expo nests `data` differently than assumed — adjust `extractData` to the key list shown. |
+   | `data missing ids; data keys: ...` | Same, finer-grained. |
+   | `snapshot missing or undecodable in app group ...` | App-group mismatch or decode failure — compare the logged group with the app's `extra.appGroup`, and the Swift struct against the JSON the app writes. |
+   | `duplicate message ...` | Dedup false positive — inspect ids. |
+   | `snapshot patched and timelines reloaded` (widget still static) | Patch works; the problem is the WidgetKit reload — try `WidgetCenter.shared.reloadTimelines(ofKind:)` per kind, or check reload-budget throttling. |
+
+5. After the fix is confirmed end-to-end (post a real message with the app
+   force-quit; widget updates without opening the app):
+   - Quiet the logging: drop the per-push info logs or mark payload values
+     `.private`; keep the error paths.
+   - Run `bun test` and `bun lint`, then merge.
+
+## Expected end-to-end behavior once fixed
+
+Publish → worker sends push with `mutableContent` → iOS launches the NSE →
+snapshot patched (message prepended, unread/channel/volume counters bumped,
+`updatedAt` refreshed) → widgets reload within ~1–2 s of the banner. The app's
+next foreground sync rebuilds the snapshot from real data, correcting the
+NSE's approximations (`todayMoreCount`, activity buckets, read state).

--- a/packages/emitsignal-mobile/targets/nse/Info.plist
+++ b/packages/emitsignal-mobile/targets/nse/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>NSExtension</key>
+    <dict>
+      <key>NSExtensionAttributes</key>
+      <dict>
+        <key>NSExtensionActivationRule</key>
+        <string>TRUEPREDICATE</string>
+      </dict>
+      <key>NSExtensionPrincipalClass</key>
+      <string>$(PRODUCT_MODULE_NAME).NotificationService</string>
+      <key>NSExtensionPointIdentifier</key>
+      <string>com.apple.usernotifications.service</string>
+    </dict>
+  </dict>
+</plist>

--- a/packages/emitsignal-mobile/targets/nse/NotificationService.swift
+++ b/packages/emitsignal-mobile/targets/nse/NotificationService.swift
@@ -1,0 +1,199 @@
+import os.log
+import UserNotifications
+import WidgetKit
+
+// Runs for every visible push (mutable-content: 1), including while the app is
+// backgrounded or terminated: patches the shared widget snapshot with the
+// incoming message and reloads the widget timelines, then delivers the
+// notification content unchanged.
+//
+// The patch is an approximation — todayMoreCount and the activity buckets are
+// only bumped, not recomputed — and the app overwrites the snapshot with a full
+// rebuild on its next foreground sync. Concurrent writes (app vs. extension)
+// go through process-safe app-group UserDefaults; a lost increment self-heals
+// on that same full sync.
+//
+// Note: simctl pushes do not launch service extensions in the simulator; test
+// on a physical device (stream logs in Console.app filtered by this subsystem).
+private let log = Logger(subsystem: "com.emitsignal.nse", category: "snapshot")
+
+class NotificationService: UNNotificationServiceExtension {
+    // Mirror MAX_RECENT / MAX_CHANNELS in lib/widget-snapshot-builder.ts.
+    private static let maxRecentMessages = 6
+    private static let maxChannels = 8
+
+    private var contentHandler: ((UNNotificationContent) -> Void)?
+    private var bestAttemptContent: UNMutableNotificationContent?
+
+    override func didReceive(
+        _ request: UNNotificationRequest,
+        withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
+    ) {
+        self.contentHandler = contentHandler
+        bestAttemptContent = request.content.mutableCopy() as? UNMutableNotificationContent
+
+        log.info("didReceive: begin")
+        patchSnapshot(content: request.content)
+        log.info("didReceive: done")
+
+        contentHandler(bestAttemptContent ?? request.content)
+    }
+
+    override func serviceExtensionTimeWillExpire() {
+        log.error("serviceExtensionTimeWillExpire")
+
+        if let bestAttemptContent {
+            contentHandler?(bestAttemptContent)
+        }
+    }
+
+    private func patchSnapshot(content: UNNotificationContent) {
+        let userInfo = content.userInfo
+
+        guard let data = extractData(from: userInfo) else {
+            let keys = userInfo.keys.compactMap { $0 as? String }.joined(separator: ",")
+            log.error("no data payload; userInfo keys: \(keys, privacy: .public)")
+            return
+        }
+
+        guard
+            let messageId = data["messageId"] as? String,
+            let topicId = data["topicId"] as? String,
+            let topicName = data["topicName"] as? String
+        else {
+            let keys = data.keys.joined(separator: ",")
+            log.error("data missing ids; data keys: \(keys, privacy: .public)")
+            return
+        }
+
+        log.info("payload ok: messageId=\(messageId, privacy: .public) appGroup=\(SharedStore.appGroup, privacy: .public)")
+
+        // Never fabricate a snapshot: absent means the app has not synced yet,
+        // the user signed out, or the schema versions disagree.
+        guard var snapshot = SharedStore.load() else {
+            log.error("snapshot missing or undecodable in app group \(SharedStore.appGroup, privacy: .public)")
+            return
+        }
+
+        // APNs can redeliver; skip messages the snapshot already contains.
+        if snapshot.recent.contains(where: { $0.id == messageId }) {
+            log.info("duplicate message \(messageId, privacy: .public); skipping")
+            return
+        }
+
+        let priority = intValue(data["priority"]) ?? 3
+        let createdAt = doubleValue(data["createdAt"]) ?? Date().timeIntervalSince1970 * 1000
+
+        // buildExpoMessages puts the message title in `subtitle` (falling back
+        // to the body text), matching `title: message.title || message.body`
+        // in the snapshot builder.
+        var title = content.subtitle
+        if title.isEmpty {
+            title = content.body
+        }
+
+        let message = WidgetSnapshot.Message(
+            createdAt: createdAt,
+            id: messageId,
+            priority: priority,
+            title: title,
+            topicName: topicName,
+            unread: true
+        )
+
+        snapshot.recent.insert(message, at: 0)
+        if snapshot.recent.count > Self.maxRecentMessages {
+            snapshot.recent.removeLast(snapshot.recent.count - Self.maxRecentMessages)
+        }
+
+        snapshot.unreadCount += 1
+
+        if let index = snapshot.channels.firstIndex(where: { $0.id == topicId }) {
+            snapshot.channels[index].unread += 1
+            snapshot.channels[index].count24h += 1
+            snapshot.channels[index].topPriority = max(snapshot.channels[index].topPriority, priority)
+        } else {
+            snapshot.channels.append(
+                WidgetSnapshot.Channel(
+                    count24h: 1,
+                    id: topicId,
+                    name: topicName,
+                    topPriority: priority,
+                    unread: 1
+                )
+            )
+            snapshot.channelCount += 1
+        }
+
+        // Mirrors the builder's ordering: unread desc, then count24h desc.
+        snapshot.channels.sort { first, second in
+            if first.unread != second.unread {
+                return first.unread > second.unread
+            }
+            return first.count24h > second.count24h
+        }
+        if snapshot.channels.count > Self.maxChannels {
+            snapshot.channels.removeLast(snapshot.channels.count - Self.maxChannels)
+        }
+
+        snapshot.volume.total24h += 1
+        if !snapshot.volume.buckets12.isEmpty {
+            snapshot.volume.buckets12[snapshot.volume.buckets12.count - 1] += 1
+        }
+
+        snapshot.primaryTopic = topicName
+        snapshot.hasData = true
+        snapshot.updatedAt = Date().timeIntervalSince1970 * 1000
+
+        SharedStore.save(snapshot)
+        WidgetCenter.shared.reloadAllTimelines()
+        log.info("snapshot patched and timelines reloaded")
+    }
+
+    // The Expo push service nests the message `data` under the top-level
+    // `body` key of the APNs payload — as a dictionary, or as a JSON string in
+    // some delivery paths. Fall back to root-level keys for direct APNs sends.
+    private func extractData(from userInfo: [AnyHashable: Any]) -> [String: Any]? {
+        if let body = userInfo["body"] as? [String: Any] {
+            return body
+        }
+
+        if let raw = userInfo["body"] as? String,
+           let data = raw.data(using: .utf8),
+           let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            return parsed
+        }
+
+        if userInfo["messageId"] is String {
+            var root: [String: Any] = [:]
+            for (key, value) in userInfo {
+                if let stringKey = key as? String {
+                    root[stringKey] = value
+                }
+            }
+            return root
+        }
+
+        return nil
+    }
+
+    private func intValue(_ value: Any?) -> Int? {
+        if let number = value as? NSNumber {
+            return number.intValue
+        }
+        if let string = value as? String {
+            return Int(string)
+        }
+        return nil
+    }
+
+    private func doubleValue(_ value: Any?) -> Double? {
+        if let number = value as? NSNumber {
+            return number.doubleValue
+        }
+        if let string = value as? String {
+            return Double(string)
+        }
+        return nil
+    }
+}

--- a/packages/emitsignal-mobile/targets/nse/expo-target.config.js
+++ b/packages/emitsignal-mobile/targets/nse/expo-target.config.js
@@ -1,0 +1,12 @@
+/** @type {import('@bacons/apple-targets').ConfigFunction} */
+module.exports = (config) => ({
+    bundleIdentifier: '.nse',
+    deploymentTarget: '17.0',
+    displayName: 'EmitSignal Notification Service',
+    entitlements: {
+        'com.apple.security.application-groups': [`group.${config.ios.bundleIdentifier}`],
+    },
+    frameworks: ['UserNotifications', 'WidgetKit'],
+    name: 'nse',
+    type: 'notification-service',
+});

--- a/packages/emitsignal-mobile/targets/widgets/Snapshot.swift
+++ b/packages/emitsignal-mobile/targets/widgets/Snapshot.swift
@@ -1,48 +1,10 @@
 import Foundation
 
-// Mirrors WidgetSnapshot in lib/widget-snapshot.ts. The app serializes this JSON
-// into the app-group UserDefaults under `widget_snapshot`; widgets render offline.
-struct WidgetSnapshot: Codable {
-    struct Channel: Codable {
-        let count24h: Int
-        let id: String
-        let name: String
-        let topPriority: Int
-        let unread: Int
-    }
-
-    struct Message: Codable {
-        let createdAt: Double
-        let id: String
-        let priority: Int
-        let title: String
-        let topicName: String
-        let unread: Bool
-
-        var date: Date {
-            Date(timeIntervalSince1970: createdAt / 1000)
-        }
-    }
-
-    struct Volume: Codable {
-        let buckets12: [Int]
-        let total24h: Int
-        let trendPct: Double?
-    }
-
-    let channelCount: Int
-    let channels: [Channel]
-    let hasData: Bool
-    let live: Bool
-    let primaryTopic: String?
-    let recent: [Message]
-    let schemaVersion: Int
-    let scheme: String
-    let todayMoreCount: Int
-    let unreadCount: Int
-    let updatedAt: Double
-    let volume: Volume
-
+// The WidgetSnapshot model and SharedStore live in
+// targets/_shared/widget-snapshot-shared.swift so the notification service
+// extension can patch the same snapshot. This file keeps the widget-only
+// presentation helpers and design-time data out of the other targets.
+extension WidgetSnapshot {
     var latest: Message? {
         recent.first
     }
@@ -56,29 +18,7 @@ struct WidgetSnapshot: Codable {
             .addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? "/"
         return URL(string: "\(scheme)://\(encoded)") ?? URL(string: "\(scheme)://")!
     }
-}
 
-enum SharedStore {
-    // group.<app bundle id>; the widget bundle id is always "<app bundle id>.widgets"
-    static var appGroup: String {
-        let bundleIdentifier = Bundle.main.bundleIdentifier ?? "com.emitsignal.widgets"
-        return "group." + bundleIdentifier.replacingOccurrences(of: ".widgets", with: "")
-    }
-
-    static func load() -> WidgetSnapshot? {
-        guard
-            let raw = UserDefaults(suiteName: appGroup)?.string(forKey: "widget_snapshot"),
-            let data = raw.data(using: .utf8),
-            let snapshot = try? JSONDecoder().decode(WidgetSnapshot.self, from: data),
-            snapshot.schemaVersion == 1
-        else {
-            return nil
-        }
-        return snapshot
-    }
-}
-
-extension WidgetSnapshot {
     // Design sample data from Logo & Identity.html · 08 Home-screen widgets
     static var sample: WidgetSnapshot {
         let now = Date().timeIntervalSince1970 * 1000


### PR DESCRIPTION
## Summary

Widgets currently only refresh while the app runs; a push arriving with the app backgrounded or terminated leaves them stale until the next app open. This adds an iOS Notification Service Extension (NSE) that runs on every visible push (`mutable-content: 1`), patches the shared widget snapshot in the app-group storage, and reloads the widget timelines — so widgets update within seconds of the banner.

- **`targets/nse/`** — the extension: parses the push data, prepends the message to the snapshot, bumps unread/channel/volume counters, refreshes `updatedAt`, and calls `WidgetCenter.reloadAllTimelines()`. No-ops safely when no snapshot exists (signed out / never synced); dedups by `messageId`.
- **`targets/_shared/widget-snapshot-shared.swift`** — the `WidgetSnapshot` model and `SharedStore` moved out of the widgets target so the app, widgets, and NSE compile one shared copy. App-group derivation generalized to work for any `.appex` across the APP_MODE bundle variants.
- **Sync-trigger fixes** — full re-sync on app foreground (reconciles the NSE's approximate counters), network-free `cached-only` sync on backgrounding, and a debounced sync when a push arrives in the foreground.

The server counterpart is already on `main` (`06cdf1c`): `mutableContent: true` plus `createdAt`/`priority` in the push `data`.

## Status — why this is a draft

Verified on a physical iPhone (preview build): the extension is provisioned and **launches on push**, but the snapshot patch does not land yet — it bails silently somewhere inside `patchSnapshot`. The extension has since been instrumented with `os_log` (subsystem `com.emitsignal.nse`) and the payload parsing hardened, but no instrumented build has been device-tested yet.

**`targets/nse/DEBUGGING.md`** documents the full state: what is proven working, what is ruled out (Xcode wiring, push delivery, and the simulator — `simctl push` never invokes NSEs), the exact test-push command, and a log-line → fix table for resuming.

## Merge checklist

- [ ] Device-test an instrumented build and fix the `patchSnapshot` bail (see DEBUGGING.md)
- [ ] End-to-end: post a message with the app force-quit; widget updates without opening the app
- [ ] Quiet the debug logging (drop per-push info logs or mark values `.private`)
- [ ] Note for EAS: the new `.nse` bundle id needs one-time credential provisioning per APP_MODE (preview already done)