### PR TITLE
fix(website): trace @resvg/resvg-js into the server bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ out
 
 
 scripts/*
+.vercel

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,7 @@
 .expo
+.nitro
+.output
+.vercel
 *.lock
 **/src/generated/**
 **/routeTree.gen.ts

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,7 @@ export default [
             '**/.expo/**',
             '**/.output/**',
             '**/.tanstack/**',
+            '**/.vercel/**',
             '**/*.config.js',
             '**/*.config.mjs',
             '**/android/**',

--- a/packages/emitsignal-website/.gitignore
+++ b/packages/emitsignal-website/.gitignore
@@ -8,6 +8,7 @@ dist-ssr
 .tanstack
 .wrangler
 .output
+.vercel
 .vinxi
 __unconfig*
 todos.json

--- a/packages/emitsignal-website/vite.config.ts
+++ b/packages/emitsignal-website/vite.config.ts
@@ -17,7 +17,10 @@ const config = defineConfig({
     },
     plugins: [
         devtools(),
-        nitro({ rollupConfig: { external: [/^@sentry\//, /^@resvg\//] } }),
+        nitro({
+            rollupConfig: { external: [/^@sentry\//] },
+            traceDeps: ['@resvg/resvg-js*'],
+        }),
         tailwindcss(),
         {
             enforce: 'pre',
@@ -34,7 +37,6 @@ const config = defineConfig({
         tsconfigPaths: true,
     },
     ssr: {
-        external: ['@resvg/resvg-js'],
         noExternal: [],
     },
 });


### PR DESCRIPTION
## Problem

The website 500s on Vercel:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@resvg/resvg-js'
    imported from /var/task/_ssr/router-Bt1NnbX0.mjs
```

## Root cause

`src/routes/api/og.tsx` imports `@resvg/resvg-js`, a native NAPI module whose real binary lives in a sibling optional dep (`@resvg/resvg-js-linux-x64-gnu`) loaded through a dynamic `require()` chain.

Nitro handles this automatically — its `nitro:externals` rollup plugin marks such packages external **and** records them for `nf3` file-tracing, which copies the package plus its platform binary into `output.serverDir/node_modules`. `@resvg/resvg-js` is already in nf3's built-in native-package list, so it needs no configuration.

But `vite.config.ts` was marking it external in two places ahead of that plugin:

- `nitro({ rollupConfig: { external: [/^@resvg\//] } })`
- `ssr.external: ['@resvg/resvg-js']`

Rollup consults its own `external` option for bare specifiers *before* plugin `resolveId` hooks, so `nitro:externals` never saw the import and never traced it. The build emitted an import with nothing copied next to it.

This affected the Docker/VPS build too — it produced the same untraced external. Because the import is top-level in a shared router chunk, `/api/og` was 500-ing there as well; it just isn't a route you hit directly, so only crawlers fetching `og:image` saw it.

## Fix

Remove both manual externals and let Nitro do its job, plus an explicit `traceDeps: ['@resvg/resvg-js*']` — the trailing `*` requests a full trace so the dynamically `require`d platform binary is copied too.

Also ignores the `.vercel/` build output in ESLint, Prettier, and git (a local `VERCEL=1` build had it being linted and format-checked as source; `.output`/`.nitro` had the same gap in Prettier).

## Verification

| | Before | After |
| --- | --- | --- |
| `VERCEL=1 bun run build` | no `node_modules` in `__server.func` at all | traces `@resvg/resvg-js` + platform binary into `__server.func/node_modules/` |
| `bun run build` (node preset) + boot | — | `/api/og` → 200, valid PNG 1200×630 |
| `bun run dev` (:5002) | — | `/api/og` → 200 PNG, `/` → 200 |
| `docker compose build website` + run container | — | traces `linux-arm64-gnu`/`musl`; `/api/og` → 200 PNG |
| `bun lint` / `bun format:check` | — | clean |

Rendered OG output was visually checked, not just content-type sniffed.
