### PR TITLE
fix(suggestions): resolve subscriptions by account for signed-in callers

### DIFF
--- a/packages/emitsignal-server/src/http/topic/__tests__/suggestions.spec.ts
+++ b/packages/emitsignal-server/src/http/topic/__tests__/suggestions.spec.ts
@@ -5,7 +5,17 @@ import { prismaMock } from '#/__tests__/mocks';
 
 mock.module('#/lib/prisma', () => ({ prisma: prismaMock }));
 
+// Header-driven so a leak into other test files behaves like the real module
+// (no test header → anonymous).
+mock.module('#/http/auth/plugin', () => ({
+    resolveUserId: ({ headers }: { headers: Record<string, string | undefined> }) =>
+        Promise.resolve(headers['x-test-user-id'] ?? null),
+}));
+
 import { suggestions } from '#/http/topic/suggestions';
+
+const NEWS = 'emitsignal/news';
+const DISCOVER = 'emitsignal/discover';
 
 describe('GET /suggestions', () => {
     const app = new Elysia().use(suggestions);
@@ -26,19 +36,19 @@ describe('GET /suggestions', () => {
             {
                 description: 'EmitSignal news & announcements',
                 displayName: 'News',
-                name: 'emitsignal/news',
+                name: NEWS,
             },
             {
                 description: 'Discover trending topics & features',
                 displayName: 'Discover',
-                name: 'emitsignal/discover',
+                name: DISCOVER,
             },
         ]);
     });
 
