### PR TITLE
docs(website): disclose log ingestion in the privacy policy

### DIFF
--- a/packages/emitsignal-website/src/routes/privacy.tsx
+++ b/packages/emitsignal-website/src/routes/privacy.tsx
@@ -21,7 +21,7 @@ export const Route = createFileRoute('/privacy')({
     }),
 });
 
-const LAST_UPDATED = 'June 23, 2026';
+const LAST_UPDATED = 'August 14, 2026';
 
 interface TableOfContentsEntry {
     id: string;
@@ -80,6 +80,11 @@ const PROCESSORS: ProcessorRow[] = [
         data: 'Performance trace spans and attributes, account id',
         name: 'OpenTelemetry collector (optional)',
         purpose: 'Performance and reliability observability',
+    },
+    {
+        data: 'Application log records: timestamp, severity, message, service name, host, request method, path and status, and an account id where one is involved',
+        name: 'Log ingestion provider (optional)',
+        purpose: 'Centralised application logging, debugging, and incident investigation',
     },
     {
         data: 'Avatar images and message attachments',
@@ -252,11 +257,18 @@ function PrivacyPage() {
 
                         <H3>Operational logs &amp; usage</H3>
                         <P>
-                            Application logs (which may include your account id, the recipient
-                            address of an email we send, and a provider message id), rate-limit
-                            counters keyed by IP address (for anonymous traffic) or account id, and
-                            daily usage quota counters. If enabled, error-monitoring and tracing
-                            services receive technical diagnostic data.
+                            Application logs (which may include your account id and a provider
+                            message id), rate-limit counters keyed by IP address (for anonymous
+                            traffic) or account id, and daily usage quota counters. If enabled,
+                            error-monitoring and tracing services receive technical diagnostic data.
+                        </P>
+                        <P>
+                            When a log ingestion provider is configured, these application logs are
+                            forwarded to it so that we can debug and investigate incidents from one
+                            place. Direct identifiers — recipient email addresses and IP addresses —
+                            are redacted before a log record leaves our servers, so what the
+                            provider receives is limited to the technical fields listed in the
+                            processor table below.
                         </P>
                     </Section>
 
@@ -359,6 +371,11 @@ function PrivacyPage() {
                             <Li>
                                 <strong>Rate-limit, quota, and cache counters</strong> expire
                                 automatically within minutes to hours.
+                            </Li>
+                            <Li>
+                                <strong>Application logs</strong> forwarded to our log ingestion
+                                provider are retained for up to 30 days, after which the provider
+                                deletes them automatically.
                             </Li>
                             <Li>
                                 <strong>


### PR DESCRIPTION
Follow-up to #38, which added optional remote log ingestion. Application logs now reach a new sub-processor, so the policy has to say so.

- Adds a `Log ingestion provider (optional)` row to the processor table, listing the technical fields a log record carries. The vendor is named in the description rather than the `name` column, since the server config is provider-switched rather than Better Stack-specific.
- Corrects §3 "Operational logs & usage": it previously named only error-monitoring and tracing services as recipients, and listed email recipient addresses as a logged field. Now states that logs are forwarded when a provider is configured, and that email addresses and IPs are redacted first.
- Adds a 30-day retention bullet to §8 for forwarded logs.
- Bumps `LAST_UPDATED` — §12 commits to this for material changes.

**Merge order:** the redaction claim in §3 is implemented by the server logging PR. Merge that one first (or together with this) so the policy is accurate on landing.

No change needed in `terms.tsx` (§10 defers to this policy generically) or in the mobile app (`app/auth/sign-in.tsx` already links to `/privacy`).

Verified with `bun run test` in the website package — 17 pass.