### PR TITLE
feat: verify inbound webhook signatures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,31 @@ Common TypeScript types (`Message`, `Topic`, `Subscription`, `Webhook`, etc.) an
 - Generics: descriptive names (`TResponse`, not `T`)
 - File names: kebab-case; component names: PascalCase
 
+### Comments
+
+Comment sparingly. A comment earns its place only when the code alone would let
+someone break something important — otherwise leave it out and let the code speak.
+
+Write one when, and only when:
+
+- Removing it would let a reader silently break correctness or security (e.g. why
+  webhook signatures verify against the raw body, not the re-serialized JSON).
+- Ordering or placement is load-bearing and not obvious from reading top to bottom.
+- The code looks wrong or redundant but is deliberate (a loop that intentionally
+  does not short-circuit, an early return that is safe despite appearances).
+- An external contract is being matched (a provider's wire format, a spec).
+
+Do **not** write one to:
+
+- Restate what the next line does (`// Only whether a secret exists` above
+  `hasSecret: !!secretCiphertext`).
+- Label a section, a constant, or an obviously-named function.
+- Explain where code was placed or which folder it belongs to.
+- Narrate a change, decision history, or what the code used to do.
+
+Prefer one tight line over three. If a comment needs a paragraph, the code
+probably needs a better name or a smaller function instead.
+
 ## Commit Rules
 
 Use [Conventional Commits](https://www.conventionalcommits.org/): `<prefix>: <description>`.

--- a/packages/emitsignal-cli/src/commands/webhooks.ts
+++ b/packages/emitsignal-cli/src/commands/webhooks.ts
@@ -372,7 +372,10 @@ function printDelivery(delivery: Delivery, asJson: boolean): void {
     const ch = color.fgDim((delivery.channel ?? '').padEnd(18));
     const dot = delivery.templated ? color.violet('●') : color.fgDim('○');
     const ms = color.fgFaint(`${delivery.ms}ms`.padEnd(8));
-    const status = color.green(String(delivery.status));
+    const status =
+        delivery.status >= 400
+            ? color.red(String(delivery.status))
+            : color.green(String(delivery.status));
     const time = color.fgFaint(formatTime(delivery.t * 1000));
 
     if (delivery.templated && delivery.renderedTitle) {

--- a/packages/emitsignal-cli/src/commands/webhooks.ts
+++ b/packages/emitsignal-cli/src/commands/webhooks.ts
@@ -1,6 +1,7 @@
+import type { VerificationScheme } from '@emitsignal/shared';
 import type { Command } from 'commander';
 
-import { relativeTime } from '@emitsignal/shared';
+import { defaultVerificationForSource, relativeTime } from '@emitsignal/shared';
 import { readFileSync } from 'node:fs';
 
 import { getBaseUrl, getToken } from '../config.ts';
@@ -30,6 +31,7 @@ interface Delivery {
 
 interface Webhook {
     count24h: number;
+    hasSecret?: boolean;
     id: string;
     lastDeliveryAt?: null | number;
     name: string;
@@ -38,6 +40,7 @@ interface Webhook {
     status: 'active' | 'error' | 'paused';
     templated: boolean;
     topicName: string;
+    verification?: VerificationScheme;
 }
 
 export function registerWebhooksCommand(program: Command): void {
@@ -55,6 +58,12 @@ export function registerWebhooksCommand(program: Command): void {
             'Source type (github|grafana|stripe|vercel|custom)',
             'custom',
         )
+        .option(
+            '--verification <scheme>',
+            'Verify inbound signatures (none|github|stripe|svix|hmac|token)',
+        )
+        .option('--secret <value>', 'Signing secret from the sending provider')
+        .option('--verification-config <json>', 'Header config, required for hmac and token')
         .action(async (opts) => {
             try {
                 if (!opts.channel) {
@@ -63,8 +72,10 @@ export function registerWebhooksCommand(program: Command): void {
                     process.exit(1);
                 }
 
+                const source = (opts.source as string) ?? 'custom';
+
                 const body: Record<string, string> = {
-                    source: (opts.source as string) ?? 'custom',
+                    source,
                     topicName: opts.channel as string,
                 };
 
@@ -74,6 +85,19 @@ export function registerWebhooksCommand(program: Command): void {
 
                 if (opts.template) {
                     body['template'] = readTemplateFile(opts.template as string);
+                }
+
+                if (opts.secret) {
+                    body['secret'] = opts.secret as string;
+                    // A secret with no scheme verifies the way the source normally signs.
+                    body['verification'] =
+                        (opts.verification as string) ?? defaultVerificationForSource(source);
+                } else if (opts.verification) {
+                    body['verification'] = opts.verification as string;
+                }
+
+                if (opts.verificationConfig) {
+                    body['verificationConfig'] = opts.verificationConfig as string;
                 }
 
                 const webhook = await webhookRequest<{ endpointUrl: string } & Webhook>(
@@ -97,6 +121,13 @@ export function registerWebhooksCommand(program: Command): void {
                 );
                 console.log(
                     `  template  ${webhook.templated ? color.violet('yes') : color.fgDim('no (raw passthrough)')}`,
+                );
+                console.log(
+                    `  verify    ${
+                        webhook.verification && webhook.verification !== 'none'
+                            ? color.green(webhook.verification)
+                            : color.amber('none — anyone with the URL can post')
+                    }`,
                 );
 
                 ok('webhook created — point your service at the endpoint above');

--- a/packages/emitsignal-docs/api/errors.mdx
+++ b/packages/emitsignal-docs/api/errors.mdx
@@ -17,26 +17,32 @@ Framework-level errors return a consistent envelope:
 Individual endpoints return their own machine-readable `error` codes (usually
 `{ "error": "<code>" }`, sometimes with extra fields). The ones you'll meet:
 
-| Status | Code                         | Where                                                  |
-| ------ | ---------------------------- | ------------------------------------------------------ |
-| `400`  | `missing_content`            | Publish with neither title nor body.                   |
-| `400`  | `invalid_topic_name`         | Publish/subscribe with an invalid topic name.          |
-| `400`  | `invalid_media`              | Publish with a malformed media reference.              |
-| `400`  | `invalid_mime_type`          | Attachment/avatar of a disallowed type.                |
-| `400`  | `file_too_large`             | Attachment exceeds the plan's size limit.              |
-| `400`  | `too_many_files`             | More than one file in an attachment upload.            |
-| `400`  | `at_least_one_file_required` | Attachment upload with no file.                        |
-| `400`  | `payload_too_large`          | Avatar exceeds the size limit.                         |
-| `401`  | `missing_token`              | Endpoint requires auth and none was resolved.          |
-| `401`  | `unauthorized`               | Avatar endpoints without auth.                         |
-| `403`  | `forbidden`                  | Authenticated but not the owner of the resource.       |
-| `403`  | `plan_limit_reached`         | `{ error, limit, metric, plan }` — topics or webhooks. |
-| `404`  | `topic_not_found`            | Topic doesn't exist.                                   |
-| `404`  | `message_not_found`          | Message doesn't exist.                                 |
-| `404`  | `not_found`                  | Subscription / push token / webhook doesn't exist.     |
-| `409`  | `attachment_already_exists`  | Message already has an attachment.                     |
-| `429`  | `daily_quota_exceeded`       | `{ error, limit, metric: "messages", resetAt }`.       |
-| `429`  | `too_many_sse_connections`   | `{ error, max, retryAfter: 60 }` — SSE connection cap. |
-| `503`  | `webhook_paused`             | Posting to a paused webhook receiver.                  |
+| Status | Code                          | Where                                                  |
+| ------ | ----------------------------- | ------------------------------------------------------ |
+| `400`  | `missing_content`             | Publish with neither title nor body.                   |
+| `400`  | `invalid_topic_name`          | Publish/subscribe with an invalid topic name.          |
+| `400`  | `invalid_media`               | Publish with a malformed media reference.              |
+| `400`  | `invalid_mime_type`           | Attachment/avatar of a disallowed type.                |
+| `400`  | `file_too_large`              | Attachment exceeds the plan's size limit.              |
+| `400`  | `too_many_files`              | More than one file in an attachment upload.            |
+| `400`  | `at_least_one_file_required`  | Attachment upload with no file.                        |
+| `400`  | `payload_too_large`           | Avatar exceeds the size limit.                         |
+| `400`  | `invalid_json`                | Webhook receiver body is not a JSON object.            |
+| `400`  | `missing_secret`              | Webhook verification enabled with no signing secret.   |
+| `400`  | `invalid_verification_scheme` | Unknown webhook `verification` value.                  |
+| `400`  | `invalid_verification_config` | `hmac`/`token` webhook without a usable header config. |
+| `401`  | `missing_token`               | Endpoint requires auth and none was resolved.          |
+| `401`  | `unauthorized`                | Avatar endpoints without auth.                         |
+| `401`  | `invalid_signature`           | `{ error, reason }` — webhook signature check failed.  |
+| `403`  | `forbidden`                   | Authenticated but not the owner of the resource.       |
+| `403`  | `plan_limit_reached`          | `{ error, limit, metric, plan }` — topics or webhooks. |
+| `404`  | `topic_not_found`             | Topic doesn't exist.                                   |
+| `404`  | `message_not_found`           | Message doesn't exist.                                 |
+| `404`  | `not_found`                   | Subscription / push token / webhook doesn't exist.     |
+| `409`  | `attachment_already_exists`   | Message already has an attachment.                     |
+| `413`  | `payload_too_large`           | Webhook receiver body over 64 KB.                      |
+| `429`  | `daily_quota_exceeded`        | `{ error, limit, metric: "messages", resetAt }`.       |
+| `429`  | `too_many_sse_connections`    | `{ error, max, retryAfter: 60 }` — SSE connection cap. |
+| `503`  | `webhook_paused`              | Posting to a paused webhook receiver.                  |
 
 See [Rate limits](/api/rate-limits) for the `429` cases.

--- a/packages/emitsignal-docs/api/webhooks.mdx
+++ b/packages/emitsignal-docs/api/webhooks.mdx
@@ -5,7 +5,8 @@ description: 'Turn inbound HTTP from third parties into signals, and stream deli
 
 A webhook gives you a public URL (`/h/:slug`) that turns an inbound HTTP POST — from
 Slack, GitHub, Grafana, Stripe, Vercel, or anything custom — into a signal on a topic.
-Management endpoints require authentication; the receiver is public.
+Management endpoints require authentication; the receiver is public, and should be
+given a signing secret so only your provider can post to it.
 
 ## Create a webhook
 
@@ -26,6 +27,17 @@ POST /webhooks
 <ParamField body="template" type="string | null">
     Optional template used to render incoming payloads into a message.
 </ParamField>
+<ParamField body="verification" type="string" default='"none"'>
+    One of `none`, `github`, `stripe`, `svix`, `hmac`, `token`. Anything other than `none` requires
+    a `secret`. See [Verifying the sender](#verifying-the-sender).
+</ParamField>
+<ParamField body="secret" type="string | null">
+    The signing secret issued by the sending provider. Write-only — it is encrypted at rest and
+    never returned by any endpoint.
+</ParamField>
+<ParamField body="verificationConfig" type="string | null">
+    JSON string describing the header to check. Required for `hmac` and `token`, ignored otherwise.
+</ParamField>
 
 Enforces your plan's `maxWebhooks` limit (`403 plan_limit_reached`).
 
@@ -33,6 +45,7 @@ Enforces your plan's `maxWebhooks` limit (`403 plan_limit_reached`).
 {
     "createdAt": 1790000000,
     "endpointUrl": "/h/cw_ab12cd",
+    "hasSecret": false,
     "id": "...",
     "name": "ci hook",
     "slug": "cw_ab12cd",
@@ -40,7 +53,9 @@ Enforces your plan's `maxWebhooks` limit (`403 plan_limit_reached`).
     "status": "active",
     "template": null,
     "templated": false,
-    "topicName": "ci/web"
+    "topicName": "ci/web",
+    "verification": "none",
+    "verificationConfig": null
 }
 ```
 
@@ -57,6 +72,7 @@ GET /webhooks
     {
         "count24h": 12,
         "createdAt": 1790000000,
+        "hasSecret": true,
         "id": "...",
         "lastDeliveryAt": 1790000000,
         "name": "ci hook",
@@ -65,7 +81,8 @@ GET /webhooks
         "status": "active",
         "templated": false,
         "topicName": "ci/web",
-        "updatedAt": 1790000000
+        "updatedAt": 1790000000,
+        "verification": "github"
     }
 ]
 ```
@@ -79,7 +96,13 @@ DELETE /webhooks/:id
 ```
 
 All **auth required** and ownership-gated (`404 not_found`, `403 forbidden`). `PATCH`
-accepts any of `name`, `status`, `template`, `topicName`. `DELETE` returns `204`.
+accepts any of `name`, `status`, `template`, `topicName`, `verification`, `secret`,
+`verificationConfig`. `DELETE` returns `204`.
+
+The secret is never readable — `GET` and `PATCH` return `hasSecret` and `verification`
+instead. On `PATCH`, omitting `secret` keeps the stored one, sending a new string
+rotates it, and sending `null` clears it (which also requires `verification: "none"`,
+otherwise the request fails with `400 missing_secret`).
 
 ## List deliveries
 
@@ -111,6 +134,10 @@ GET /webhooks/:id/deliveries
 ]
 ```
 
+Deliveries rejected by signature verification are recorded too, with `status` `401`, a
+null `messageId`, and a `payload` of `{ "preview", "reason", "truncated" }` holding the
+first 2 KB of the unverified body.
+
 ## Stream deliveries live
 
 ```
@@ -130,14 +157,57 @@ auth connection cap 10).
 POST /h/:slug
 ```
 
-**Public** — anyone with the slug can post any JSON body. The payload is turned into a
-message on the webhook's topic: if a `template` is set it renders title/body/priority/
-tags, otherwise a default message is built (title `"<source> delivery"`, body = pretty
-JSON, priority 3, tag `[source]`). The message fires the live bus and enqueues push.
+**Public.** With `verification: "none"` anyone who knows the slug can post any JSON
+body; with a scheme configured, the request must carry a valid signature. The payload
+is turned into a message on the webhook's topic: if a `template` is set it renders
+title/body/priority/tags, otherwise a default message is built (title
+`"<source> delivery"`, body = pretty JSON, priority 3, tag `[source]`). The message
+fires the live bus and enqueues push.
 
+- `400 invalid_json` — body is not a JSON object
+- `401 invalid_signature` — `{ error, reason }`; see below
 - `404 not_found` — unknown slug
+- `413 payload_too_large` — body over 64 KB
 - `503 webhook_paused` — the webhook's `status` is `paused`
 
 ```json
 { "messageId": "...", "ok": true }
 ```
+
+## Verifying the sender
+
+Because the receiver is public, the slug is the only thing standing between your topic
+and anyone who has seen the URL in a log or a screenshot. Setting a `secret` makes
+EmitSignal check each delivery's signature against the **raw request bytes** before
+anything is published — no message, no push, no live fanout on a failed check.
+
+| `verification` | Header(s) checked                             | Secret to paste                   |
+| -------------- | --------------------------------------------- | --------------------------------- |
+| `github`       | `X-Hub-Signature-256`                         | Repo → Settings → Webhooks secret |
+| `stripe`       | `Stripe-Signature`                            | `whsec_…` signing secret          |
+| `svix`         | `svix-id`, `svix-timestamp`, `svix-signature` | `whsec_…` (Resend, Clerk, …)      |
+| `hmac`         | Whatever `verificationConfig.header` names    | Provider's shared secret          |
+| `token`        | Whatever `verificationConfig.header` names    | The static token itself           |
+
+`stripe` and `svix` also reject deliveries whose signed timestamp is more than 5
+minutes old, so a captured request cannot be replayed indefinitely.
+
+For `hmac` and `token`, `verificationConfig` is a JSON **string**:
+
+```json
+{
+    "algorithm": "sha1",
+    "encoding": "hex",
+    "header": "x-vercel-signature",
+    "prefix": ""
+}
+```
+
+`algorithm` is one of `sha1`, `sha256` (default), `sha512`; `encoding` is `hex`
+(default) or `base64`; `prefix` is stripped from the header value before comparison
+(e.g. `"sha256="` or `"Bearer "`). `token` uses only `header` and `prefix` — the header
+carries the secret itself rather than a signature.
+
+A rejected delivery returns `401` with a `reason` of `missing_signature`,
+`bad_signature`, `stale_timestamp`, or `bad_config`, and is recorded in the delivery
+log so you can see it in [the live stream](#stream-deliveries-live).

--- a/packages/emitsignal-docs/cli/webhooks.mdx
+++ b/packages/emitsignal-docs/cli/webhooks.mdx
@@ -13,7 +13,8 @@ Every webhook endpoint gets a public URL — `https://api.emitsignal.com/h/<slug
 Point any service that speaks webhooks at it, and each inbound `POST` is published
 to a topic (channel) and fans out to your subscribers in real time. Attach an
 optional template to turn a provider's raw payload into a clean title and body,
-or leave it off to forward the payload untouched.
+or leave it off to forward the payload untouched. Pass `--secret` so only your
+provider can post to the endpoint.
 
 ## Subcommands
 
@@ -50,13 +51,35 @@ or leave it off to forward the payload untouched.
     Path to a [template file](#templates). Omit for raw passthrough.
 </ParamField>
 
+<ParamField body="--secret" type="string">
+    Signing secret issued by the sending provider. Setting it turns on signature verification — see
+    [Verifying the sender](#verifying-the-sender).
+</ParamField>
+
+<ParamField
+    body="--verification"
+    type="none | github | stripe | svix | hmac | token"
+    default="matches --source"
+>
+    Signature scheme to enforce. Defaults to whatever the chosen `--source` normally signs with —
+    `github`, `stripe`, and `svix` need nothing more than `--secret`. `grafana` and `vercel` infer
+    `token` and `hmac`, which also need `--verification-config`.
+</ParamField>
+
+<ParamField body="--verification-config" type="json">
+    Header config for `hmac` and `token`, e.g.
+    `'{"header":"x-vercel-signature","algorithm":"sha1"}'`.
+</ParamField>
+
 <ParamField body="--json" type="flag">
     Machine-readable output — includes the endpoint `id` and full URL.
 </ParamField>
 
 <Term title="emitsignal — zsh">
-    <Cmt># create an endpoint for GitHub, publishing to ci/deploys</Cmt>
-    <Cmd wrap>emitsignal webhooks create -n deploy-hook -s github -c ci/deploys</Cmd>
+    <Cmt># create a verified endpoint for GitHub, publishing to ci/deploys</Cmt>
+    <Cmd wrap>
+        emitsignal webhooks create -n deploy-hook -s github -c ci/deploys --secret $GH_HOOK_SECRET
+    </Cmd>
     <Out color="#f7f7f8">
         &nbsp;&nbsp;id&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; clx8f2a0b00deploy01
     </Out>
@@ -68,8 +91,37 @@ or leave it off to forward the payload untouched.
         <span style={{ color: '#fbbf24' }}>/h/gh_a1b2c3d</span>
     </Out>
     <Out color="#71717a">&nbsp;&nbsp;template&nbsp; no (raw passthrough)</Out>
+    <Out>
+        &nbsp;&nbsp;verify&nbsp;&nbsp;&nbsp;&nbsp;
+        <span style={{ color: '#4ade80' }}>github</span>
+    </Out>
     <Ok>webhook created — point your service at the endpoint above</Ok>
 </Term>
+
+## Verifying the sender
+
+The `/h/<slug>` URL is public, so without a secret anyone who has seen it in a log
+can publish to your channel. Pass `--secret` and each delivery's signature is checked
+against the raw request body before anything is published; failures are rejected with
+`401` and show up in `webhooks listen` with a red status and the reason in place of the
+payload.
+
+<Term title="emitsignal — zsh">
+    <Cmt># scheme inferred from --source</Cmt>
+    <Cmd wrap>emitsignal webhooks create -s stripe -c billing/stripe --secret whsec_9f2ac41e</Cmd>
+    <Sp />
+    <Cmt># a provider we don't special-case: name the header yourself</Cmt>
+    <Cmd wrap>
+        emitsignal webhooks create -s vercel -c ci/deploys --secret $VERCEL_SECRET --verification
+        hmac --verification-config '&#123;"header":"x-vercel-signature","algorithm":"sha1"&#125;'
+    </Cmd>
+</Term>
+
+<Note>
+    The secret is write-only. It is encrypted at rest and never returned by the API — `--json`
+    output carries only `verification` and a `hasSecret` boolean. Keep your own copy at the
+    provider.
+</Note>
 
 ## List endpoints
 
@@ -130,6 +182,11 @@ inline snippet of the payload.
     </Out>
     <Out color="#f7f7f8">
         {'21:04:02  ●  billing/stripe    200  18ms    Payment succeeded · inv_8842 · $42.00'}
+    </Out>
+    <Out color="#f7f7f8">
+        {'21:04:40  ○  ci/deploys        '}
+        <span style={{ color: '#f87171' }}>401</span>
+        {'  2ms     raw → {"reason":"bad_signature",…}'}
     </Out>
     <Sp />
     <Cmt># or follow a single source</Cmt>

--- a/packages/emitsignal-docs/cli/webhooks.mdx
+++ b/packages/emitsignal-docs/cli/webhooks.mdx
@@ -108,7 +108,9 @@ payload.
 
 <Term title="emitsignal — zsh">
     <Cmt># scheme inferred from --source</Cmt>
-    <Cmd wrap>emitsignal webhooks create -s stripe -c billing/stripe --secret whsec_9f2ac41e</Cmd>
+    <Cmd wrap>
+        emitsignal webhooks create -s stripe -c billing/stripe --secret $STRIPE_WEBHOOK_SECRET
+    </Cmd>
     <Sp />
     <Cmt># a provider we don't special-case: name the header yourself</Cmt>
     <Cmd wrap>

--- a/packages/emitsignal-server/prisma/migrations/20260809120000_webhook_signing_secrets/migration.sql
+++ b/packages/emitsignal-server/prisma/migrations/20260809120000_webhook_signing_secrets/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "Webhook" ADD COLUMN     "secretCiphertext" TEXT,
+ADD COLUMN     "verification" TEXT NOT NULL DEFAULT 'none',
+ADD COLUMN     "verificationConfig" TEXT;

--- a/packages/emitsignal-server/prisma/schema.prisma
+++ b/packages/emitsignal-server/prisma/schema.prisma
@@ -324,6 +324,10 @@ model Webhook {
     topicName String
     userId    String
 
+    secretCiphertext   String?
+    verification       String  @default("none")
+    verificationConfig String?
+
     deliveries WebhookDelivery[]
     user       User              @relation(fields: [userId], references: [id], onDelete: Cascade)
 

--- a/packages/emitsignal-server/src/http/webhooks/__tests__/create.spec.ts
+++ b/packages/emitsignal-server/src/http/webhooks/__tests__/create.spec.ts
@@ -138,3 +138,109 @@ describe('POST /webhooks', () => {
         });
     });
 });
+
+describe('POST /webhooks signing secrets', () => {
+    const app = new Elysia().use(createWebhook);
+
+    function request(body: Record<string, unknown>) {
+        return new Request('http://localhost/webhooks', {
+            body: JSON.stringify({ topicName: 'deploys', ...body }),
+            headers: { 'Content-Type': 'application/json', 'x-test-user-id': 'user-1' },
+            method: 'POST',
+        });
+    }
+
+    function storedData(): Record<string, unknown> {
+        const calls = prismaMock.webhook.create.mock.calls;
+        const lastCall = calls[calls.length - 1] as unknown as [{ data: Record<string, unknown> }];
+
+        return lastCall[0].data;
+    }
+
+    beforeEach(() => {
+        resetUserPlansForTests();
+        setUserPlanForTests('user-1', 'free');
+        prismaMock.webhook.count.mockReset();
+        prismaMock.webhook.count.mockResolvedValue(0);
+        prismaMock.webhook.create.mockClear();
+        prismaMock.topic.findUnique.mockResolvedValue(null);
+    });
+
+    it('defaults to no verification when the fields are omitted', async () => {
+        const res = await app.handle(request({}));
+
+        expect(res.status).toBe(200);
+        expect(storedData().verification).toBe('none');
+        expect(storedData().secretCiphertext).toBeNull();
+        expect((await res.json()).hasSecret).toBe(false);
+    });
+
+    it('encrypts the secret and never returns it', async () => {
+        const res = await app.handle(
+            request({ secret: 'super-secret-value', source: 'github', verification: 'github' }),
+        );
+
+        expect(res.status).toBe(200);
+
+        const stored = storedData().secretCiphertext as string;
+
+        expect(stored).toStartWith('v1.');
+        expect(stored).not.toContain('super-secret-value');
+
+        const payload = await res.json();
+
+        expect(payload.hasSecret).toBe(true);
+        expect(JSON.stringify(payload)).not.toContain('super-secret-value');
+        expect(payload.secret).toBeUndefined();
+        expect(payload.secretCiphertext).toBeUndefined();
+    });
+
+    it('rejects a verified webhook with no secret', async () => {
+        const res = await app.handle(request({ verification: 'github' }));
+
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toBe('missing_secret');
+        expect(prismaMock.webhook.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unknown verification scheme', async () => {
+        const res = await app.handle(request({ secret: 'x', verification: 'paypal' }));
+
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toBe('invalid_verification_scheme');
+    });
+
+    it('rejects an hmac webhook without a usable config', async () => {
+        const res = await app.handle(request({ secret: 'x', verification: 'hmac' }));
+
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toBe('invalid_verification_config');
+    });
+
+    it('stores the config for an hmac webhook', async () => {
+        const verificationConfig = JSON.stringify({
+            algorithm: 'sha256',
+            header: 'x-signature',
+        });
+
+        const res = await app.handle(
+            request({ secret: 'x', verification: 'hmac', verificationConfig }),
+        );
+
+        expect(res.status).toBe(200);
+        expect(storedData().verificationConfig).toBe(verificationConfig);
+    });
+
+    it('drops a config that the chosen scheme does not use', async () => {
+        const res = await app.handle(
+            request({
+                secret: 'x',
+                verification: 'github',
+                verificationConfig: JSON.stringify({ header: 'x-signature' }),
+            }),
+        );
+
+        expect(res.status).toBe(200);
+        expect(storedData().verificationConfig).toBeNull();
+    });
+});

--- a/packages/emitsignal-server/src/http/webhooks/__tests__/receive.spec.ts
+++ b/packages/emitsignal-server/src/http/webhooks/__tests__/receive.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
 import { Elysia } from 'elysia';
+import { createHmac } from 'node:crypto';
 
 import { prismaMock } from '#/__tests__/mocks';
 
@@ -20,6 +21,7 @@ mock.module('#/http/auth/plugin', () => ({
 }));
 
 import { receiveWebhook } from '#/http/webhooks/receive';
+import { encryptSecret } from '#/lib/crypto/secret-box';
 import { resetUserPlansForTests, setUserPlanForTests } from '#/services/billing/get-user-plan';
 import { duration } from '#/utils/duration';
 
@@ -33,11 +35,14 @@ describe('POST /h/:slug link → view action', () => {
     function withTemplate(template: Record<string, string>) {
         prismaMock.webhook.findUnique.mockResolvedValue({
             id: 'wh-1',
+            secretCiphertext: null,
             source: 'custom',
             status: 'active',
             template: JSON.stringify(template),
             topicName: 'deploys',
             userId: null,
+            verification: 'none',
+            verificationConfig: null,
         });
     }
 
@@ -108,11 +113,14 @@ describe('POST /h/:slug link → view action', () => {
     it('stores no action when the template has no link at all', async () => {
         prismaMock.webhook.findUnique.mockResolvedValue({
             id: 'wh-1',
+            secretCiphertext: null,
             source: 'custom',
             status: 'active',
             template: JSON.stringify({ title: '{{event.name}}' }),
             topicName: 'deploys',
             userId: null,
+            verification: 'none',
+            verificationConfig: null,
         });
 
         const res = await app.handle(request({ event: { name: 'deploy' } }));
@@ -124,11 +132,14 @@ describe('POST /h/:slug link → view action', () => {
     it('stores no action for an untemplated passthrough delivery', async () => {
         prismaMock.webhook.findUnique.mockResolvedValue({
             id: 'wh-1',
+            secretCiphertext: null,
             source: 'custom',
             status: 'active',
             template: null,
             topicName: 'deploys',
             userId: null,
+            verification: 'none',
+            verificationConfig: null,
         });
 
         const res = await app.handle(request({ event: { name: 'deploy' } }));
@@ -216,11 +227,14 @@ describe('POST /h/:slug delivery retention', () => {
     function withOwner(userId: null | string) {
         prismaMock.webhook.findUnique.mockResolvedValue({
             id: 'wh-1',
+            secretCiphertext: null,
             source: 'custom',
             status: 'active',
             template: null,
             topicName: 'deploys',
             userId,
+            verification: 'none',
+            verificationConfig: null,
         });
     }
 
@@ -259,5 +273,190 @@ describe('POST /h/:slug delivery retention', () => {
         await app.handle(request());
 
         expect(storedExpiryDays()).toBe(3);
+    });
+});
+
+describe('POST /h/:slug signature verification', () => {
+    const app = new Elysia().use(receiveWebhook);
+
+    const SECRET = 'a-github-webhook-secret';
+    const PAYLOAD = { action: 'opened', number: 7 };
+    const RAW_BODY = JSON.stringify(PAYLOAD);
+
+    function githubSignature(body: string, secret: string): string {
+        return `sha256=${createHmac('sha256', secret).update(body, 'utf8').digest('hex')}`;
+    }
+
+    function withVerification(verification: string, secret: null | string) {
+        prismaMock.webhook.findUnique.mockResolvedValue({
+            id: 'wh-1',
+            secretCiphertext: secret ? encryptSecret(secret) : null,
+            source: 'github',
+            status: 'active',
+            template: null,
+            topicName: 'deploys',
+            userId: 'user-free',
+            verification,
+            verificationConfig: null,
+        });
+    }
+
+    function request(headers: Record<string, string> = {}, body = RAW_BODY) {
+        return new Request('http://localhost/h/gh_abc1234', {
+            body,
+            headers: { 'Content-Type': 'application/json', ...headers },
+            method: 'POST',
+        });
+    }
+
+    function storedDelivery(): Record<string, unknown> {
+        const calls = prismaMock.webhookDelivery.create.mock.calls;
+        const lastCall = calls[calls.length - 1] as unknown as [{ data: Record<string, unknown> }];
+
+        return lastCall[0].data;
+    }
+
+    beforeEach(() => {
+        resetUserPlansForTests();
+        setUserPlanForTests('user-free', 'free');
+        prismaMock.message.create.mockClear();
+        prismaMock.webhookDelivery.create.mockClear();
+        mockBus.publish.mockClear();
+        mockBus.publishWebhookDelivery.mockClear();
+        mockPushQueue.add.mockClear();
+        prismaMock.topic.findUnique.mockResolvedValue({
+            displayName: 'deploys',
+            id: 'topic-1',
+            name: 'deploys',
+        });
+    });
+
+    it('accepts a correctly signed delivery and publishes it', async () => {
+        withVerification('github', SECRET);
+
+        const res = await app.handle(
+            request({ 'x-hub-signature-256': githubSignature(RAW_BODY, SECRET) }),
+        );
+
+        expect(res.status).toBe(200);
+        expect(prismaMock.message.create).toHaveBeenCalled();
+        expect(mockBus.publish).toHaveBeenCalled();
+        expect(mockPushQueue.add).toHaveBeenCalled();
+        expect(storedDelivery().status).toBe(200);
+    });
+
+    it('rejects a delivery signed with the wrong secret without publishing anything', async () => {
+        withVerification('github', SECRET);
+
+        const res = await app.handle(
+            request({ 'x-hub-signature-256': githubSignature(RAW_BODY, 'not-the-secret') }),
+        );
+
+        expect(res.status).toBe(401);
+        await expect(res.json()).resolves.toEqual({
+            error: 'invalid_signature',
+            reason: 'bad_signature',
+        });
+        expect(prismaMock.message.create).not.toHaveBeenCalled();
+        expect(mockBus.publish).not.toHaveBeenCalled();
+        expect(mockPushQueue.add).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unsigned delivery to a verified webhook', async () => {
+        withVerification('github', SECRET);
+
+        const res = await app.handle(request());
+
+        expect(res.status).toBe(401);
+        await expect(res.json()).resolves.toEqual({
+            error: 'invalid_signature',
+            reason: 'missing_signature',
+        });
+        expect(prismaMock.message.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects a body altered after it was signed', async () => {
+        withVerification('github', SECRET);
+
+        const res = await app.handle(
+            request(
+                { 'x-hub-signature-256': githubSignature(RAW_BODY, SECRET) },
+                JSON.stringify({ action: 'closed', number: 7 }),
+            ),
+        );
+
+        expect(res.status).toBe(401);
+        expect(prismaMock.message.create).not.toHaveBeenCalled();
+    });
+
+    it('logs the rejection as a 401 delivery with a truncated payload', async () => {
+        withVerification('github', SECRET);
+
+        await app.handle(request());
+
+        const delivery = storedDelivery();
+
+        expect(delivery.status).toBe(401);
+        expect(delivery.messageId).toBeNull();
+        expect(delivery.templated).toBe(false);
+        expect(JSON.parse(delivery.payload as string)).toEqual({
+            preview: RAW_BODY,
+            reason: 'missing_signature',
+            truncated: false,
+        });
+        expect(mockBus.publishWebhookDelivery).toHaveBeenCalled();
+    });
+
+    it('rejects when verification is on but no secret is stored', async () => {
+        withVerification('github', null);
+
+        const res = await app.handle(
+            request({ 'x-hub-signature-256': githubSignature(RAW_BODY, SECRET) }),
+        );
+
+        expect(res.status).toBe(401);
+        await expect(res.json()).resolves.toEqual({
+            error: 'invalid_signature',
+            reason: 'bad_config',
+        });
+    });
+
+    it('rejects an unrecognized scheme rather than letting the delivery through', async () => {
+        withVerification('paypal', SECRET);
+
+        const res = await app.handle(request());
+
+        expect(res.status).toBe(401);
+        expect(prismaMock.message.create).not.toHaveBeenCalled();
+    });
+
+    it('leaves unverified webhooks working exactly as before', async () => {
+        withVerification('none', null);
+
+        const res = await app.handle(request());
+
+        expect(res.status).toBe(200);
+        expect(prismaMock.message.create).toHaveBeenCalled();
+    });
+
+    it('rejects a malformed JSON body with 400', async () => {
+        withVerification('none', null);
+
+        const res = await app.handle(request({}, '{not-json'));
+
+        expect(res.status).toBe(400);
+        await expect(res.json()).resolves.toEqual({ error: 'invalid_json' });
+        expect(prismaMock.message.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects a body over the size cap even when content-length lies', async () => {
+        withVerification('none', null);
+
+        const res = await app.handle(
+            request({ 'content-length': '10' }, JSON.stringify({ blob: 'x'.repeat(70_000) })),
+        );
+
+        expect(res.status).toBe(413);
+        expect(prismaMock.message.create).not.toHaveBeenCalled();
     });
 });

--- a/packages/emitsignal-server/src/http/webhooks/create.ts
+++ b/packages/emitsignal-server/src/http/webhooks/create.ts
@@ -84,7 +84,6 @@ export const createWebhook = new Elysia().post(
                     ? (body.verificationConfig ?? null)
                     : null,
             },
-            // secretCiphertext is deliberately absent: the secret is write-only.
             select: {
                 createdAt: true,
                 id: true,

--- a/packages/emitsignal-server/src/http/webhooks/create.ts
+++ b/packages/emitsignal-server/src/http/webhooks/create.ts
@@ -1,10 +1,16 @@
 import Elysia, { t } from 'elysia';
 
 import { resolveUserId } from '#/http/auth/plugin';
+import {
+    validateVerificationBody,
+    verificationBodySchema,
+} from '#/http/webhooks/verification-input';
+import { encryptSecret } from '#/lib/crypto/secret-box';
 import { prisma } from '#/lib/prisma';
 import { getUserPlan } from '#/services/billing/get-user-plan';
 import { PLANS } from '#/services/billing/plans';
 import { canPublishToTopicName } from '#/services/topic-access';
+import { schemeNeedsConfig } from '#/utils/webhook-signature';
 
 function randomSlug(prefix: string): string {
     const alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789';
@@ -55,18 +61,30 @@ export const createWebhook = new Elysia().post(
             });
         }
 
+        const verification = validateVerificationBody(body, false);
+
+        if ('error' in verification) {
+            return status(400, { error: verification.error });
+        }
+
         const prefix = SOURCE_PREFIX[body.source ?? 'custom'] ?? 'cw';
         const slug = randomSlug(prefix);
 
         const webhook = await prisma.webhook.create({
             data: {
                 name: body.name || `${body.source ?? 'custom'} webhook`,
+                secretCiphertext: body.secret ? encryptSecret(body.secret) : null,
                 slug,
                 source: body.source ?? 'custom',
                 template: body.template ?? null,
                 topicName: body.topicName,
                 userId,
+                verification: verification.scheme,
+                verificationConfig: schemeNeedsConfig(verification.scheme)
+                    ? (body.verificationConfig ?? null)
+                    : null,
             },
+            // secretCiphertext is deliberately absent: the secret is write-only.
             select: {
                 createdAt: true,
                 id: true,
@@ -76,6 +94,8 @@ export const createWebhook = new Elysia().post(
                 status: true,
                 template: true,
                 topicName: true,
+                verification: true,
+                verificationConfig: true,
             },
         });
 
@@ -83,6 +103,7 @@ export const createWebhook = new Elysia().post(
             ...webhook,
             createdAt: Math.floor(webhook.createdAt.getTime() / 1000),
             endpointUrl: `/h/${webhook.slug}`,
+            hasSecret: !!body.secret,
             templated: !!webhook.template,
         };
     },
@@ -92,6 +113,7 @@ export const createWebhook = new Elysia().post(
             source: t.Optional(t.String({ default: 'custom' })),
             template: t.Optional(t.Nullable(t.String())),
             topicName: t.String(),
+            ...verificationBodySchema,
         }),
     },
 );

--- a/packages/emitsignal-server/src/http/webhooks/get.ts
+++ b/packages/emitsignal-server/src/http/webhooks/get.ts
@@ -16,6 +16,7 @@ export const getWebhook = new Elysia().get('/webhooks/:id', async ({ headers, pa
             createdAt: true,
             id: true,
             name: true,
+            secretCiphertext: true,
             slug: true,
             source: true,
             status: true,
@@ -23,6 +24,8 @@ export const getWebhook = new Elysia().get('/webhooks/:id', async ({ headers, pa
             topicName: true,
             updatedAt: true,
             userId: true,
+            verification: true,
+            verificationConfig: true,
         },
         where: { id: params.id },
     });
@@ -51,6 +54,7 @@ export const getWebhook = new Elysia().get('/webhooks/:id', async ({ headers, pa
     return {
         count24h,
         createdAt: Math.floor(webhook.createdAt.getTime() / 1000),
+        hasSecret: !!webhook.secretCiphertext,
         id: webhook.id,
         lastDeliveryAt: lastDelivery ? Math.floor(lastDelivery.createdAt.getTime() / 1000) : null,
         name: webhook.name,
@@ -61,5 +65,7 @@ export const getWebhook = new Elysia().get('/webhooks/:id', async ({ headers, pa
         templated: !!webhook.template,
         topicName: webhook.topicName,
         updatedAt: Math.floor(webhook.updatedAt.getTime() / 1000),
+        verification: webhook.verification,
+        verificationConfig: webhook.verificationConfig,
     };
 });

--- a/packages/emitsignal-server/src/http/webhooks/list.ts
+++ b/packages/emitsignal-server/src/http/webhooks/list.ts
@@ -19,12 +19,14 @@ export const listWebhooks = new Elysia().get('/webhooks', async ({ headers, stat
             createdAt: true,
             id: true,
             name: true,
+            secretCiphertext: true,
             slug: true,
             source: true,
             status: true,
             template: true,
             topicName: true,
             updatedAt: true,
+            verification: true,
         },
         where: { userId },
     });
@@ -63,6 +65,7 @@ export const listWebhooks = new Elysia().get('/webhooks', async ({ headers, stat
         return {
             count24h: countByWebhookId.get(webhook.id) ?? 0,
             createdAt: Math.floor(webhook.createdAt.getTime() / 1000),
+            hasSecret: !!webhook.secretCiphertext,
             id: webhook.id,
             lastDeliveryAt: lastDeliveryAt ? Math.floor(lastDeliveryAt.getTime() / 1000) : null,
             name: webhook.name,
@@ -72,6 +75,7 @@ export const listWebhooks = new Elysia().get('/webhooks', async ({ headers, stat
             templated: !!webhook.template,
             topicName: webhook.topicName,
             updatedAt: Math.floor(webhook.updatedAt.getTime() / 1000),
+            verification: webhook.verification,
         };
     });
 });

--- a/packages/emitsignal-server/src/http/webhooks/receive.ts
+++ b/packages/emitsignal-server/src/http/webhooks/receive.ts
@@ -5,7 +5,9 @@ import type { Action } from '#/utils/actions';
 
 import { resolveUserId } from '#/http/auth/plugin';
 import { consumeLimit } from '#/http/plugins/rate-limit-plugin';
+import { decryptSecret } from '#/lib/crypto/secret-box';
 import { bus } from '#/lib/event-bus';
+import { logger } from '#/lib/logger';
 import { prisma } from '#/lib/prisma';
 import { pushQueue } from '#/lib/queue';
 import { webhookReceiveLimiter } from '#/lib/rate-limit';
@@ -20,30 +22,45 @@ import { serializeMessage } from '#/services/message';
 import { getOrCreateTopic } from '#/services/topic';
 import { canPublishToTopicName } from '#/services/topic-access';
 import { validateActions } from '#/utils/actions';
+import {
+    isVerificationScheme,
+    type VerificationFailureReason,
+    verifyWebhookSignature,
+} from '#/utils/webhook-signature';
 
 // Public endpoint: cap the inbound payload so a single caller can't store huge
 // WebhookDelivery rows or exhaust memory. 64 KB is generous for webhook JSON.
 const MAX_WEBHOOK_BODY_BYTES = 64 * 1024;
 
+const REJECTED_PAYLOAD_PREVIEW_BYTES = 2 * 1024;
+
+// Signatures cover the exact bytes that were sent: re-serializing the parsed JSON
+// does not reproduce them, so the raw text has to survive parsing.
+const rawBodyByRequest = new WeakMap<Request, string>();
+
 export const receiveWebhook = new Elysia().post(
     '/h/:slug',
-    async ({ body, headers, params, status }) => {
+    async ({ headers, params, request, status }) => {
         const start = Date.now();
 
-        const contentLength = Number(headers['content-length'] ?? 0);
+        const rawBody = rawBodyByRequest.get(request) ?? '';
 
-        if (Number.isFinite(contentLength) && contentLength > MAX_WEBHOOK_BODY_BYTES) {
+        // content-length is caller-controlled and absent on chunked requests.
+        if (Buffer.byteLength(rawBody, 'utf8') > MAX_WEBHOOK_BODY_BYTES) {
             return status(413, { error: 'payload_too_large' });
         }
 
         const webhook = await prisma.webhook.findUnique({
             select: {
                 id: true,
+                secretCiphertext: true,
                 source: true,
                 status: true,
                 template: true,
                 topicName: true,
                 userId: true,
+                verification: true,
+                verificationConfig: true,
             },
             where: { slug: params.slug },
         });
@@ -56,11 +73,26 @@ export const receiveWebhook = new Elysia().post(
             return status(503, { error: 'webhook_paused' });
         }
 
+        // Must stay ahead of topic creation, message, push and bus fanout — an
+        // unsigned request may not cause any observable side effect.
+        const failure = verifyDelivery(webhook, headers, rawBody);
+
+        if (failure) {
+            await recordRejectedDelivery(webhook, rawBody, failure, Date.now() - start);
+
+            return status(401, { error: 'invalid_signature', reason: failure });
+        }
+
         if (!(await canPublishToTopicName(webhook.topicName, webhook.userId ?? null))) {
             return status(403, { error: 'forbidden' });
         }
 
-        const payload = body as Record<string, unknown>;
+        const payload = parseJsonPayload(rawBody);
+
+        if (!payload) {
+            return status(400, { error: 'invalid_json' });
+        }
+
         const template = parseTemplate(webhook.template);
         const templated = !!template;
 
@@ -165,8 +197,121 @@ export const receiveWebhook = new Elysia().post(
         beforeHandle: ({ params, set }) =>
             consumeLimit(webhookReceiveLimiter, `webhook:${params.slug}`, set),
         body: t.Unknown(),
+        // Elysia's default parser consumes the stream and only returns the parsed
+        // object; size and syntax are checked in the handler instead.
+        parse: [
+            async ({ request }) => {
+                rawBodyByRequest.set(request, await request.text());
+
+                return {};
+            },
+        ],
     },
 );
+
+function parseJsonPayload(rawBody: string): null | Record<string, unknown> {
+    if (!rawBody.trim()) {
+        return {};
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(rawBody);
+
+        if (!parsed || typeof parsed !== 'object') {
+            return null;
+        }
+
+        return parsed as Record<string, unknown>;
+    } catch {
+        return null;
+    }
+}
+
+async function recordRejectedDelivery(
+    webhook: { id: string; source: string; topicName: string; userId: string },
+    rawBody: string,
+    reason: VerificationFailureReason,
+    ms: number,
+): Promise<void> {
+    const rejectedAt = new Date();
+    const plan = webhook.userId ? await getUserPlan(webhook.userId) : null;
+    const expiresAt = webhookDeliveryExpiresAt(rejectedAt, webhookRetentionDays(plan));
+
+    // The body is unauthenticated — keep a debuggable slice, not the whole blob.
+    const payload = {
+        preview: rawBody.slice(0, REJECTED_PAYLOAD_PREVIEW_BYTES),
+        reason,
+        truncated: rawBody.length > REJECTED_PAYLOAD_PREVIEW_BYTES,
+    };
+
+    const delivery = await prisma.webhookDelivery.create({
+        data: {
+            expiresAt,
+            messageId: null,
+            ms,
+            payload: JSON.stringify(payload),
+            status: 401,
+            templated: false,
+            webhookId: webhook.id,
+        },
+        select: { createdAt: true, id: true },
+    });
+
+    bus.publishWebhookDelivery(webhook.userId, {
+        channel: webhook.topicName,
+        expiresAt: Math.floor(expiresAt.getTime() / 1000),
+        id: delivery.id,
+        ms,
+        payload,
+        source: webhook.source,
+        status: 401,
+        t: Math.floor(delivery.createdAt.getTime() / 1000),
+        templated: false,
+    });
+}
+
+// Returns null when the delivery is authentic, otherwise the failure reason.
+function verifyDelivery(
+    webhook: {
+        secretCiphertext: null | string;
+        verification: string;
+        verificationConfig: null | string;
+    },
+    headers: Record<string, string | undefined>,
+    rawBody: string,
+): null | VerificationFailureReason {
+    if (webhook.verification === 'none') {
+        return null;
+    }
+
+    if (!isVerificationScheme(webhook.verification) || !webhook.secretCiphertext) {
+        return 'bad_config';
+    }
+
+    let secret: string;
+
+    try {
+        secret = decryptSecret(webhook.secretCiphertext);
+    } catch (error) {
+        // Almost always a rotated WEBHOOK_SECRET_KEY, which the 401 alone hides.
+        logger.error(
+            { error, verification: webhook.verification },
+            'webhook secret decrypt failed',
+        );
+
+        return 'bad_config';
+    }
+
+    const result = verifyWebhookSignature({
+        config: webhook.verificationConfig,
+        headers,
+        rawBody,
+        scheme: webhook.verification,
+        secret,
+    });
+
+    return result.ok ? null : result.reason;
+}
 
 // The rendered link comes from the caller's payload on a public endpoint, so it
 // is untrusted: run it through the same validator `POST /topic/:name` uses so

--- a/packages/emitsignal-server/src/http/webhooks/update.ts
+++ b/packages/emitsignal-server/src/http/webhooks/update.ts
@@ -1,8 +1,14 @@
 import Elysia, { t } from 'elysia';
 
 import { resolveUserId } from '#/http/auth/plugin';
+import {
+    validateVerificationBody,
+    verificationBodySchema,
+} from '#/http/webhooks/verification-input';
+import { encryptSecret } from '#/lib/crypto/secret-box';
 import { prisma } from '#/lib/prisma';
 import { canPublishToTopicName } from '#/services/topic-access';
+import { schemeNeedsConfig } from '#/utils/webhook-signature';
 
 export const updateWebhook = new Elysia().patch(
     '/webhooks/:id',
@@ -14,7 +20,7 @@ export const updateWebhook = new Elysia().patch(
         }
 
         const webhook = await prisma.webhook.findUnique({
-            select: { userId: true },
+            select: { secretCiphertext: true, userId: true, verification: true },
             where: { id: params.id },
         });
 
@@ -36,26 +42,66 @@ export const updateWebhook = new Elysia().patch(
             });
         }
 
+        // A rename must not silently drop an existing secret.
+        const touchesVerification =
+            body.secret !== undefined ||
+            body.verification !== undefined ||
+            body.verificationConfig !== undefined;
+
+        let verificationData: Record<string, null | string> = {};
+
+        if (touchesVerification) {
+            const validation = validateVerificationBody(
+                { ...body, verification: body.verification ?? webhook.verification },
+                !!webhook.secretCiphertext,
+            );
+
+            if ('error' in validation) {
+                return status(400, { error: validation.error });
+            }
+
+            const clearing = validation.scheme === 'none' || body.secret === null;
+
+            verificationData = {
+                verification: validation.scheme,
+                verificationConfig: schemeNeedsConfig(validation.scheme)
+                    ? (body.verificationConfig ?? null)
+                    : null,
+            };
+
+            if (body.secret) {
+                verificationData.secretCiphertext = encryptSecret(body.secret);
+            } else if (clearing) {
+                verificationData.secretCiphertext = null;
+            }
+        }
+
         const updated = await prisma.webhook.update({
             data: {
                 name: body.name ?? undefined,
                 status: body.status ?? undefined,
                 template: body.template !== undefined ? body.template : undefined,
                 topicName: body.topicName ?? undefined,
+                ...verificationData,
             },
             select: {
                 id: true,
                 name: true,
+                secretCiphertext: true,
                 slug: true,
                 source: true,
                 status: true,
                 template: true,
                 topicName: true,
+                verification: true,
+                verificationConfig: true,
             },
             where: { id: params.id },
         });
 
-        return { ...updated, templated: !!updated.template };
+        const { secretCiphertext, ...safe } = updated;
+
+        return { ...safe, hasSecret: !!secretCiphertext, templated: !!updated.template };
     },
     {
         body: t.Object({
@@ -63,6 +109,7 @@ export const updateWebhook = new Elysia().patch(
             status: t.Optional(t.String()),
             template: t.Optional(t.Nullable(t.String())),
             topicName: t.Optional(t.String()),
+            ...verificationBodySchema,
         }),
         params: t.Object({ id: t.String() }),
     },

--- a/packages/emitsignal-server/src/http/webhooks/verification-input.ts
+++ b/packages/emitsignal-server/src/http/webhooks/verification-input.ts
@@ -1,0 +1,57 @@
+import { t } from 'elysia';
+
+import {
+    isVerificationScheme,
+    parseVerificationConfig,
+    schemeNeedsConfig,
+    type VerificationScheme,
+} from '#/utils/webhook-signature';
+
+export const verificationBodySchema = {
+    secret: t.Optional(t.Nullable(t.String({ maxLength: 512, minLength: 1 }))),
+    verification: t.Optional(t.String({ maxLength: 32 })),
+    verificationConfig: t.Optional(t.Nullable(t.String({ maxLength: 1024 }))),
+};
+
+export interface VerificationBody {
+    secret?: null | string;
+    verification?: string;
+    verificationConfig?: null | string;
+}
+
+export type VerificationValidation =
+    | { error: 'invalid_verification_config' | 'invalid_verification_scheme' | 'missing_secret' }
+    | { ok: true; scheme: VerificationScheme };
+
+/**
+ * Validates a create/update request's verification fields.
+ *
+ * `hasStoredSecret` lets an update change the scheme or config without
+ * re-sending a secret that is already on the row.
+ */
+export function validateVerificationBody(
+    body: VerificationBody,
+    hasStoredSecret: boolean,
+): VerificationValidation {
+    const scheme = body.verification ?? 'none';
+
+    if (!isVerificationScheme(scheme)) {
+        return { error: 'invalid_verification_scheme' };
+    }
+
+    if (scheme === 'none') {
+        return { ok: true, scheme };
+    }
+
+    const secretAvailable = body.secret === null ? false : !!body.secret || hasStoredSecret;
+
+    if (!secretAvailable) {
+        return { error: 'missing_secret' };
+    }
+
+    if (schemeNeedsConfig(scheme) && !parseVerificationConfig(body.verificationConfig ?? null)) {
+        return { error: 'invalid_verification_config' };
+    }
+
+    return { ok: true, scheme };
+}

--- a/packages/emitsignal-server/src/lib/crypto/__tests__/secret-box.spec.ts
+++ b/packages/emitsignal-server/src/lib/crypto/__tests__/secret-box.spec.ts
@@ -2,19 +2,19 @@ import { describe, expect, it } from 'bun:test';
 
 import { decryptSecret, encryptSecret } from '#/lib/crypto/secret-box';
 
-const SECRET = 'whsec_M2E4YmZhNzQtNGYxYy00ZjQzLTk1YzMtY2Y5ZDNhNzE=';
+const PLAINTEXT = 'fixture-plaintext-not-a-credential';
 
 describe('secret box', () => {
     it('round-trips a secret', () => {
-        expect(decryptSecret(encryptSecret(SECRET))).toBe(SECRET);
+        expect(decryptSecret(encryptSecret(PLAINTEXT))).toBe(PLAINTEXT);
     });
 
     it('never stores the plaintext in the ciphertext', () => {
-        expect(encryptSecret(SECRET)).not.toContain(SECRET);
+        expect(encryptSecret(PLAINTEXT)).not.toContain(PLAINTEXT);
     });
 
     it('produces a different ciphertext each time (fresh nonce)', () => {
-        expect(encryptSecret(SECRET)).not.toBe(encryptSecret(SECRET));
+        expect(encryptSecret(PLAINTEXT)).not.toBe(encryptSecret(PLAINTEXT));
     });
 
     it('round-trips unicode and empty strings', () => {
@@ -24,7 +24,7 @@ describe('secret box', () => {
 
     it('rejects a tampered ciphertext rather than returning garbage', () => {
         const [version, initializationVector, ciphertext, authenticationTag] =
-            encryptSecret(SECRET).split('.');
+            encryptSecret(PLAINTEXT).split('.');
         const flipped = Buffer.from(ciphertext as string, 'base64');
 
         flipped[0] = (flipped[0] ?? 0) ^ 0xff;
@@ -39,7 +39,7 @@ describe('secret box', () => {
     });
 
     it('rejects a tampered authentication tag', () => {
-        const parts = encryptSecret(SECRET).split('.');
+        const parts = encryptSecret(PLAINTEXT).split('.');
 
         parts[3] = Buffer.alloc(16).toString('base64');
 

--- a/packages/emitsignal-server/src/lib/crypto/__tests__/secret-box.spec.ts
+++ b/packages/emitsignal-server/src/lib/crypto/__tests__/secret-box.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'bun:test';
+
+import { decryptSecret, encryptSecret } from '#/lib/crypto/secret-box';
+
+const SECRET = 'whsec_M2E4YmZhNzQtNGYxYy00ZjQzLTk1YzMtY2Y5ZDNhNzE=';
+
+describe('secret box', () => {
+    it('round-trips a secret', () => {
+        expect(decryptSecret(encryptSecret(SECRET))).toBe(SECRET);
+    });
+
+    it('never stores the plaintext in the ciphertext', () => {
+        expect(encryptSecret(SECRET)).not.toContain(SECRET);
+    });
+
+    it('produces a different ciphertext each time (fresh nonce)', () => {
+        expect(encryptSecret(SECRET)).not.toBe(encryptSecret(SECRET));
+    });
+
+    it('round-trips unicode and empty strings', () => {
+        expect(decryptSecret(encryptSecret('sécret—☃'))).toBe('sécret—☃');
+        expect(decryptSecret(encryptSecret(''))).toBe('');
+    });
+
+    it('rejects a tampered ciphertext rather than returning garbage', () => {
+        const [version, initializationVector, ciphertext, authenticationTag] =
+            encryptSecret(SECRET).split('.');
+        const flipped = Buffer.from(ciphertext as string, 'base64');
+
+        flipped[0] = (flipped[0] ?? 0) ^ 0xff;
+
+        expect(() =>
+            decryptSecret(
+                [version, initializationVector, flipped.toString('base64'), authenticationTag].join(
+                    '.',
+                ),
+            ),
+        ).toThrow();
+    });
+
+    it('rejects a tampered authentication tag', () => {
+        const parts = encryptSecret(SECRET).split('.');
+
+        parts[3] = Buffer.alloc(16).toString('base64');
+
+        expect(() => decryptSecret(parts.join('.'))).toThrow();
+    });
+
+    it('rejects an unrecognized format', () => {
+        expect(() => decryptSecret('not-a-ciphertext')).toThrow(/unrecognized/);
+        expect(() => decryptSecret('v2.a.b.c')).toThrow(/unrecognized/);
+    });
+});

--- a/packages/emitsignal-server/src/lib/crypto/secret-box.ts
+++ b/packages/emitsignal-server/src/lib/crypto/secret-box.ts
@@ -1,0 +1,65 @@
+import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from 'node:crypto';
+
+import { environment } from '#/schema/environment';
+
+// Webhook signing secrets cannot be hashed the way passwords are: verifying an
+// HMAC requires the original key material back.
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_BYTES = 12; // 96-bit nonce, the size GCM is specified for
+const KEY_BYTES = 32;
+const VERSION = 'v1';
+
+const key = deriveKey();
+
+export function decryptSecret(payload: string): string {
+    const parts = payload.split('.');
+
+    if (parts.length !== 4 || parts[0] !== VERSION) {
+        throw new Error('secret_box: unrecognized ciphertext format');
+    }
+
+    const [, initializationVector, ciphertext, authenticationTag] = parts;
+
+    const decipher = createDecipheriv(ALGORITHM, key, Buffer.from(initializationVector, 'base64'));
+
+    decipher.setAuthTag(Buffer.from(authenticationTag, 'base64'));
+
+    const decrypted = Buffer.concat([
+        decipher.update(Buffer.from(ciphertext, 'base64')),
+        decipher.final(),
+    ]);
+
+    return decrypted.toString('utf8');
+}
+
+export function encryptSecret(plaintext: string): string {
+    const initializationVector = randomBytes(IV_BYTES);
+    const cipher = createCipheriv(ALGORITHM, key, initializationVector);
+
+    const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+
+    return [
+        VERSION,
+        initializationVector.toString('base64'),
+        ciphertext.toString('base64'),
+        cipher.getAuthTag().toString('base64'),
+    ].join('.');
+}
+
+function deriveKey(): Buffer {
+    if (environment.WEBHOOK_SECRET_KEY) {
+        const decoded = Buffer.from(environment.WEBHOOK_SECRET_KEY, 'base64');
+
+        if (decoded.length !== KEY_BYTES) {
+            throw new Error(
+                'WEBHOOK_SECRET_KEY must decode to 32 bytes (e.g. `openssl rand -base64 32`).',
+            );
+        }
+
+        return decoded;
+    }
+
+    // BETTER_AUTH_SECRET is already validated as strong in production.
+    return scryptSync(environment.BETTER_AUTH_SECRET, 'emitsignal-webhook-secret', KEY_BYTES);
+}

--- a/packages/emitsignal-server/src/schema/environment.ts
+++ b/packages/emitsignal-server/src/schema/environment.ts
@@ -95,6 +95,10 @@ export const environmentSchema = Type.Object({
     ),
 
     UPLOAD_DIR: Type.String({ default: './uploads' }),
+
+    // Base64 32-byte key encrypting webhook signing secrets at rest. When unset,
+    // derived from BETTER_AUTH_SECRET; set it to rotate the two independently.
+    WEBHOOK_SECRET_KEY: Type.Optional(Type.String()),
 });
 
 export type Environment = typeof environment;

--- a/packages/emitsignal-server/src/utils/__tests__/webhook-signature.spec.ts
+++ b/packages/emitsignal-server/src/utils/__tests__/webhook-signature.spec.ts
@@ -1,0 +1,348 @@
+import { describe, expect, it } from 'bun:test';
+import { createHmac } from 'node:crypto';
+
+import {
+    isVerificationScheme,
+    parseVerificationConfig,
+    schemeNeedsConfig,
+    verifyWebhookSignature,
+} from '#/utils/webhook-signature';
+
+const SECRET = 'a-webhook-secret';
+const RAW_BODY = '{"action":"opened","number":42}';
+
+function nowSeconds(): number {
+    return Math.floor(Date.now() / 1000);
+}
+
+describe('verifyWebhookSignature', () => {
+    it('passes through when the scheme is none', () => {
+        const result = verifyWebhookSignature({
+            config: null,
+            headers: {},
+            rawBody: RAW_BODY,
+            scheme: 'none',
+            secret: '',
+        });
+
+        expect(result).toEqual({ ok: true });
+    });
+
+    it('rejects any verified scheme when no secret is present', () => {
+        const result = verifyWebhookSignature({
+            config: null,
+            headers: {},
+            rawBody: RAW_BODY,
+            scheme: 'github',
+            secret: '',
+        });
+
+        expect(result).toEqual({ ok: false, reason: 'bad_config' });
+    });
+
+    describe('github', () => {
+        function githubHeader(body: string, secret: string): string {
+            return `sha256=${createHmac('sha256', secret).update(body, 'utf8').digest('hex')}`;
+        }
+
+        function verify(headers: Record<string, string | undefined>, rawBody = RAW_BODY) {
+            return verifyWebhookSignature({
+                config: null,
+                headers,
+                rawBody,
+                scheme: 'github',
+                secret: SECRET,
+            });
+        }
+
+        it('accepts a valid sha256 signature', () => {
+            expect(verify({ 'x-hub-signature-256': githubHeader(RAW_BODY, SECRET) })).toEqual({
+                ok: true,
+            });
+        });
+
+        it('rejects a signature made with a different secret', () => {
+            expect(
+                verify({ 'x-hub-signature-256': githubHeader(RAW_BODY, 'wrong-secret') }),
+            ).toEqual({ ok: false, reason: 'bad_signature' });
+        });
+
+        it('rejects when the body was tampered with after signing', () => {
+            expect(
+                verify(
+                    { 'x-hub-signature-256': githubHeader(RAW_BODY, SECRET) },
+                    '{"action":"closed","number":42}',
+                ),
+            ).toEqual({ ok: false, reason: 'bad_signature' });
+        });
+
+        it('rejects a missing header', () => {
+            expect(verify({})).toEqual({ ok: false, reason: 'missing_signature' });
+        });
+
+        it('rejects a header without the sha256= prefix', () => {
+            expect(verify({ 'x-hub-signature-256': 'abc123' })).toEqual({
+                ok: false,
+                reason: 'bad_signature',
+            });
+        });
+    });
+
+    describe('stripe', () => {
+        function stripeHeader(timestamp: number, secret: string, extra?: string): string {
+            const signature = createHmac('sha256', secret)
+                .update(`${timestamp}.${RAW_BODY}`, 'utf8')
+                .digest('hex');
+
+            return `t=${timestamp},v1=${extra ?? signature}${extra ? `,v1=${signature}` : ''}`;
+        }
+
+        function verify(headers: Record<string, string | undefined>) {
+            return verifyWebhookSignature({
+                config: null,
+                headers,
+                rawBody: RAW_BODY,
+                scheme: 'stripe',
+                secret: SECRET,
+            });
+        }
+
+        it('accepts a valid signature', () => {
+            expect(verify({ 'stripe-signature': stripeHeader(nowSeconds(), SECRET) })).toEqual({
+                ok: true,
+            });
+        });
+
+        it('accepts when one of several v1 entries matches (secret rotation)', () => {
+            const header = stripeHeader(nowSeconds(), SECRET, 'deadbeef');
+
+            expect(header.split('v1=').length).toBe(3);
+            expect(verify({ 'stripe-signature': header })).toEqual({ ok: true });
+        });
+
+        it('rejects a signature outside the tolerance window', () => {
+            expect(
+                verify({ 'stripe-signature': stripeHeader(nowSeconds() - 600, SECRET) }),
+            ).toEqual({ ok: false, reason: 'stale_timestamp' });
+        });
+
+        it('rejects a valid signature over a different timestamp', () => {
+            const timestamp = nowSeconds();
+            const signature = createHmac('sha256', SECRET)
+                .update(`${timestamp - 5}.${RAW_BODY}`, 'utf8')
+                .digest('hex');
+
+            expect(verify({ 'stripe-signature': `t=${timestamp},v1=${signature}` })).toEqual({
+                ok: false,
+                reason: 'bad_signature',
+            });
+        });
+
+        it('rejects a header with no v1 entry', () => {
+            expect(verify({ 'stripe-signature': `t=${nowSeconds()}` })).toEqual({
+                ok: false,
+                reason: 'missing_signature',
+            });
+        });
+    });
+
+    describe('svix', () => {
+        const KEY_BYTES = Buffer.from('svix-key-material-32-bytes-long!', 'utf8');
+        const SVIX_SECRET = `whsec_${KEY_BYTES.toString('base64')}`;
+        const IDENTIFIER = 'msg_2abc';
+
+        function svixHeaders(timestamp: number, key: Buffer) {
+            const signature = createHmac('sha256', key)
+                .update(`${IDENTIFIER}.${timestamp}.${RAW_BODY}`, 'utf8')
+                .digest('base64');
+
+            return {
+                'svix-id': IDENTIFIER,
+                'svix-signature': `v1,${signature}`,
+                'svix-timestamp': String(timestamp),
+            };
+        }
+
+        function verify(headers: Record<string, string | undefined>) {
+            return verifyWebhookSignature({
+                config: null,
+                headers,
+                rawBody: RAW_BODY,
+                scheme: 'svix',
+                secret: SVIX_SECRET,
+            });
+        }
+
+        it('accepts a valid signature over id.timestamp.body', () => {
+            expect(verify(svixHeaders(nowSeconds(), KEY_BYTES))).toEqual({ ok: true });
+        });
+
+        it('accepts when the signature list carries an unknown version alongside v1', () => {
+            const headers = svixHeaders(nowSeconds(), KEY_BYTES);
+
+            expect(
+                verify({ ...headers, 'svix-signature': `v0,ignored ${headers['svix-signature']}` }),
+            ).toEqual({ ok: true });
+        });
+
+        it('rejects a signature made with different key material', () => {
+            const wrongKey = Buffer.from('a-completely-different-key-here!', 'utf8');
+
+            expect(verify(svixHeaders(nowSeconds(), wrongKey))).toEqual({
+                ok: false,
+                reason: 'bad_signature',
+            });
+        });
+
+        it('rejects a stale timestamp', () => {
+            expect(verify(svixHeaders(nowSeconds() - 600, KEY_BYTES))).toEqual({
+                ok: false,
+                reason: 'stale_timestamp',
+            });
+        });
+
+        it('rejects when any svix header is missing', () => {
+            const headers = svixHeaders(nowSeconds(), KEY_BYTES);
+
+            expect(verify({ ...headers, 'svix-id': undefined })).toEqual({
+                ok: false,
+                reason: 'missing_signature',
+            });
+        });
+    });
+
+    describe('hmac', () => {
+        const config = JSON.stringify({
+            algorithm: 'sha1',
+            encoding: 'hex',
+            header: 'x-vercel-signature',
+        });
+
+        function verify(headers: Record<string, string | undefined>, rawConfig = config) {
+            return verifyWebhookSignature({
+                config: rawConfig,
+                headers,
+                rawBody: RAW_BODY,
+                scheme: 'hmac',
+                secret: SECRET,
+            });
+        }
+
+        it('accepts a configured sha1 hex signature', () => {
+            const signature = createHmac('sha1', SECRET).update(RAW_BODY, 'utf8').digest('hex');
+
+            expect(verify({ 'x-vercel-signature': signature })).toEqual({ ok: true });
+        });
+
+        it('accepts a base64 signature behind a configured prefix', () => {
+            const signature = createHmac('sha256', SECRET)
+                .update(RAW_BODY, 'utf8')
+                .digest('base64');
+
+            expect(
+                verify(
+                    { 'x-shopify-hmac': `sha256=${signature}` },
+                    JSON.stringify({
+                        algorithm: 'sha256',
+                        encoding: 'base64',
+                        header: 'x-shopify-hmac',
+                        prefix: 'sha256=',
+                    }),
+                ),
+            ).toEqual({ ok: true });
+        });
+
+        it('rejects when the configured prefix is absent', () => {
+            const signature = createHmac('sha256', SECRET)
+                .update(RAW_BODY, 'utf8')
+                .digest('base64');
+
+            expect(
+                verify(
+                    { 'x-shopify-hmac': signature },
+                    JSON.stringify({
+                        algorithm: 'sha256',
+                        encoding: 'base64',
+                        header: 'x-shopify-hmac',
+                        prefix: 'sha256=',
+                    }),
+                ),
+            ).toEqual({ ok: false, reason: 'bad_signature' });
+        });
+
+        it('rejects a malformed config', () => {
+            expect(verify({ 'x-vercel-signature': 'whatever' }, '{not json')).toEqual({
+                ok: false,
+                reason: 'bad_config',
+            });
+        });
+
+        it('rejects a config with an unsupported algorithm', () => {
+            expect(
+                verify(
+                    { 'x-vercel-signature': 'whatever' },
+                    JSON.stringify({ algorithm: 'md5', header: 'x-vercel-signature' }),
+                ),
+            ).toEqual({ ok: false, reason: 'bad_config' });
+        });
+    });
+
+    describe('token', () => {
+        const config = JSON.stringify({ header: 'authorization', prefix: 'Bearer ' });
+
+        function verify(headers: Record<string, string | undefined>) {
+            return verifyWebhookSignature({
+                config,
+                headers,
+                rawBody: RAW_BODY,
+                scheme: 'token',
+                secret: SECRET,
+            });
+        }
+
+        it('accepts a matching shared token', () => {
+            expect(verify({ authorization: `Bearer ${SECRET}` })).toEqual({ ok: true });
+        });
+
+        it('rejects a different token of the same length', () => {
+            expect(verify({ authorization: `Bearer ${'x'.repeat(SECRET.length)}` })).toEqual({
+                ok: false,
+                reason: 'bad_signature',
+            });
+        });
+
+        it('rejects a missing header', () => {
+            expect(verify({})).toEqual({ ok: false, reason: 'missing_signature' });
+        });
+    });
+});
+
+describe('parseVerificationConfig', () => {
+    it('defaults algorithm and encoding and lowercases the header', () => {
+        expect(parseVerificationConfig(JSON.stringify({ header: 'X-Signature' }))).toEqual({
+            algorithm: 'sha256',
+            encoding: 'hex',
+            header: 'x-signature',
+            prefix: '',
+        });
+    });
+
+    it('returns null for null, malformed JSON, and a missing header', () => {
+        expect(parseVerificationConfig(null)).toBeNull();
+        expect(parseVerificationConfig('{oops')).toBeNull();
+        expect(parseVerificationConfig(JSON.stringify({ header: '  ' }))).toBeNull();
+    });
+});
+
+describe('scheme helpers', () => {
+    it('recognizes known schemes only', () => {
+        expect(isVerificationScheme('github')).toBe(true);
+        expect(isVerificationScheme('paypal')).toBe(false);
+    });
+
+    it('requires config only for the user-configured schemes', () => {
+        expect(schemeNeedsConfig('hmac')).toBe(true);
+        expect(schemeNeedsConfig('token')).toBe(true);
+        expect(schemeNeedsConfig('github')).toBe(false);
+    });
+});

--- a/packages/emitsignal-server/src/utils/webhook-signature.ts
+++ b/packages/emitsignal-server/src/utils/webhook-signature.ts
@@ -1,0 +1,316 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+// Every provider signs the raw request bytes, so callers must pass the untouched
+// body text — a re-serialized JSON object will not reproduce the signature.
+
+export type VerificationFailureReason =
+    | 'bad_config'
+    | 'bad_signature'
+    | 'missing_signature'
+    | 'stale_timestamp';
+
+export interface VerificationInput {
+    config: null | string;
+    headers: Record<string, string | undefined>;
+    rawBody: string;
+    scheme: VerificationScheme;
+    secret: string;
+}
+
+export type VerificationResult = { ok: false; reason: VerificationFailureReason } | { ok: true };
+
+export type VerificationScheme = 'github' | 'hmac' | 'none' | 'stripe' | 'svix' | 'token';
+
+export const VERIFICATION_SCHEMES: VerificationScheme[] = [
+    'none',
+    'github',
+    'stripe',
+    'svix',
+    'hmac',
+    'token',
+];
+
+// Bounds replay of a captured delivery. Matches Stripe's and Svix's tolerance.
+export const MAX_SIGNATURE_SKEW_SECONDS = 300;
+
+export interface VerificationConfig {
+    algorithm: 'sha1' | 'sha256' | 'sha512';
+    encoding: 'base64' | 'hex';
+    header: string;
+    prefix: string;
+}
+
+export function isVerificationScheme(value: string): value is VerificationScheme {
+    return VERIFICATION_SCHEMES.includes(value as VerificationScheme);
+}
+
+export function parseVerificationConfig(raw: null | string): null | VerificationConfig {
+    if (!raw) {
+        return null;
+    }
+
+    let parsed: unknown;
+
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        return null;
+    }
+
+    if (!parsed || typeof parsed !== 'object') {
+        return null;
+    }
+
+    const candidate = parsed as Record<string, unknown>;
+    const header = typeof candidate.header === 'string' ? candidate.header.trim() : '';
+
+    if (!header) {
+        return null;
+    }
+
+    const algorithm = candidate.algorithm ?? 'sha256';
+    const encoding = candidate.encoding ?? 'hex';
+
+    if (algorithm !== 'sha1' && algorithm !== 'sha256' && algorithm !== 'sha512') {
+        return null;
+    }
+
+    if (encoding !== 'base64' && encoding !== 'hex') {
+        return null;
+    }
+
+    return {
+        algorithm,
+        encoding,
+        header: header.toLowerCase(),
+        prefix: typeof candidate.prefix === 'string' ? candidate.prefix : '',
+    };
+}
+
+export function schemeNeedsConfig(scheme: VerificationScheme): boolean {
+    return scheme === 'hmac' || scheme === 'token';
+}
+
+export function verifyWebhookSignature(input: VerificationInput): VerificationResult {
+    if (input.scheme === 'none') {
+        return { ok: true };
+    }
+
+    if (!input.secret) {
+        return { ok: false, reason: 'bad_config' };
+    }
+
+    switch (input.scheme) {
+        case 'github':
+            return verifyGithub(input);
+        case 'hmac':
+            return verifyGenericHmac(input);
+        case 'stripe':
+            return verifyStripe(input);
+        case 'svix':
+            return verifySvix(input);
+        case 'token':
+            return verifyToken(input);
+        default:
+            return { ok: false, reason: 'bad_config' };
+    }
+}
+
+function matches(received: string, expected: string): VerificationResult {
+    return timingSafeEqualString(received.trim(), expected)
+        ? { ok: true }
+        : { ok: false, reason: 'bad_signature' };
+}
+
+function matchesAny(received: string[], expected: string): VerificationResult {
+    // Deliberately does not short-circuit: the comparison count stays independent
+    // of which entry matched.
+    let found = false;
+
+    for (const candidate of received) {
+        if (timingSafeEqualString(candidate.trim(), expected)) {
+            found = true;
+        }
+    }
+
+    return found ? { ok: true } : { ok: false, reason: 'bad_signature' };
+}
+
+function timingSafeEqualString(received: string, expected: string): boolean {
+    const receivedBytes = Buffer.from(received, 'utf8');
+    const expectedBytes = Buffer.from(expected, 'utf8');
+
+    // timingSafeEqual throws on length mismatch; a signature's length is not
+    // secret, so the early return leaks nothing.
+    if (receivedBytes.length !== expectedBytes.length) {
+        return false;
+    }
+
+    return timingSafeEqual(receivedBytes, expectedBytes);
+}
+
+// User-configured HMAC over the raw body, for providers we do not special-case.
+function verifyGenericHmac({
+    config,
+    headers,
+    rawBody,
+    secret,
+}: VerificationInput): VerificationResult {
+    const parsed = parseVerificationConfig(config);
+
+    if (!parsed) {
+        return { ok: false, reason: 'bad_config' };
+    }
+
+    const header = headers[parsed.header];
+
+    if (!header) {
+        return { ok: false, reason: 'missing_signature' };
+    }
+
+    if (parsed.prefix && !header.startsWith(parsed.prefix)) {
+        return { ok: false, reason: 'bad_signature' };
+    }
+
+    const expected = createHmac(parsed.algorithm, secret)
+        .update(rawBody, 'utf8')
+        .digest(parsed.encoding);
+
+    return matches(header.slice(parsed.prefix.length), expected);
+}
+
+// GitHub: X-Hub-Signature-256: sha256=<hex HMAC-SHA256 of the raw body>.
+function verifyGithub({ headers, rawBody, secret }: VerificationInput): VerificationResult {
+    const header = headers['x-hub-signature-256'];
+
+    if (!header) {
+        return { ok: false, reason: 'missing_signature' };
+    }
+
+    if (!header.startsWith('sha256=')) {
+        return { ok: false, reason: 'bad_signature' };
+    }
+
+    const expected = createHmac('sha256', secret).update(rawBody, 'utf8').digest('hex');
+
+    return matches(header.slice('sha256='.length), expected);
+}
+
+// Stripe: Stripe-Signature: t=<unix>,v1=<hex>[,v1=<hex>], signed over `${t}.${raw}`.
+// Multiple v1 entries appear during a secret rotation — any match is enough.
+function verifyStripe({ headers, rawBody, secret }: VerificationInput): VerificationResult {
+    const header = headers['stripe-signature'];
+
+    if (!header) {
+        return { ok: false, reason: 'missing_signature' };
+    }
+
+    const signatures: string[] = [];
+    let timestamp = '';
+
+    for (const part of header.split(',')) {
+        const separator = part.indexOf('=');
+
+        if (separator === -1) {
+            continue;
+        }
+
+        const key = part.slice(0, separator).trim();
+        const value = part.slice(separator + 1).trim();
+
+        if (key === 't') {
+            timestamp = value;
+        }
+
+        if (key === 'v1') {
+            signatures.push(value);
+        }
+    }
+
+    if (!timestamp || signatures.length === 0) {
+        return { ok: false, reason: 'missing_signature' };
+    }
+
+    if (!withinSkew(timestamp)) {
+        return { ok: false, reason: 'stale_timestamp' };
+    }
+
+    const expected = createHmac('sha256', secret)
+        .update(`${timestamp}.${rawBody}`, 'utf8')
+        .digest('hex');
+
+    return matchesAny(signatures, expected);
+}
+
+// Svix (Resend, Clerk, ...): svix-signature is a space-separated list of
+// `v1,<base64>` entries over `${svix-id}.${svix-timestamp}.${raw}`. The secret
+// is `whsec_<base64 key bytes>`, and the key is the decoded bytes, not the text.
+function verifySvix({ headers, rawBody, secret }: VerificationInput): VerificationResult {
+    const identifier = headers['svix-id'];
+    const timestamp = headers['svix-timestamp'];
+    const header = headers['svix-signature'];
+
+    if (!identifier || !timestamp || !header) {
+        return { ok: false, reason: 'missing_signature' };
+    }
+
+    if (!withinSkew(timestamp)) {
+        return { ok: false, reason: 'stale_timestamp' };
+    }
+
+    const key = Buffer.from(
+        secret.startsWith('whsec_') ? secret.slice('whsec_'.length) : secret,
+        'base64',
+    );
+
+    if (key.length === 0) {
+        return { ok: false, reason: 'bad_config' };
+    }
+
+    const expected = createHmac('sha256', key)
+        .update(`${identifier}.${timestamp}.${rawBody}`, 'utf8')
+        .digest('base64');
+
+    const signatures: string[] = [];
+
+    for (const entry of header.split(' ')) {
+        const [version, signature] = entry.split(',');
+
+        if (version === 'v1' && signature) {
+            signatures.push(signature);
+        }
+    }
+
+    if (signatures.length === 0) {
+        return { ok: false, reason: 'missing_signature' };
+    }
+
+    return matchesAny(signatures, expected);
+}
+
+// Shared-token schemes: the header carries the secret itself, not a signature.
+function verifyToken({ config, headers, secret }: VerificationInput): VerificationResult {
+    const parsed = parseVerificationConfig(config);
+
+    if (!parsed) {
+        return { ok: false, reason: 'bad_config' };
+    }
+
+    const header = headers[parsed.header];
+
+    if (!header) {
+        return { ok: false, reason: 'missing_signature' };
+    }
+
+    return matches(parsed.prefix ? header.slice(parsed.prefix.length) : header, secret);
+}
+
+function withinSkew(timestamp: string): boolean {
+    const seconds = Number(timestamp);
+
+    if (!Number.isFinite(seconds)) {
+        return false;
+    }
+
+    return Math.abs(Math.floor(Date.now() / 1000) - seconds) <= MAX_SIGNATURE_SKEW_SECONDS;
+}

--- a/packages/emitsignal-shared/package.json
+++ b/packages/emitsignal-shared/package.json
@@ -8,7 +8,8 @@
         "./priority": "./src/priority.ts",
         "./topic": "./src/topic.ts",
         "./url": "./src/url.ts",
-        "./webhook-template": "./src/webhook-template.ts"
+        "./webhook-template": "./src/webhook-template.ts",
+        "./webhook-verification": "./src/webhook-verification.ts"
     },
     "license": "AGPL-3.0-only",
     "main": "src/index.ts",

--- a/packages/emitsignal-shared/src/api.ts
+++ b/packages/emitsignal-shared/src/api.ts
@@ -152,7 +152,6 @@ export interface WebhookTemplate {
 }
 
 export interface WebhookVerificationInput {
-    // null clears the stored secret; omitted leaves it untouched.
     secret?: null | string;
     verification?: VerificationScheme;
     verificationConfig?: null | string;

--- a/packages/emitsignal-shared/src/api.ts
+++ b/packages/emitsignal-shared/src/api.ts
@@ -1,5 +1,6 @@
 import type { BillingInfo } from './billing.ts';
 import type { MessageFilterParams } from './message-filters.ts';
+import type { VerificationScheme } from './webhook-verification.ts';
 
 const REQUEST_TIMEOUT_MS = 15_000;
 
@@ -111,6 +112,7 @@ export interface TopicWithCounts extends Topic {
 export interface Webhook {
     count24h: number;
     createdAt: number;
+    hasSecret: boolean;
     id: string;
     lastDeliveryAt: null | number;
     name: string;
@@ -121,6 +123,8 @@ export interface Webhook {
     templated: boolean;
     topicName: string;
     updatedAt: number;
+    verification: VerificationScheme;
+    verificationConfig?: null | string;
 }
 
 export interface WebhookDelivery {
@@ -145,6 +149,13 @@ export interface WebhookTemplate {
     priority?: string;
     tags?: string;
     title?: string;
+}
+
+export interface WebhookVerificationInput {
+    // null clears the stored secret; omitted leaves it untouched.
+    secret?: null | string;
+    verification?: VerificationScheme;
+    verificationConfig?: null | string;
 }
 
 export function createApiClient(baseUrl: string) {
@@ -223,12 +234,14 @@ export function createApiClient(baseUrl: string) {
             });
         },
 
-        createWebhook(input: {
-            name?: string;
-            source?: string;
-            template?: null | string;
-            topicName: string;
-        }) {
+        createWebhook(
+            input: {
+                name?: string;
+                source?: string;
+                template?: null | string;
+                topicName: string;
+            } & WebhookVerificationInput,
+        ) {
             return request<{ endpointUrl: string } & Webhook>('/webhooks', {
                 body: JSON.stringify(input),
                 method: 'POST',
@@ -444,7 +457,12 @@ export function createApiClient(baseUrl: string) {
 
         updateWebhook(
             id: string,
-            input: { name?: string; status?: string; template?: null | string; topicName?: string },
+            input: {
+                name?: string;
+                status?: string;
+                template?: null | string;
+                topicName?: string;
+            } & WebhookVerificationInput,
         ) {
             return request<Webhook>(`/webhooks/${encodeURIComponent(id)}`, {
                 body: JSON.stringify(input),

--- a/packages/emitsignal-shared/src/index.ts
+++ b/packages/emitsignal-shared/src/index.ts
@@ -6,3 +6,4 @@ export * from './priority.ts';
 export * from './topic.ts';
 export * from './url.ts';
 export * from './webhook-template.ts';
+export * from './webhook-verification.ts';

--- a/packages/emitsignal-shared/src/webhook-verification.ts
+++ b/packages/emitsignal-shared/src/webhook-verification.ts
@@ -1,0 +1,57 @@
+// Identifiers and presentation metadata only; verification runs on the server.
+export interface VerificationConfig {
+    algorithm?: 'sha1' | 'sha256' | 'sha512';
+    encoding?: 'base64' | 'hex';
+    header: string;
+    prefix?: string;
+}
+
+export type VerificationScheme = 'github' | 'hmac' | 'none' | 'stripe' | 'svix' | 'token';
+
+export const VERIFICATION_LABELS: Record<VerificationScheme, string> = {
+    github: 'GitHub (X-Hub-Signature-256)',
+    hmac: 'Custom HMAC',
+    none: 'None — anyone with the URL can post',
+    stripe: 'Stripe (Stripe-Signature)',
+    svix: 'Svix / Resend (svix-signature)',
+    token: 'Shared token header',
+};
+
+export const VERIFICATION_SCHEMES: VerificationScheme[] = [
+    'github',
+    'hmac',
+    'none',
+    'stripe',
+    'svix',
+    'token',
+];
+
+export const VERIFICATION_HINTS: Record<VerificationScheme, string> = {
+    github: 'Repository → Settings → Webhooks → Secret.',
+    hmac: 'Pick the header, digest, and encoding your provider documents.',
+    none: 'Deliveries are accepted from anyone who knows the endpoint URL.',
+    stripe: 'Stripe Dashboard → Developers → Webhooks → Signing secret (whsec_…).',
+    svix: 'Resend/Clerk dashboard → Webhooks → Signing secret (whsec_…).',
+    token: 'The static token your provider sends in a header, compared verbatim.',
+};
+
+export function schemeNeedsConfig(scheme: VerificationScheme): boolean {
+    return scheme === 'hmac' || scheme === 'token';
+}
+
+export const DEFAULT_VERIFICATION_BY_SOURCE: Record<string, VerificationScheme> = {
+    custom: 'none',
+    github: 'github',
+    grafana: 'token',
+    stripe: 'stripe',
+    vercel: 'hmac',
+};
+
+export function defaultVerificationForSource(source: string): VerificationScheme {
+    return DEFAULT_VERIFICATION_BY_SOURCE[source] ?? 'none';
+}
+
+export const DEFAULT_CONFIG_BY_SOURCE: Record<string, VerificationConfig> = {
+    grafana: { header: 'authorization', prefix: 'Bearer ' },
+    vercel: { algorithm: 'sha1', encoding: 'hex', header: 'x-vercel-signature' },
+};

--- a/packages/emitsignal-shared/src/webhook-verification.ts
+++ b/packages/emitsignal-shared/src/webhook-verification.ts
@@ -1,4 +1,3 @@
-// Identifiers and presentation metadata only; verification runs on the server.
 export interface VerificationConfig {
     algorithm?: 'sha1' | 'sha256' | 'sha512';
     encoding?: 'base64' | 'hex';

--- a/packages/emitsignal-website/src/components/app/settings/advanced-page.tsx
+++ b/packages/emitsignal-website/src/components/app/settings/advanced-page.tsx
@@ -126,13 +126,6 @@ export function AdvancedPage() {
                             <SettingsInput monospace suffix="req/min" value="600" />
                         </SettingsField>
                     </div>
-
-                    <SettingsField
-                        hint="Used to verify the X-Signal-Signature HMAC on every outbound webhook"
-                        label="Webhook signing secret"
-                    >
-                        <SettingsInput monospace suffix="rotate" value="whsec_9f2a••••c41e" />
-                    </SettingsField>
                 </SettingsCard>
 
                 <SettingsCard

--- a/packages/emitsignal-website/src/components/app/webhooks/deliveries-log.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/deliveries-log.tsx
@@ -335,7 +335,6 @@ function ExpiryLabel({ expiresAt }: { expiresAt: null | number }) {
     );
 }
 
-// Rejected deliveries carry a reason instead of a provider payload.
 const REJECTION_LABELS: Record<string, string> = {
     bad_config: 'rejected · verification misconfigured',
     bad_signature: 'rejected · signature did not match',

--- a/packages/emitsignal-website/src/components/app/webhooks/deliveries-log.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/deliveries-log.tsx
@@ -143,7 +143,11 @@ export function DeliveriesLog({ webhookId }: { webhookId: string }) {
                                     {summary}
                                 </div>
                                 <div className="mt-1.5 flex items-center gap-2">
-                                    <span className="font-mono text-[10px] text-success">
+                                    <span
+                                        className={`font-mono text-[10px] ${
+                                            isRejected(delivery) ? 'text-danger' : 'text-success'
+                                        }`}
+                                    >
                                         {delivery.status}
                                     </span>
                                     <span className="font-mono text-[10px] text-faint">
@@ -184,7 +188,11 @@ export function DeliveriesLog({ webhookId }: { webhookId: string }) {
                             </div>
                         </div>
                         <div className="ml-auto flex items-center gap-3.5 font-mono text-[11px]">
-                            <span className="text-success">● {active.status} OK</span>
+                            {isRejected(active) ? (
+                                <span className="text-danger">● {active.status} REJECTED</span>
+                            ) : (
+                                <span className="text-success">● {active.status} OK</span>
+                            )}
                             <span className="text-dim">{active.durationMs}ms</span>
                             <ExpiryLabel expiresAt={active.expiresAt} />
                         </div>
@@ -327,15 +335,32 @@ function ExpiryLabel({ expiresAt }: { expiresAt: null | number }) {
     );
 }
 
+// Rejected deliveries carry a reason instead of a provider payload.
+const REJECTION_LABELS: Record<string, string> = {
+    bad_config: 'rejected · verification misconfigured',
+    bad_signature: 'rejected · signature did not match',
+    missing_signature: 'rejected · no signature sent',
+    stale_timestamp: 'rejected · timestamp outside the allowed window',
+};
+
 function getSummary(delivery: WebhookDelivery): string {
     if (typeof delivery.payload === 'object' && delivery.payload !== null) {
         const payload = delivery.payload as Record<string, unknown>;
+
+        if (isRejected(delivery) && typeof payload['reason'] === 'string') {
+            return REJECTION_LABELS[payload['reason']] ?? `rejected · ${payload['reason']}`;
+        }
+
         if (typeof payload['type'] === 'string') return payload['type'];
         if (typeof payload['event'] === 'string') return payload['event'];
         if (typeof payload['action'] === 'string')
             return `${delivery.source} · ${payload['action']}`;
     }
     return `${delivery.source} delivery`;
+}
+
+function isRejected(delivery: WebhookDelivery): boolean {
+    return delivery.status >= 400;
 }
 
 function SectionLabel({ children, right }: { children: React.ReactNode; right?: React.ReactNode }) {

--- a/packages/emitsignal-website/src/components/app/webhooks/verification-fields.test.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/verification-fields.test.tsx
@@ -1,0 +1,50 @@
+import type { VerificationScheme } from '@emitsignal/shared';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { VerificationFields } from './verification-fields';
+
+function renderFields(secret = 'whsec_abc123', scheme: VerificationScheme = 'github') {
+    return render(
+        <VerificationFields
+            config={{ algorithm: 'sha256', encoding: 'hex', header: '', prefix: '' }}
+            hasStoredSecret={false}
+            onConfigChange={vi.fn()}
+            onSchemeChange={vi.fn()}
+            onSecretChange={vi.fn()}
+            scheme={scheme}
+            secret={secret}
+        />,
+    );
+}
+
+describe('VerificationFields secret reveal', () => {
+    test('masks the secret until the reveal button is pressed', () => {
+        renderFields();
+
+        const input = screen.getByPlaceholderText('Paste the signing secret');
+
+        expect(input.getAttribute('type')).toBe('password');
+
+        fireEvent.click(screen.getByTitle('Show secret'));
+
+        expect(input.getAttribute('type')).toBe('text');
+
+        fireEvent.click(screen.getByTitle('Hide secret'));
+
+        expect(input.getAttribute('type')).toBe('password');
+    });
+
+    test('cannot reveal an empty field', () => {
+        renderFields('');
+
+        expect((screen.getByTitle('Show secret') as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    test('cannot reveal when verification is off', () => {
+        renderFields('', 'none');
+
+        expect((screen.getByTitle('Show secret') as HTMLButtonElement).disabled).toBe(true);
+    });
+});

--- a/packages/emitsignal-website/src/components/app/webhooks/verification-fields.test.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/verification-fields.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, test, vi } from 'vitest';
 
 import { VerificationFields } from './verification-fields';
 
-function renderFields(secret = 'whsec_abc123', scheme: VerificationScheme = 'github') {
+function renderFields(secret = 'fixture-secret-value', scheme: VerificationScheme = 'github') {
     return render(
         <VerificationFields
             config={{ algorithm: 'sha256', encoding: 'hex', header: '', prefix: '' }}

--- a/packages/emitsignal-website/src/components/app/webhooks/verification-fields.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/verification-fields.tsx
@@ -1,0 +1,186 @@
+import type { VerificationConfig, VerificationScheme } from '@emitsignal/shared';
+
+import {
+    schemeNeedsConfig,
+    VERIFICATION_HINTS,
+    VERIFICATION_LABELS,
+    VERIFICATION_SCHEMES,
+} from '@emitsignal/shared';
+import { ChevronDown, Eye, EyeOff, ShieldAlert, ShieldCheck } from 'lucide-react';
+import { useState } from 'react';
+
+interface VerificationFieldsProps {
+    config: VerificationConfig;
+    hasStoredSecret: boolean;
+    onConfigChange: (config: VerificationConfig) => void;
+    onSchemeChange: (scheme: VerificationScheme) => void;
+    onSecretChange: (secret: string) => void;
+    scheme: VerificationScheme;
+    secret: string;
+}
+
+const FIELD_CLASS =
+    'w-full rounded-lg border border-line bg-elev px-3 py-2 font-mono text-[12px] text-fg outline-none placeholder:text-faint';
+const LABEL_CLASS = 'mb-2 font-mono text-[10px] uppercase tracking-[1.3px] text-dim';
+
+export function VerificationFields({
+    config,
+    hasStoredSecret,
+    onConfigChange,
+    onSchemeChange,
+    onSecretChange,
+    scheme,
+    secret,
+}: VerificationFieldsProps) {
+    const [secretVisible, setSecretVisible] = useState(false);
+
+    const verified = scheme !== 'none';
+    const needsConfig = schemeNeedsConfig(scheme);
+
+    return (
+        <div className="border-b border-line px-6 py-4">
+            <div className="mb-3 flex items-center gap-2">
+                {verified ? (
+                    <ShieldCheck className="text-success" size={13} />
+                ) : (
+                    <ShieldAlert className="text-warn" size={13} />
+                )}
+                <span className="font-mono text-[10px] uppercase tracking-[1.3px] text-dim">
+                    Signature verification
+                </span>
+            </div>
+
+            <div className="grid grid-cols-[1.1fr_1.6fr] gap-5">
+                <div>
+                    <div className={LABEL_CLASS}>Scheme</div>
+                    <div className="flex items-center gap-2 rounded-lg border border-line bg-elev px-3 py-2">
+                        <select
+                            className="flex-1 bg-transparent font-mono text-[12px] text-fg outline-none"
+                            onChange={(event) =>
+                                onSchemeChange(event.target.value as VerificationScheme)
+                            }
+                            value={scheme}
+                        >
+                            {VERIFICATION_SCHEMES.map((option) => (
+                                <option key={option} value={option}>
+                                    {VERIFICATION_LABELS[option]}
+                                </option>
+                            ))}
+                        </select>
+                        <ChevronDown className="pointer-events-none text-dim" size={13} />
+                    </div>
+                </div>
+
+                <div>
+                    <div className={LABEL_CLASS}>
+                        {verified ? 'Secret from the provider' : 'No secret required'}
+                    </div>
+                    <div className="relative">
+                        <input
+                            autoComplete="off"
+                            className={`${FIELD_CLASS} pr-9`}
+                            disabled={!verified}
+                            onChange={(event) => onSecretChange(event.target.value)}
+                            placeholder={
+                                hasStoredSecret
+                                    ? 'A secret is stored — type to replace it'
+                                    : 'Paste the signing secret'
+                            }
+                            spellCheck={false}
+                            type={secretVisible ? 'text' : 'password'}
+                            value={secret}
+                        />
+                        <button
+                            className="absolute inset-y-0 right-0 flex cursor-pointer items-center px-2.5 text-faint hover:text-fg disabled:cursor-default disabled:opacity-40"
+                            disabled={!verified || !secret}
+                            onClick={() => setSecretVisible((visible) => !visible)}
+                            tabIndex={-1}
+                            title={secretVisible ? 'Hide secret' : 'Show secret'}
+                            type="button"
+                        >
+                            {secretVisible ? <EyeOff size={14} /> : <Eye size={14} />}
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <div className="mt-2 font-mono text-[10.5px] text-faint">
+                {VERIFICATION_HINTS[scheme]}
+                {verified &&
+                    hasStoredSecret &&
+                    ' A secret is already stored; leave blank to keep it.'}
+            </div>
+
+            {needsConfig && (
+                <div className="mt-4 grid grid-cols-[1.6fr_1fr_1fr_1.1fr] gap-3">
+                    <div>
+                        <div className={LABEL_CLASS}>Header</div>
+                        <input
+                            className={FIELD_CLASS}
+                            onChange={(event) =>
+                                onConfigChange({ ...config, header: event.target.value })
+                            }
+                            placeholder="x-signature"
+                            spellCheck={false}
+                            value={config.header}
+                        />
+                    </div>
+
+                    {scheme === 'hmac' && (
+                        <>
+                            <div>
+                                <div className={LABEL_CLASS}>Digest</div>
+                                <select
+                                    className={FIELD_CLASS}
+                                    onChange={(event) =>
+                                        onConfigChange({
+                                            ...config,
+                                            algorithm: event.target
+                                                .value as VerificationConfig['algorithm'],
+                                        })
+                                    }
+                                    value={config.algorithm ?? 'sha256'}
+                                >
+                                    <option value="sha1">sha1</option>
+                                    <option value="sha256">sha256</option>
+                                    <option value="sha512">sha512</option>
+                                </select>
+                            </div>
+
+                            <div>
+                                <div className={LABEL_CLASS}>Encoding</div>
+                                <select
+                                    className={FIELD_CLASS}
+                                    onChange={(event) =>
+                                        onConfigChange({
+                                            ...config,
+                                            encoding: event.target
+                                                .value as VerificationConfig['encoding'],
+                                        })
+                                    }
+                                    value={config.encoding ?? 'hex'}
+                                >
+                                    <option value="hex">hex</option>
+                                    <option value="base64">base64</option>
+                                </select>
+                            </div>
+                        </>
+                    )}
+
+                    <div className={scheme === 'token' ? 'col-span-2' : undefined}>
+                        <div className={LABEL_CLASS}>Prefix (optional)</div>
+                        <input
+                            className={FIELD_CLASS}
+                            onChange={(event) =>
+                                onConfigChange({ ...config, prefix: event.target.value })
+                            }
+                            placeholder={scheme === 'token' ? 'Bearer ' : 'sha256='}
+                            spellCheck={false}
+                            value={config.prefix ?? ''}
+                        />
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/packages/emitsignal-website/src/components/app/webhooks/webhook-create.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/webhook-create.tsx
@@ -1,3 +1,10 @@
+import type { VerificationConfig, VerificationScheme } from '@emitsignal/shared';
+
+import {
+    DEFAULT_CONFIG_BY_SOURCE,
+    defaultVerificationForSource,
+    schemeNeedsConfig,
+} from '@emitsignal/shared';
 import { applyTemplate as applyTemplateExact } from '@emitsignal/shared/webhook-template';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
@@ -14,6 +21,7 @@ import { queryKeys } from '#/lib/query-client';
 import { JsonView } from './json-view';
 import { NotifPreview } from './notif-preview';
 import { applyTemplate } from './template-string';
+import { VerificationFields } from './verification-fields';
 
 const SOURCE_DATA: Record<
     string,
@@ -116,10 +124,39 @@ const EMPTY_TEMPLATE: WebhookTemplate = {
 // ── Props ─────────────────────────────────────────────────────────────────────
 
 interface WebhookCreateProps {
-    initialData?: { samplePayload?: null | string; template: null | string } & Pick<
+    initialData?: {
+        samplePayload?: null | string;
+        template: null | string;
+    } & Pick<
         Webhook,
-        'id' | 'name' | 'slug' | 'source' | 'topicName'
+        | 'hasSecret'
+        | 'id'
+        | 'name'
+        | 'slug'
+        | 'source'
+        | 'topicName'
+        | 'verification'
+        | 'verificationConfig'
     >;
+}
+
+const EMPTY_CONFIG: VerificationConfig = {
+    algorithm: 'sha256',
+    encoding: 'hex',
+    header: '',
+    prefix: '',
+};
+
+function parseConfig(raw: null | string | undefined): null | VerificationConfig {
+    if (!raw) {
+        return null;
+    }
+
+    try {
+        return JSON.parse(raw) as VerificationConfig;
+    } catch {
+        return null;
+    }
 }
 
 const EMPTY_PAYLOAD = '{\n  \n}';
@@ -152,6 +189,10 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
     const [previewMode, setPreviewMode] = useState<'pretty' | 'raw'>('pretty');
     const [saveError, setSaveError] = useState<null | string>(null);
     const [saving, setSaving] = useState(false);
+    const [secret, setSecret] = useState('');
+    const [scheme, setScheme] = useState<VerificationScheme>(
+        initialData?.verification ?? defaultVerificationForSource(initialSource),
+    );
     const [source, setSource] = useState<Source>(initialSource);
     const [templateFields, setTemplateFields] = useState<WebhookTemplate>(
         initialTemplate ?? EMPTY_TEMPLATE,
@@ -159,6 +200,13 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
     const [topicName, setTopicName] = useState(initialData?.topicName ?? '');
     const [useTemplate, setUseTemplate] = useState(initialTemplate !== null);
     const templateDirtyRef = useRef(false);
+
+    const [verificationConfig, setVerificationConfig] = useState<VerificationConfig>(
+        parseConfig(initialData?.verificationConfig) ??
+            DEFAULT_CONFIG_BY_SOURCE[initialSource] ??
+            EMPTY_CONFIG,
+    );
+    const verificationDirtyRef = useRef(false);
 
     // Active payload for preview
     const activePayload: Record<string, unknown> =
@@ -201,6 +249,21 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
         setUseTemplate(template !== null);
 
         templateDirtyRef.current = false;
+
+        if (!verificationDirtyRef.current) {
+            setScheme(defaultVerificationForSource(source));
+            setVerificationConfig(DEFAULT_CONFIG_BY_SOURCE[source] ?? EMPTY_CONFIG);
+        }
+    }
+
+    function handleSchemeChange(next: VerificationScheme) {
+        verificationDirtyRef.current = true;
+
+        setScheme(next);
+
+        if (schemeNeedsConfig(next) && !verificationConfig.header) {
+            setVerificationConfig(DEFAULT_CONFIG_BY_SOURCE[source] ?? EMPTY_CONFIG);
+        }
     }
 
     function handleTemplateFieldChange(field: keyof WebhookTemplate, value: string) {
@@ -236,17 +299,37 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
             return setSaveError('Channel name is required');
         }
 
+        const hasStoredSecret = !!initialData?.hasSecret;
+
+        if (scheme !== 'none' && !secret.trim() && !hasStoredSecret) {
+            return setSaveError('Paste the signing secret, or set verification to None');
+        }
+
+        if (scheme !== 'none' && schemeNeedsConfig(scheme) && !verificationConfig.header.trim()) {
+            return setSaveError('A header name is required for this verification scheme');
+        }
+
         setSaving(true);
         setSaveError(null);
 
         try {
             const template = useTemplate ? JSON.stringify(templateFields) : null;
 
+            const verification = {
+                // Blank keeps the stored secret; switching to None clears it.
+                secret: secret.trim() ? secret.trim() : scheme === 'none' ? null : undefined,
+                verification: scheme,
+                verificationConfig: schemeNeedsConfig(scheme)
+                    ? JSON.stringify(verificationConfig)
+                    : null,
+            };
+
             if (isEdit && initialData) {
                 await api.updateWebhook(initialData.id, {
                     name: `${source} webhook`,
                     template,
                     topicName: topicName.trim(),
+                    ...verification,
                 });
             } else {
                 await api.createWebhook({
@@ -254,6 +337,7 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
                     source,
                     template,
                     topicName: topicName.trim(),
+                    ...verification,
                 });
             }
 
@@ -287,6 +371,11 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
         })();
         setTemplateFields(template ?? EMPTY_TEMPLATE);
         setUseTemplate(template !== null);
+
+        setScheme(initialData.verification ?? 'none');
+        setSecret('');
+        setVerificationConfig(parseConfig(initialData.verificationConfig) ?? EMPTY_CONFIG);
+        verificationDirtyRef.current = false;
     }, [initialData?.id]);
 
     // Seed the custom payload editor once deliveries resolve (the sample payload
@@ -404,6 +493,16 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
                     )}
                 </div>
             </div>
+
+            <VerificationFields
+                config={verificationConfig}
+                hasStoredSecret={!!initialData?.hasSecret}
+                onConfigChange={setVerificationConfig}
+                onSchemeChange={handleSchemeChange}
+                onSecretChange={setSecret}
+                scheme={scheme}
+                secret={secret}
+            />
 
             {/* editor split */}
             <div className="flex min-h-0 flex-1">

--- a/packages/emitsignal-website/src/components/app/webhooks/webhooks-table.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/webhooks-table.tsx
@@ -196,7 +196,21 @@ function WebhookRow({
             <div className="flex min-w-0 items-center gap-3">
                 <SourceGlyph size={34} source={webhook.source as WebhookSource} />
                 <div className="min-w-0">
-                    <div className="text-[13.5px] font-semibold">{webhook.name}</div>
+                    <div className="flex min-w-0 items-center gap-2">
+                        <span className="truncate text-[13.5px] font-semibold">{webhook.name}</span>
+                        {webhook.verification === 'none' && (
+                            <span
+                                className="shrink-0 rounded-full border px-2 py-0.5 font-mono text-[9.5px] text-warn"
+                                style={{
+                                    borderColor:
+                                        'color-mix(in srgb, var(--color-warn) 30%, transparent)',
+                                }}
+                                title="No signing secret — anyone with the endpoint URL can post to this webhook"
+                            >
+                                unverified
+                            </span>
+                        )}
+                    </div>
                     <div className="mt-0.5 font-mono text-[10.5px] text-dim">
                         → {webhook.topicName}
                     </div>

--- a/packages/emitsignal-website/src/routes/api.tsx
+++ b/packages/emitsignal-website/src/routes/api.tsx
@@ -536,7 +536,7 @@ ci/web-app/main`}</Block>
                             <Endpoint
                                 auth
                                 desc="Update a webhook."
-                                method="PUT"
+                                method="PATCH"
                                 path="/webhooks/:id"
                             />
                             <Endpoint
@@ -552,47 +552,61 @@ ci/web-app/main`}</Block>
                                 path="/webhooks/:id/deliveries"
                             />
                             <Endpoint
-                                auth
-                                desc="Replay a failed delivery."
+                                desc="Receive a delivery from your provider."
                                 method="POST"
-                                path="/webhooks/:id/deliveries/:delivery_id/replay"
+                                path="/h/:slug"
                             />
                         </div>
 
-                        <H3>Webhook payload</H3>
-                        <Block>{`POST https://your-server.example.com/emitsignal-hook
+                        <H3>Receiving a delivery</H3>
+                        <p className="mb-3 text-[13.5px] leading-relaxed text-muted">
+                            EmitSignal receives webhooks — point your provider at the endpoint below
+                            and each delivery is published to the webhook&rsquo;s channel.
+                        </p>
+                        <Block>{`POST https://api.emitsignal.com/h/gh_9f2ac41e8b3d
 Content-Type: application/json
-X-EmitSignal-Signature: sha256=xxxxxxxxxxxxxxxx
-X-EmitSignal-Delivery: del_01j9xz3p4q5r
+X-Hub-Signature-256: sha256=xxxxxxxxxxxxxxxx
 
 {
-  "event": "signal.published",
-  "signal": {
-    "id":       "sig_01j9xz3p4q5r6s7t8u9v0w1x2y",
-    "topic":    "deploy/prod",
-    "title":    "v2.14.3 shipped",
-    "message":  "api-gateway deployed · 1m 42s",
-    "priority": 4,
-    "tags":     ["deploy", "production"],
-    "published_at": "2026-05-28T21:52:01Z"
-  }
+  "action": "completed",
+  "workflow_run": { "name": "deploy", "conclusion": "success" }
 }`}</Block>
 
                         <div className="mt-4">
-                            <H3>Signature verification</H3>
-                            <Block>{`// Node.js
-import crypto from 'crypto'
+                            <H3>Verifying the sender</H3>
+                            <p className="mb-3 text-[13.5px] leading-relaxed text-muted">
+                                Without a secret, anyone who learns the endpoint URL can post to it.
+                                Add the signing secret your provider issued and every delivery is
+                                checked against the raw request body before it is published —
+                                requests that fail are rejected with{' '}
+                                <code className="font-mono text-[12.5px] text-accent">401</code> and
+                                recorded in the delivery log so you can debug them.
+                            </p>
+                            <Block>{`{
+  "topicName": "deploy/prod",
+  "source": "github",
+  "verification": "github",     // github | stripe | svix | hmac | token | none
+  "secret": "the-secret-from-your-provider"
+}
 
-function verifySignature(payload, signature, secret) {
-  const expected = 'sha256=' + crypto
-    .createHmac('sha256', secret)
-    .update(payload)
-    .digest('hex')
-  return crypto.timingSafeEqual(
-    Buffer.from(expected),
-    Buffer.from(signature)
-  )
+// hmac and token also take a header config:
+{
+  "verification": "hmac",
+  "secret": "...",
+  "verificationConfig": "{\\"header\\":\\"x-vercel-signature\\",\\"algorithm\\":\\"sha1\\",\\"encoding\\":\\"hex\\"}"
 }`}</Block>
+                            <p className="mt-3 text-[13.5px] leading-relaxed text-muted">
+                                The secret is write-only: it is encrypted at rest and never returned
+                                by the API. Webhook responses carry{' '}
+                                <code className="font-mono text-[12.5px] text-accent">
+                                    hasSecret
+                                </code>{' '}
+                                and{' '}
+                                <code className="font-mono text-[12.5px] text-accent">
+                                    verification
+                                </code>{' '}
+                                only.
+                            </p>
                         </div>
                     </Section>
 

--- a/packages/emitsignal-website/src/routes/app/webhooks/$webhookId.edit.tsx
+++ b/packages/emitsignal-website/src/routes/app/webhooks/$webhookId.edit.tsx
@@ -40,6 +40,7 @@ function EditWebhookPage() {
             ) : webhook ? (
                 <WebhookCreate
                     initialData={{
+                        hasSecret: webhook.hasSecret,
                         id: webhook.id,
                         name: webhook.name,
                         samplePayload,
@@ -47,6 +48,8 @@ function EditWebhookPage() {
                         source: webhook.source,
                         template: webhook.template ?? null,
                         topicName: webhook.topicName,
+                        verification: webhook.verification,
+                        verificationConfig: webhook.verificationConfig,
                     }}
                 />
             ) : (


### PR DESCRIPTION
## Why

`POST /h/:slug` accepted any request that knew the slug. The slug is the only credential and it travels in the URL, so it leaks through logs, proxies, browser history, and screenshots — anyone who learned one could inject arbitrary notifications into the owner's topic, and the endpoint published to the bus and push queue on every hit.

Every real provider already signs its deliveries; we were discarding that signature. This adds per-webhook **inbound** verification: paste the secret the provider issued, and each delivery is checked against the raw request bytes before anything is published.

Scope: EmitSignal only *receives* webhooks. Nothing here signs outbound traffic — two places in the website claimed an outbound-signing feature that never existed, and both are corrected.

## What changed

**Schema** — `Webhook` gains `secretCiphertext`, `verification` (default `'none'`), `verificationConfig`. The migration is additive; existing webhooks stay on `'none'` and behave exactly as before.

**Encryption** (`src/lib/crypto/secret-box.ts`) — AES-256-GCM. HMAC verification needs the original key material back, so the secret cannot be hashed like a password. Key comes from the new optional `WEBHOOK_SECRET_KEY`, otherwise derived via scrypt from `BETTER_AUTH_SECRET`, so existing deployments need no new env var.

**Verifiers** (`src/utils/webhook-signature.ts`) — GitHub, Stripe (multi-`v1` rotation + 300s skew), Svix/Resend (`whsec_` base64 key over `id.timestamp.body`), generic HMAC, and shared token. All comparisons go through one `timingSafeEqual` helper.

**Receiver** — a `parse` hook captures the raw bytes, since signatures cover bytes and `JSON.stringify` of the parsed body does not round-trip. Verification runs before topic creation, message insert, bus fanout, and push enqueue. Failures return `401` and write a `status: 401` delivery with a 2 KB payload preview and reason, streamed live to the deliveries log.

**CRUD** — the secret is write-only: encrypted on write, never in any `select` or response. `GET`/`LIST` expose `hasSecret` and `verification` only.

**Website** — verification block in the create/edit form (scheme pre-filled per source, password field with a reveal toggle, header/digest/encoding for hmac/token), an `unverified` badge on the webhook name, and red styling plus a reason for 401 rows in the deliveries log.

**Docs** — `api/webhooks.mdx`, `api/errors.mdx`, and `cli/webhooks.mdx` updated for the new fields, flags, and status codes.

**Removed two false claims of outbound signing** — the hardcoded fake `whsec_9f2a••••c41e` field in settings, and the `X-EmitSignal-Signature` docs in `routes/api.tsx` (rewritten as real inbound docs; also fixed `PUT`→`PATCH` and dropped a documented-but-nonexistent replay endpoint).

**Also fixed** — `webhooks listen` hardcoded green for every delivery status, so a rejected 401 would have rendered green. Harmless before this change, wrong now.

## Verification

55 new tests covering each scheme (valid, wrong secret, missing header, tampered body, stale timestamp, malformed config), the crypto round-trip and tamper detection, and the route behaviour (valid publishes; invalid returns 401, writes a 401 delivery, and calls none of `message.create` / `bus.publish` / `pushQueue.add`).

`bun lint`, `bun format:check`, 442 server tests and 17 website tests all pass.

## Notes for the reviewer

- **The migration has not been run against a database.** It is validated only by `prisma generate`. Additive — two nullable columns and one `NOT NULL DEFAULT 'none'` — but it needs a real `bun run db:migrate` before this ships.
- **Existing test fixtures had to gain the new columns.** `receive.spec.ts` mocks predated them, so `verification` came back `undefined` and every delivery was rejected as `bad_config`. That is the fail-closed path working: a missing `verification` in a `select` disables the webhook rather than the check. I updated the fixtures rather than making the check lenient.
- **Clearing a secret is deliberately strict.** `PATCH { secret: null }` while `verification` is still on returns `400 missing_secret` instead of silently switching verification off. Silently disabling signature checks is the exact failure this feature exists to prevent.
- **Individual commits are not independently green.** The shared commit makes `hasSecret`/`verification` required on the `Webhook` type, so website typecheck only recovers at the website commit. `git bisect` across this branch will be noisy.
- **The Mintlify docs build could not be run** — it fails with `Cannot find module 'ajv/dist/core'` on a clean tree too. The three changed `.mdx` files were instead compiled with `@mdx-js/mdx` to confirm they parse; Mintlify component rendering is unverified.
