### PR TITLE
fix: keep mobile sessions alive for regular users

### DIFF
--- a/packages/emitsignal-mobile/lib/auth-client.ts
+++ b/packages/emitsignal-mobile/lib/auth-client.ts
@@ -28,4 +28,8 @@ export const authClient = createAuthClient({
         emailOTPClient(),
         inferAdditionalFields({ user: { onboarded: { type: 'boolean' } } }),
     ],
+    sessionOptions: {
+        refetchOnWindowFocus: true,
+        refetchWhenOffline: true,
+    },
 });

--- a/packages/emitsignal-server/src/lib/auth.ts
+++ b/packages/emitsignal-server/src/lib/auth.ts
@@ -223,6 +223,8 @@ export const auth = betterAuth({
             enabled: true,
             maxAge: duration.minutes(5).as('seconds'),
         },
+        expiresIn: duration.days(30).as('seconds'),
+        updateAge: duration.days(1).as('seconds'),
     },
     socialProviders: {
         ...(isAppleAuthEnabled


### PR DESCRIPTION
## Problem

The mobile app twice cold-started on the anonymous welcome screen instead of the tabs. The session really had expired, and the 7-day default was why.

`src/lib/auth.ts` set only `session.cookieCache`, so Better Auth's defaults applied: **7-day absolute expiry**, slid forward only by a `/get-session` call once the session is older than 24h. Two things made that window easy to fall out of:

- **Normal app traffic renews nothing the client can use.** API calls go through `emitsignal-shared/src/api.ts`, a plain `fetch` that never writes back to SecureStore. Only better-auth's own `/get-session` slides the stored cookie, and the Expo plugin drops that cookie locally once its `Max-Age` passes. Using the app frequently was not, by itself, keeping the session alive.
- **The foreground refetch that does renew could be silently skipped.** better-auth gates it behind `refetchWhenOffline || onlineManager.isOnline`, defaulting to `false`, and the Expo online manager reads `isOnline = !!state.isInternetReachable` — which Android reports as `null` in some states, marking the device offline and skipping the refresh on a working network.

## Changes

- **server** — `expiresIn: 30d`, `updateAge: 1d`. `updateAge` is the old default made explicit, so DB write volume is unchanged (one `Session` update per user per day); the 30 days is what widens the window. Both `Session.expiresAt` and the cookie's `Max-Age` derive from it, so the server row and client cookie extend together.
- **mobile** — `sessionOptions: { refetchOnWindowFocus: true, refetchWhenOffline: true }`. The first is already the default and is stated for clarity; the second removes the reachability gate. Refetching while genuinely offline is harmless: a network error keeps the previous session data, and only a 401 clears it.