-    it('excludes curated topics the device is already subscribed to', async () => {
+    it('excludes curated topics the anonymous device is already subscribed to', async () => {
         prismaMock.subscription.findMany.mockResolvedValueOnce([
-            { topic: { name: 'emitsignal/news' } },
+            { deviceId: 'dev-1', topic: { name: NEWS }, topicId: 't1' },
         ]);
 
         const res = await app.handle(new Request('http://localhost/suggestions?deviceId=dev-1'));
@@ -48,7 +58,55 @@ describe('GET /suggestions', () => {
         const data = await res.json();
 
         expect(data).toHaveLength(1);
-        expect(data[0]).toMatchObject({ name: 'emitsignal/discover' });
+        expect(data[0]).toMatchObject({ name: DISCOVER });
+    });
+
+    it('scopes the anonymous device query to userId null', async () => {
+        await app.handle(new Request('http://localhost/suggestions?deviceId=dev-1'));
+
+        expect(prismaMock.subscription.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { deviceId: 'dev-1', userId: null },
+            }),
+        );
+    });
+
+    it('excludes topics the signed-in account is subscribed to without a deviceId', async () => {
+        prismaMock.subscription.findMany.mockResolvedValueOnce([
+            { deviceId: 'dev-other', topic: { name: NEWS }, topicId: 't1' },
+        ]);
+
+        const res = await app.handle(
+            new Request('http://localhost/suggestions', {
+                headers: { 'x-test-user-id': 'user-1' },
+            }),
+        );
+
+        expect(res.status).toBe(200);
+
+        const data = await res.json();
+
+        expect(data).toHaveLength(1);
+        expect(data[0]).toMatchObject({ name: DISCOVER });
+        expect(prismaMock.subscription.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({ where: { userId: 'user-1' } }),
+        );
+    });
+
+    it('excludes account subscriptions made on another device', async () => {
+        prismaMock.subscription.findMany.mockResolvedValueOnce([
+            { deviceId: 'dev-a', topic: { name: NEWS }, topicId: 't1' },
+            { deviceId: 'dev-a', topic: { name: DISCOVER }, topicId: 't2' },
+        ]);
+
+        const res = await app.handle(
+            new Request('http://localhost/suggestions?deviceId=dev-b', {
+                headers: { 'x-test-user-id': 'user-1' },
+            }),
+        );
+
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual([]);
     });
 
     it('returns items with correct shape', async () => {
@@ -68,7 +126,7 @@ describe('GET /suggestions', () => {
         }
     });
 
-    it('does not query subscriptions when deviceId is not provided', async () => {
+    it('does not query subscriptions when anonymous and no deviceId is provided', async () => {
         const res = await app.handle(new Request('http://localhost/suggestions'));
 
         expect(res.status).toBe(200);

--- a/packages/emitsignal-server/src/http/topic/suggestions.ts
+++ b/packages/emitsignal-server/src/http/topic/suggestions.ts
@@ -1,7 +1,7 @@
 import Elysia, { t } from 'elysia';
 
 import { authAwareBeforeHandle } from '#/http/plugins/rate-limit-plugin';
-import { prisma } from '#/lib/prisma';
+import { resolveSubscriptions } from '#/http/subscriptions/resolve';
 import { readAnonLimiter, readAuthLimiter } from '#/lib/rate-limit';
 
 const CURATED = [
@@ -19,18 +19,14 @@ const CURATED = [
 
 export const suggestions = new Elysia().get(
     '/suggestions',
-    async ({ query }) => {
-        // Collect device subscription names so we don't re-suggest curated
-        // channels the device is already subscribed to.
-        let subscribedNames: string[] = [];
+    async ({ headers, query }) => {
+        // Resolve subscriptions the same way the rest of the subscriptions
+        // surface does: by account when the caller is signed in, by device when
+        // anonymous. Filtering on deviceId alone re-suggested curated channels
+        // to signed-in users on a second device or a fresh install.
+        const { rows } = await resolveSubscriptions({ deviceId: query.deviceId, headers });
 
-        if (query.deviceId) {
-            const deviceSubs = await prisma.subscription.findMany({
-                select: { topic: { select: { name: true } } },
-                where: { deviceId: query.deviceId },
-            });
-            subscribedNames = deviceSubs.map((subscription) => subscription.topic.name);
-        }
+        const subscribedNames = rows.map((subscription) => subscription.topic.name);
 
         return CURATED.filter((curated) => !subscribedNames.includes(curated.name));
     },


### PR DESCRIPTION
## Problem

`GET /suggestions` filtered curated channels using `deviceId` alone — no session resolution, no `userId` in the where clause. `subscriptions/claim.ts` preserves `deviceId` when adopting anonymous rows into an account, so same-device filtering happened to keep working, which masked the bug. It breaks whenever the deviceId no longer identifies the caller's subscriptions:

- **Cross-device** — subscribe on device A, open device B: different `deviceId`, zero rows, already-subscribed channels re-suggested.
- **Missing or late `deviceId`** — `getSuggestions` drops the query param when undefined; mobile `DeviceProvider` resolves async, and the website's `getDeviceId()` returns the literal `'server'` during SSR.
- **Cleared local storage** — account subscriptions persist, the filter does not.

That covers the onboarding path `app/auth/first-channels.tsx` drives.

## Fix

Delegate to `resolveSubscriptions`, the helper `subscriptions/list.ts`, `messages.ts`, and `metrics.ts` already use — account subscriptions when signed in, device subscriptions scoped to `userId: null` when anonymous. `suggestions.ts` was the one route on this surface that never got migrated.

```ts
const { rows } = await resolveSubscriptions({ deviceId: query.deviceId, headers });
const subscribedNames = rows.map((subscription) => subscription.topic.name);
```

This also closes a smaller gap: the old device query had no `userId: null` guard, so it could match rows already claimed by an account.

Signed-in callers filter on account subscriptions only, matching `resolveSubscriptions` semantics and relying on `claim` at sign-in rather than unioning in unclaimed device rows.

## Cost

`authAwareBeforeHandle` already calls `resolveUserId` on this route and the result is memoized in `sessionUserIdCache`, so the added resolution is a cache hit rather than a second Better Auth round trip. `resolveSubscriptions` does use `include: { topic: true }` where the old code had a name-only select — more columns than a two-entry curated list strictly needs, accepted in exchange for a single definition of "what am I subscribed to."

## Tests

Three new cases in `suggestions.spec.ts` cover anonymous `userId: null` scoping, signed-in without a `deviceId`, and signed-in on a different device. Auth is mocked header-driven (`x-test-user-id`) so a module-mock leak into another spec file still behaves like the real module.

Verified the tests are not vacuous: reverting `suggestions.ts` alone fails exactly those three (4 pass, 3 fail). With the fix, 7 pass, 0 fail.

Full server suite: 392 pass, 0 fail across 51 files. `bun lint` clean, `bun format` reports no changes.

`bunx tsc --noEmit` reports 4 errors, all pre-existing in `subscriptions/__tests__/update.spec.ts` (lines 69, 90) and untouched here — worth a separate cleanup.
