### PR TITLE
feat: retain webhook deliveries for a bounded, plan-based window

### DIFF
--- a/packages/emitsignal-server/prisma/migrations/20260807021101_webhook_delivery_expires_at/migration.sql
+++ b/packages/emitsignal-server/prisma/migrations/20260807021101_webhook_delivery_expires_at/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "WebhookDelivery" ADD COLUMN     "expiresAt" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "WebhookDelivery_expiresAt_idx" ON "WebhookDelivery"("expiresAt");

--- a/packages/emitsignal-server/prisma/migrations/20260807021102_backfill_webhook_delivery_expires_at/migration.sql
+++ b/packages/emitsignal-server/prisma/migrations/20260807021102_backfill_webhook_delivery_expires_at/migration.sql
@@ -1,0 +1,6 @@
+-- Backfill rows written before the column existed so the retention sweep can
+-- reach them. Uses the free-plan window (3 days); anything already older than
+-- that expires immediately on the next sweep, which is the intent.
+UPDATE "WebhookDelivery"
+SET "expiresAt" = "createdAt" + INTERVAL '3 days'
+WHERE "expiresAt" IS NULL;

--- a/packages/emitsignal-server/prisma/schema.prisma
+++ b/packages/emitsignal-server/prisma/schema.prisma
@@ -335,6 +335,7 @@ model WebhookDelivery {
     id        String   @id @default(cuid())
 
     createdAt DateTime @default(now())
+    expiresAt   DateTime?
     messageId   String?
     ms          Int
     payload     String
@@ -344,5 +345,6 @@ model WebhookDelivery {
 
     webhook Webhook @relation(fields: [webhookId], references: [id], onDelete: Cascade)
 
+    @@index([expiresAt])
     @@index([webhookId, createdAt])
 }

--- a/packages/emitsignal-server/src/http/webhooks/__tests__/receive.spec.ts
+++ b/packages/emitsignal-server/src/http/webhooks/__tests__/receive.spec.ts
@@ -20,6 +20,8 @@ mock.module('#/http/auth/plugin', () => ({
 }));
 
 import { receiveWebhook } from '#/http/webhooks/receive';
+import { resetUserPlansForTests, setUserPlanForTests } from '#/services/billing/get-user-plan';
+import { duration } from '#/utils/duration';
 
 describe('POST /h/:slug link → view action', () => {
     const app = new Elysia().use(receiveWebhook);
@@ -188,5 +190,74 @@ describe('POST /h/:slug link → view action', () => {
 
         expect(res.status).toBe(200);
         expect(storedActions()).toEqual([]);
+    });
+});
+
+describe('POST /h/:slug delivery retention', () => {
+    const app = new Elysia().use(receiveWebhook);
+
+    function request() {
+        return new Request('http://localhost/h/cw_abc1234', {
+            body: JSON.stringify({ event: { name: 'deploy' } }),
+            headers: { 'Content-Type': 'application/json' },
+            method: 'POST',
+        });
+    }
+
+    // Days between the stored delivery's expiry and now, rounded to whole days.
+    function storedExpiryDays(): number {
+        const calls = prismaMock.webhookDelivery.create.mock.calls;
+        const lastCall = calls[calls.length - 1] as unknown as [{ data: Record<string, unknown> }];
+        const expiresAt = lastCall[0].data.expiresAt as Date;
+
+        return Math.round((expiresAt.getTime() - Date.now()) / duration.days(1).as('ms'));
+    }
+
+    function withOwner(userId: null | string) {
+        prismaMock.webhook.findUnique.mockResolvedValue({
+            id: 'wh-1',
+            source: 'custom',
+            status: 'active',
+            template: null,
+            topicName: 'deploys',
+            userId,
+        });
+    }
+
+    beforeEach(() => {
+        resetUserPlansForTests();
+        prismaMock.webhookDelivery.create.mockClear();
+        prismaMock.topic.findUnique.mockResolvedValue({
+            displayName: 'deploys',
+            id: 'topic-1',
+            name: 'deploys',
+        });
+    });
+
+    it('expires a free owner’s delivery after 3 days', async () => {
+        withOwner('user-free');
+        setUserPlanForTests('user-free', 'free');
+
+        const res = await app.handle(request());
+
+        expect(res.status).toBe(200);
+        expect(storedExpiryDays()).toBe(3);
+    });
+
+    it('expires a beam owner’s delivery after 30 days, unlike their messages', async () => {
+        withOwner('user-beam');
+        setUserPlanForTests('user-beam', 'beam');
+
+        await app.handle(request());
+
+        expect(storedExpiryDays()).toBe(30);
+    });
+
+    it('expires an unowned webhook’s delivery on the anonymous window', async () => {
+        withOwner(null);
+
+        await app.handle(request());
+
+        expect(storedExpiryDays()).toBe(3);
     });
 });

--- a/packages/emitsignal-server/src/http/webhooks/deliveries.ts
+++ b/packages/emitsignal-server/src/http/webhooks/deliveries.ts
@@ -31,6 +31,7 @@ export const listDeliveries = new Elysia().get(
             orderBy: { createdAt: 'desc' },
             select: {
                 createdAt: true,
+                expiresAt: true,
                 id: true,
                 messageId: true,
                 ms: true,
@@ -47,6 +48,7 @@ export const listDeliveries = new Elysia().get(
             channel: webhook.topicName,
             createdAt: Math.floor(delivery.createdAt.getTime() / 1000),
             durationMs: delivery.ms,
+            expiresAt: delivery.expiresAt ? Math.floor(delivery.expiresAt.getTime() / 1000) : null,
             id: delivery.id,
             messageId: delivery.messageId,
             payload: JSON.parse(delivery.payload) as unknown,

--- a/packages/emitsignal-server/src/http/webhooks/receive.ts
+++ b/packages/emitsignal-server/src/http/webhooks/receive.ts
@@ -10,7 +10,12 @@ import { prisma } from '#/lib/prisma';
 import { pushQueue } from '#/lib/queue';
 import { webhookReceiveLimiter } from '#/lib/rate-limit';
 import { getUserPlan } from '#/services/billing/get-user-plan';
-import { messageExpiresAt, messageRetentionDays } from '#/services/billing/retention';
+import {
+    messageExpiresAt,
+    messageRetentionDays,
+    webhookDeliveryExpiresAt,
+    webhookRetentionDays,
+} from '#/services/billing/retention';
 import { serializeMessage } from '#/services/message';
 import { getOrCreateTopic } from '#/services/topic';
 import { canPublishToTopicName } from '#/services/topic-access';
@@ -125,8 +130,11 @@ export const receiveWebhook = new Elysia().post(
 
         const ms = Date.now() - start;
 
+        const deliveryExpiresAt = webhookDeliveryExpiresAt(deliveredAt, webhookRetentionDays(plan));
+
         const delivery = await prisma.webhookDelivery.create({
             data: {
+                expiresAt: deliveryExpiresAt,
                 messageId: message.id,
                 ms,
                 payload: JSON.stringify(payload),
@@ -139,6 +147,7 @@ export const receiveWebhook = new Elysia().post(
 
         bus.publishWebhookDelivery(webhook.userId, {
             channel: webhook.topicName,
+            expiresAt: Math.floor(deliveryExpiresAt.getTime() / 1000),
             id: delivery.id,
             ms,
             payload,

--- a/packages/emitsignal-server/src/lib/event-bus.ts
+++ b/packages/emitsignal-server/src/lib/event-bus.ts
@@ -35,6 +35,7 @@ export interface MessageEvent {
 
 export interface WebhookDeliveryEvent {
     channel: string;
+    expiresAt: number;
     id: string;
     ms: number;
     payload: Record<string, unknown>;

--- a/packages/emitsignal-server/src/lib/queue/purge/purge-worker.ts
+++ b/packages/emitsignal-server/src/lib/queue/purge/purge-worker.ts
@@ -160,7 +160,36 @@ async function purgeExpired(): Promise<void> {
         }
     }
 
-    logger.info({ expiredAttachments, retiredMessages }, 'retention sweep completed');
+    let expiredDeliveries = 0;
+
+    // Webhook deliveries own no storage objects, so they can be removed directly —
+    // the batching only bounds the size of each DELETE.
+    for (;;) {
+        const batch = await prisma.webhookDelivery.findMany({
+            select: { id: true },
+            take: RETENTION_BATCH_SIZE,
+            where: { expiresAt: { lt: now, not: null } },
+        });
+
+        if (batch.length === 0) {
+            break;
+        }
+
+        const { count } = await prisma.webhookDelivery.deleteMany({
+            where: { id: { in: batch.map((delivery) => delivery.id) } },
+        });
+
+        expiredDeliveries += count;
+
+        if (batch.length < RETENTION_BATCH_SIZE) {
+            break;
+        }
+    }
+
+    logger.info(
+        { expiredAttachments, expiredDeliveries, retiredMessages },
+        'retention sweep completed',
+    );
 }
 
 async function purgeSignals(userId: string): Promise<void> {

--- a/packages/emitsignal-server/src/services/billing/__tests__/retention.spec.ts
+++ b/packages/emitsignal-server/src/services/billing/__tests__/retention.spec.ts
@@ -1,11 +1,15 @@
+import { PLAN_ORDER, PLANS } from '@emitsignal/shared';
 import { describe, expect, it } from 'bun:test';
 
 import {
     ANON_RETENTION_DAYS,
+    ANON_WEBHOOK_RETENTION_DAYS,
     ATTACHMENT_MAX_RETENTION_DAYS,
     attachmentExpiresAt,
     messageExpiresAt,
     messageRetentionDays,
+    webhookDeliveryExpiresAt,
+    webhookRetentionDays,
 } from '#/services/billing/retention';
 import { duration } from '#/utils/duration';
 
@@ -36,6 +40,40 @@ describe('messageExpiresAt', () => {
         expect((expiresAt as Date).getTime() - deliveredAt.getTime()).toBe(
             duration.days(7).as('ms'),
         );
+    });
+});
+
+describe('webhookRetentionDays', () => {
+    it('maps each plan to its webhook window', () => {
+        expect(webhookRetentionDays('beam')).toBe(30);
+        expect(webhookRetentionDays('free')).toBe(3);
+        expect(webhookRetentionDays('pulse')).toBe(14);
+    });
+
+    it('uses the anonymous window when there is no plan', () => {
+        expect(ANON_WEBHOOK_RETENTION_DAYS).toBe(3);
+        expect(webhookRetentionDays(null)).toBe(ANON_WEBHOOK_RETENTION_DAYS);
+    });
+
+    it('never keeps deliveries forever, on any plan', () => {
+        for (const plan of PLAN_ORDER) {
+            expect(PLANS[plan].limits.webhookRetentionDays).toBeGreaterThan(0);
+        }
+    });
+
+    it('stays shorter than the message window it accompanies', () => {
+        expect(webhookRetentionDays('free')).toBeLessThan(messageRetentionDays('free'));
+        expect(webhookRetentionDays('pulse')).toBeLessThan(messageRetentionDays('pulse'));
+    });
+});
+
+describe('webhookDeliveryExpiresAt', () => {
+    const createdAt = new Date('2026-01-01T00:00:00.000Z');
+
+    it('adds the retention window to the delivery time', () => {
+        const expiresAt = webhookDeliveryExpiresAt(createdAt, 3);
+
+        expect(expiresAt.getTime() - createdAt.getTime()).toBe(duration.days(3).as('ms'));
     });
 });
 

--- a/packages/emitsignal-server/src/services/billing/retention.ts
+++ b/packages/emitsignal-server/src/services/billing/retention.ts
@@ -5,6 +5,7 @@ import { PLANS } from '@emitsignal/shared';
 import { duration } from '#/utils/duration';
 
 export const ANON_RETENTION_DAYS = 7;
+export const ANON_WEBHOOK_RETENTION_DAYS = 3;
 export const ATTACHMENT_MAX_RETENTION_DAYS = 14;
 
 export function attachmentExpiresAt(deliveredAt: Date, retentionDays: number): Date {
@@ -27,4 +28,12 @@ export function messageExpiresAt(deliveredAt: Date, retentionDays: number): Date
 
 export function messageRetentionDays(plan: null | PlanName): number {
     return plan ? PLANS[plan].limits.retentionDays : ANON_RETENTION_DAYS;
+}
+
+export function webhookDeliveryExpiresAt(createdAt: Date, retentionDays: number): Date {
+    return new Date(createdAt.getTime() + duration.days(retentionDays).as('ms'));
+}
+
+export function webhookRetentionDays(plan: null | PlanName): number {
+    return plan ? PLANS[plan].limits.webhookRetentionDays : ANON_WEBHOOK_RETENTION_DAYS;
 }

--- a/packages/emitsignal-shared/src/api.ts
+++ b/packages/emitsignal-shared/src/api.ts
@@ -127,6 +127,7 @@ export interface WebhookDelivery {
     channel: string;
     createdAt: number;
     durationMs: number;
+    expiresAt: null | number;
     id: string;
     messageId: null | string;
     payload: Record<string, unknown>;

--- a/packages/emitsignal-shared/src/billing.ts
+++ b/packages/emitsignal-shared/src/billing.ts
@@ -33,6 +33,7 @@ export interface PlanLimits {
     // 0 means "keep forever" (no expiry is ever set). Attachments derive their
     // own, shorter window from this — see the server retention helper.
     retentionDays: number;
+    webhookRetentionDays: number;
 }
 
 export type PlanName = 'beam' | 'free' | 'pulse';
@@ -59,6 +60,7 @@ export const PLANS: Record<PlanName, PlanDefinition> = {
             maxWebhooks: 30,
             messagesPerDay: 20_000,
             retentionDays: 0,
+            webhookRetentionDays: 30,
         },
         name: 'beam',
         priceMonthlyUsd: 12,
@@ -75,6 +77,7 @@ export const PLANS: Record<PlanName, PlanDefinition> = {
             maxWebhooks: 2,
             messagesPerDay: 100,
             retentionDays: 90,
+            webhookRetentionDays: 3,
         },
         name: 'free',
         priceMonthlyUsd: 0,
@@ -91,6 +94,7 @@ export const PLANS: Record<PlanName, PlanDefinition> = {
             maxWebhooks: 10,
             messagesPerDay: 2500,
             retentionDays: 365,
+            webhookRetentionDays: 14,
         },
         name: 'pulse',
         priceMonthlyUsd: 5,

--- a/packages/emitsignal-shared/src/format.ts
+++ b/packages/emitsignal-shared/src/format.ts
@@ -1,3 +1,39 @@
+export function formatExpiry(value: Date | null | number | string): {
+    expired: boolean;
+    text: string;
+} {
+    if (value === null) {
+        return { expired: false, text: 'Never' };
+    }
+
+    const timestamp = typeof value === 'number' ? value : new Date(value).getTime();
+    const diff = timestamp - Date.now();
+
+    if (diff <= 0) {
+        return { expired: true, text: 'Expired' };
+    }
+
+    const days = Math.ceil(diff / 86_400_000);
+
+    if (days <= 1) {
+        return { expired: false, text: 'Today' };
+    }
+
+    if (days < 7) {
+        return { expired: false, text: `${days}d` };
+    }
+
+    if (days < 30) {
+        return { expired: false, text: `${Math.round(days / 7)}w` };
+    }
+
+    if (days < 365) {
+        return { expired: false, text: `${Math.round(days / 30)}mo` };
+    }
+
+    return { expired: false, text: `${Math.round(days / 365)}y` };
+}
+
 export function formatSize(bytes: number): string {
     if (!bytes || bytes < 1024) return `${bytes} B`;
     if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;

--- a/packages/emitsignal-website/src/components/app/keys/keys-table.tsx
+++ b/packages/emitsignal-website/src/components/app/keys/keys-table.tsx
@@ -6,37 +6,7 @@ import type { ApiKey } from '#/hooks/use-api-keys';
 import { Dot } from '#/components/ui/dot';
 import { Pill } from '#/components/ui/pill';
 import { Sparkline } from '#/components/ui/sparkline';
-
-function formatExpiry(date: Date | null): { expired: boolean; text: string } {
-    if (!date) {
-        return { expired: false, text: 'Never' };
-    }
-
-    const diff = new Date(date).getTime() - Date.now();
-
-    if (diff <= 0) {
-        return { expired: true, text: 'Expired' };
-    }
-    const days = Math.ceil(diff / 86_400_000);
-
-    if (days <= 1) {
-        return { expired: false, text: 'Today' };
-    }
-
-    if (days < 7) {
-        return { expired: false, text: `${days}d` };
-    }
-
-    if (days < 30) {
-        return { expired: false, text: `${Math.round(days / 7)}w` };
-    }
-
-    if (days < 365) {
-        return { expired: false, text: `${Math.round(days / 30)}mo` };
-    }
-
-    return { expired: false, text: `${Math.round(days / 365)}y` };
-}
+import { formatExpiry } from '#/lib/format';
 
 function timeAgo(date: Date | null): string {
     if (!date) {

--- a/packages/emitsignal-website/src/components/app/webhooks/deliveries-log.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/deliveries-log.tsx
@@ -8,6 +8,7 @@ import type { WebhookDelivery, WebhookTemplate } from '#/lib/api';
 import { useWebhook } from '#/hooks/use-webhook';
 import { useWebhookDeliveries } from '#/hooks/use-webhook-deliveries';
 import { API_URL } from '#/lib/api';
+import { formatExpiry } from '#/lib/format';
 
 import type { WebhookSource } from './source-glyph';
 
@@ -148,6 +149,7 @@ export function DeliveriesLog({ webhookId }: { webhookId: string }) {
                                     <span className="font-mono text-[10px] text-faint">
                                         {delivery.durationMs}ms
                                     </span>
+                                    <ExpiryLabel expiresAt={delivery.expiresAt} />
                                     {delivery.templated ? (
                                         <span
                                             className="rounded px-1.5 py-0.5 font-mono text-[9.5px] text-accent"
@@ -184,6 +186,7 @@ export function DeliveriesLog({ webhookId }: { webhookId: string }) {
                         <div className="ml-auto flex items-center gap-3.5 font-mono text-[11px]">
                             <span className="text-success">● {active.status} OK</span>
                             <span className="text-dim">{active.durationMs}ms</span>
+                            <ExpiryLabel expiresAt={active.expiresAt} />
                         </div>
                     </div>
 
@@ -301,6 +304,26 @@ export function DeliveriesLog({ webhookId }: { webhookId: string }) {
                 </div>
             )}
         </div>
+    );
+}
+
+// How long this delivery record survives before the retention sweep removes it.
+// The API sends unix seconds.
+function ExpiryLabel({ expiresAt }: { expiresAt: null | number }) {
+    if (!expiresAt) {
+        return null;
+    }
+
+    const expiry = formatExpiry(expiresAt * 1000);
+
+    return (
+        <span
+            className="font-mono text-[10px]"
+            style={{ color: expiry.expired ? 'var(--color-danger)' : 'var(--color-faint)' }}
+            title={`Delivery record removed on ${new Date(expiresAt * 1000).toLocaleString()}`}
+        >
+            {expiry.expired ? 'expired' : `expires ${expiry.text.toLowerCase()}`}
+        </span>
     );
 }
 

--- a/packages/emitsignal-website/src/lib/format.ts
+++ b/packages/emitsignal-website/src/lib/format.ts
@@ -1,1 +1,1 @@
-export { formatSize, relativeTime } from '@emitsignal/shared/format';
+export { formatExpiry, formatSize, relativeTime } from '@emitsignal/shared/format';

--- a/packages/emitsignal-website/src/routes/app/webhooks/$webhookId.tsx
+++ b/packages/emitsignal-website/src/routes/app/webhooks/$webhookId.tsx
@@ -36,7 +36,6 @@ function WebhookDeliveriesPage() {
                         </button>
                     </div>
                 }
-                subtitle="last 24h"
                 title={
                     <span className="flex items-center gap-2">
                         <Link className="text-dim no-underline hover:text-fg" to="/app/webhooks">


### PR DESCRIPTION
## Why

`WebhookDelivery` is the only unbounded table in the schema. `POST /h/:slug` writes one row per
inbound delivery holding the full raw JSON payload, and nothing ever deletes those rows except a
cascade when the parent webhook or user is deleted. Webhooks fire far more often than manual
publishes and carry much larger bodies, so the table grows without limit — and `GET /webhooks` runs
raw SQL aggregates over it on every request, so it gets slower as it grows.

Messages already solve this: `Message.expiresAt` is stamped at delivery from the owner's plan and an
hourly `purge` job sweeps expired rows. This extends the same mechanism to `WebhookDelivery` with a
much shorter window, and surfaces the expiry in the website.

Delivery history is for tracking/debugging, not archival, so **no plan keeps it forever** — unlike
messages, where Beam is `retentionDays: 0`.

| Plan | `retentionDays` (messages, unchanged) | `webhookRetentionDays` (new) |
| --- | --- | --- |
| free | 90 | **3** |
| pulse | 365 | **14** |
| beam | 0 (forever) | **30** |

## What changed

**Server**
- `PlanLimits.webhookRetentionDays` in `@emitsignal/shared`.
- `WebhookDelivery.expiresAt` + `@@index([expiresAt])`. Two migrations: the column, then a backfill
  (`createdAt + 3 days`) so rows written before the column exists are reachable by the sweep.
- `webhookDeliveryExpiresAt` / `webhookRetentionDays` in `services/billing/retention.ts`, alongside
  the message helpers. Returns `Date`, not `Date | null` — there is no "keep forever" branch.
- `receive.ts` stamps `expiresAt` at insert, reusing the plan already resolved for the message
  expiry (no extra `getUserPlan` call).
- `purgeExpired()` gains a batched delete for deliveries rather than a new `PurgeJob` kind — it is
  the same concern and already runs hourly. `expiredDeliveries` added to the sweep log line.
- `GET /webhooks/:id/deliveries` returns `expiresAt` as unix seconds; the SSE `WebhookDeliveryEvent`
  carries it too, for the CLI stream.

**Website**
- `formatExpiry` lifted out of `keys-table.tsx` into `@emitsignal/shared/format` and reused, instead
  of a second copy.
- `deliveries-log.tsx` shows `expires 3d` on the list row and in the detail pane, absolute date on
  hover, red once expired.
- The webhook detail toolbar subtitle now reads `history kept 3 days` from `useBilling()`, replacing
  the hardcoded (and already inaccurate) `"last 24h"`.

## Test plan

- `bun test` in `emitsignal-server`: 389 pass, 0 fail (7 new tests covering the per-plan windows, the
  anonymous fallback, and the stamped expiry for free vs beam owners).
- `bunx vitest run` in `emitsignal-website`: 14 pass. Note `bun test` at the repo root fails those 14
  with `document is not defined` — a pre-existing runner mismatch, unrelated to this branch.
- `bun lint` and `bun format:check` clean. `tsc --noEmit` clean on both packages (the 4 errors in
  `subscriptions/__tests__/update.spec.ts` pre-date this work).
- End-to-end against real Postgres/Redis: a live `POST /h/:slug` with a GitHub `push` payload stored
  `expiresAt` exactly 3.00 days out for a free owner; the purge worker deleted an expired delivery
  and left a live one untouched.

## Note for reviewers

A plan upgrade does not retroactively extend already-stored deliveries, since the expiry is stamped
at insert. This matches how `Message.expiresAt` already behaves.
