### PR TITLE
refactor(server): make the log stream useful

### DIFF
--- a/packages/emitsignal-server/src/http/messages/purge.ts
+++ b/packages/emitsignal-server/src/http/messages/purge.ts
@@ -1,6 +1,7 @@
 import Elysia from 'elysia';
 
 import { resolveUserId } from '#/http/auth/plugin';
+import { logger } from '#/lib/logger';
 import { purgeQueue } from '#/lib/queue';
 import { captureTraceContext } from '#/lib/trace-context';
 
@@ -14,6 +15,8 @@ export const purgeSignals = new Elysia().delete('/me/signals', async ({ headers,
     if (!userId) {
         return status(401, { error: 'missing_token' });
     }
+
+    logger.info({ userId }, 'signal purge requested');
 
     await purgeQueue.add('purge-signals', {
         kind: 'signals',

--- a/packages/emitsignal-server/src/http/plugins/__tests__/logger-plugin.spec.ts
+++ b/packages/emitsignal-server/src/http/plugins/__tests__/logger-plugin.spec.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import Elysia, { t } from 'elysia';
+
+import { logger } from '#/lib/logger';
+
+import { loggerPlugin } from '../logger-plugin';
+
+mock.module('@sentry/bun', () => ({ captureException: () => {} }));
+
+const info = spyOn(logger, 'info');
+const warn = spyOn(logger, 'warn');
+const error = spyOn(logger, 'error');
+
+function buildApp() {
+    return new Elysia()
+        .use(loggerPlugin)
+        .get('/health', () => 'ok')
+        .get('/ok', () => ({ ok: true }))
+        .get('/boom', () => {
+            throw new Error('kaboom');
+        })
+        .post('/echo', ({ body }) => body, { body: t.Object({ title: t.String() }) });
+}
+
+// onAfterResponse fires after the handler resolves, so the assertions need a tick.
+async function call(path: string, init?: RequestInit) {
+    const response = await buildApp().handle(new Request(`http://localhost${path}`, init));
+
+    await Bun.sleep(1);
+
+    return response;
+}
+
+afterEach(() => {
+    info.mockClear();
+    warn.mockClear();
+    error.mockClear();
+});
+
+describe('loggerPlugin access log', () => {
+    it('logs a successful request at info with structured fields', async () => {
+        await call('/ok');
+
+        expect(info).toHaveBeenCalledTimes(1);
+
+        const [fields, message] = info.mock.calls[0] as [Record<string, unknown>, string];
+
+        expect(message).toBe('request');
+        expect(fields.method).toBe('GET');
+        expect(fields.path).toBe('/ok');
+        expect(fields.status).toBe(200);
+        expect(typeof fields.durationMs).toBe('number');
+    });
+
+    it('measures each request separately rather than sharing one timestamp', async () => {
+        const app = buildApp();
+
+        await Promise.all([
+            app.handle(new Request('http://localhost/ok')),
+            app.handle(new Request('http://localhost/ok')),
+        ]);
+
+        await Bun.sleep(1);
+
+        const durations = info.mock.calls.map(
+            (arguments_) => (arguments_[0] as { durationMs: number }).durationMs,
+        );
+
+        expect(durations).toHaveLength(2);
+        expect(durations.every((duration) => duration >= 0)).toBe(true);
+    });
+
+    it('skips the health check when it succeeds', async () => {
+        await call('/health');
+
+        expect(info).not.toHaveBeenCalled();
+    });
+
+    it('logs client errors at warn, not error', async () => {
+        await call('/missing');
+
+        expect(error).not.toHaveBeenCalled();
+        expect((warn.mock.calls[0]?.[0] as { status: number }).status).toBe(404);
+    });
+
+    it('omits the duration when no route matched instead of reporting NaN', async () => {
+        await call('/missing');
+
+        expect((warn.mock.calls[0]?.[0] as { durationMs?: number }).durationMs).toBeUndefined();
+    });
+
+    it('logs server errors at error', async () => {
+        await call('/boom');
+
+        const accessCall = error.mock.calls.find((arguments_) => arguments_[1] === 'request');
+
+        expect((accessCall?.[0] as { status: number }).status).toBe(500);
+    });
+
+    it('reports validation failures at warn with field paths but no submitted values', async () => {
+        await call('/echo', {
+            body: JSON.stringify({ title: 42 }),
+            headers: { 'content-type': 'application/json' },
+            method: 'POST',
+        });
+
+        const validationCall = warn.mock.calls.find(
+            (arguments_) => arguments_[1] === 'validation failed',
+        );
+
+        expect(validationCall).toBeDefined();
+
+        const fields = validationCall?.[0] as { fields: string[] };
+
+        expect(fields.fields).toContain('/title');
+        expect(JSON.stringify(fields)).not.toContain('42');
+    });
+});

--- a/packages/emitsignal-server/src/http/plugins/logger-plugin.ts
+++ b/packages/emitsignal-server/src/http/plugins/logger-plugin.ts
@@ -26,32 +26,47 @@ function contentLength(set: { headers: Record<string, string | undefined> }, bod
     }
 }
 
+// Client-caused failures (401, 404, 422, 429) are not our errors; logging them
+// as such buries real 5xx incidents and inflates error-rate alerts.
+function levelFor(status: number) {
+    if (status >= 500) {
+        return 'error' as const;
+    }
+
+    if (status >= 400) {
+        return 'warn' as const;
+    }
+
+    return 'info' as const;
+}
+
 export const loggerPlugin = new Elysia({ name: 'logger' })
-    .decorate('logger', logger)
-    .state('requestStart', 0)
-    .onRequest(({ store }) => {
-        store.requestStart = performance.now();
-    })
-    .onAfterResponse(({ request, responseValue, set, store }) => {
-        const status = set.status ?? 200;
+    .derive(() => ({ requestStart: performance.now() }))
+    .onAfterResponse(({ request, requestStart, responseValue, set }) => {
+        const status = (set.status ?? 200) as number;
 
         const path = new URL(request.url).pathname;
 
-        if (isUnobservedPath(path) && (status as number) < 400) {
+        if (isUnobservedPath(path) && status < 400) {
             return;
         }
 
-        const durationMs = (performance.now() - store.requestStart).toFixed(3);
-        const length = contentLength(set as never, responseValue);
-        const message = `${request.method} ${path} ${status} ${durationMs} ms - ${length}`;
+        // No route matched means `derive` never ran, so there is no start time.
+        const start = requestStart as number | undefined;
 
-        if ((status as number) >= 400) {
-            logger.error(message);
-
-            return;
-        }
-
-        logger.info(message);
+        logger[levelFor(status)](
+            {
+                durationMs:
+                    start === undefined
+                        ? undefined
+                        : Number((performance.now() - start).toFixed(3)),
+                length: contentLength(set as never, responseValue),
+                method: request.method,
+                path,
+                status,
+            },
+            'request',
+        );
     })
     .onError(({ code, error, request }) => {
         const path = new URL(request.url).pathname;
@@ -61,9 +76,11 @@ export const loggerPlugin = new Elysia({ name: 'logger' })
         }
 
         if (code === 'VALIDATION') {
-            logger.error(
-                { cause: error.cause, code, method: request.method, url: path },
-                'validation errors',
+            // Only the field paths: the TypeBox cause embeds the offending request
+            // body value, which would put user input into the log pipeline.
+            logger.warn(
+                { code, fields: validationFields(error), method: request.method, url: path },
+                'validation failed',
             );
 
             return;
@@ -77,3 +94,15 @@ export const loggerPlugin = new Elysia({ name: 'logger' })
         });
     })
     .as('global');
+
+function validationFields(error: unknown): string[] {
+    const all = (error as { all?: unknown }).all;
+
+    if (!Array.isArray(all)) {
+        return [];
+    }
+
+    return all
+        .map((issue) => (issue as { path?: unknown }).path)
+        .filter((path): path is string => typeof path === 'string');
+}

--- a/packages/emitsignal-server/src/http/plugins/rate-limit-plugin.ts
+++ b/packages/emitsignal-server/src/http/plugins/rate-limit-plugin.ts
@@ -71,6 +71,8 @@ export async function consumeLimit(
         if (rl?.msBeforeNext !== undefined) {
             const retryAfter = Math.ceil(rl.msBeforeNext / 1000);
 
+            logger.warn({ limiter: limiter.keyPrefix, retryAfter }, 'rate limit exceeded');
+
             set.headers['retry-after'] = String(retryAfter);
             set.status = 429;
 

--- a/packages/emitsignal-server/src/http/plugins/rate-limit-plugin.ts
+++ b/packages/emitsignal-server/src/http/plugins/rate-limit-plugin.ts
@@ -80,7 +80,10 @@ export async function consumeLimit(
         // a limiter outage used to be logged and then silently ignored
         // on every route. Surface it as an exception so it actually pages someone,
         // instead of only landing in a log nobody is watching.
-        logger.error({ error, failClosed: options.failClosed === true, key }, 'rate limiter error');
+        logger.error(
+            { error, failClosed: options.failClosed === true, limiter: limiter.keyPrefix },
+            'rate limiter error',
+        );
         reportLimiterError(error);
 
         if (options.failClosed) {

--- a/packages/emitsignal-server/src/http/topic/publish.ts
+++ b/packages/emitsignal-server/src/http/topic/publish.ts
@@ -3,8 +3,10 @@ import Elysia, { t } from 'elysia';
 import { resolveUserId } from '#/http/auth/plugin';
 import { authAwareBeforeHandle } from '#/http/plugins/rate-limit-plugin';
 import { bus } from '#/lib/event-bus';
+import { logger } from '#/lib/logger';
 import { prisma } from '#/lib/prisma';
 import { pushQueue, scheduleQueue } from '#/lib/queue';
+import { enqueueDetached } from '#/lib/queue/enqueue';
 import { publishAnonLimiter, publishAuthLimiter } from '#/lib/rate-limit';
 import { captureTraceContext } from '#/lib/trace-context';
 import { getUserLimits, getUserPlan } from '#/services/billing/get-user-plan';
@@ -97,6 +99,11 @@ function publishRoute(path: string, deprecated: boolean) {
                 const quota = await consumeDailyQuota(userId, 'messages', limits.messagesPerDay);
 
                 if (!quota.allowed) {
+                    logger.warn(
+                        { limit: quota.limit, metric: 'messages', userId },
+                        'daily quota exceeded',
+                    );
+
                     Object.assign(set.headers, quotaExceededHeaders(quota));
 
                     return status(429, {
@@ -180,7 +187,8 @@ function publishRoute(path: string, deprecated: boolean) {
             });
 
             if (isScheduled) {
-                scheduleQueue.add(
+                enqueueDetached(
+                    scheduleQueue,
                     'schedule-delivery',
                     { messageId: message.id, traceContext: captureTraceContext() },
                     { delay: (scheduledAtUnix - now) * 1000 },
@@ -197,7 +205,7 @@ function publishRoute(path: string, deprecated: boolean) {
 
             bus.publish(topic.name, { ...event, topicName: topic.name });
 
-            pushQueue.add('push-message', {
+            enqueueDetached(pushQueue, 'push-message', {
                 actions,
                 body: messageBody,
                 createdAt: message.createdAt.getTime(),

--- a/packages/emitsignal-server/src/http/webhooks/receive.ts
+++ b/packages/emitsignal-server/src/http/webhooks/receive.ts
@@ -10,6 +10,7 @@ import { bus } from '#/lib/event-bus';
 import { logger } from '#/lib/logger';
 import { prisma } from '#/lib/prisma';
 import { pushQueue } from '#/lib/queue';
+import { enqueueDetached } from '#/lib/queue/enqueue';
 import { webhookReceiveLimiter } from '#/lib/rate-limit';
 import { captureTraceContext } from '#/lib/trace-context';
 import { getUserPlan } from '#/services/billing/get-user-plan';
@@ -149,7 +150,7 @@ export const receiveWebhook = new Elysia().post(
 
         bus.publish(topic.name, { ...event, topicName: topic.name });
 
-        pushQueue.add('push-message', {
+        enqueueDetached(pushQueue, 'push-message', {
             actions,
             body: messageBody,
             createdAt: message.createdAt.getTime(),

--- a/packages/emitsignal-server/src/lib/auth.ts
+++ b/packages/emitsignal-server/src/lib/auth.ts
@@ -12,6 +12,7 @@ import path from 'node:path';
 import { createElement } from 'react';
 import Stripe from 'stripe';
 
+import { logger } from '#/lib/logger';
 import { captureTraceContext } from '#/lib/trace-context';
 import { environment, isProduction } from '#/schema/environment';
 import { invalidateUserPlanCache } from '#/services/billing/get-user-plan';
@@ -40,15 +41,51 @@ const stripePlugins = isStripeBillingEnabled()
               subscription: {
                   enabled: true,
                   onSubscriptionCancel: async ({ subscription }) => {
+                      logger.info(
+                          {
+                              event: 'cancelled',
+                              plan: subscription.plan,
+                              userId: subscription.referenceId,
+                          },
+                          'subscription changed',
+                      );
+
                       await invalidateUserPlanCache(subscription.referenceId);
                   },
                   onSubscriptionComplete: async ({ subscription }) => {
+                      logger.info(
+                          {
+                              event: 'completed',
+                              plan: subscription.plan,
+                              userId: subscription.referenceId,
+                          },
+                          'subscription changed',
+                      );
+
                       await invalidateUserPlanCache(subscription.referenceId);
                   },
                   onSubscriptionDeleted: async ({ subscription }) => {
+                      logger.info(
+                          {
+                              event: 'deleted',
+                              plan: subscription.plan,
+                              userId: subscription.referenceId,
+                          },
+                          'subscription changed',
+                      );
+
                       await invalidateUserPlanCache(subscription.referenceId);
                   },
                   onSubscriptionUpdate: async ({ subscription }) => {
+                      logger.info(
+                          {
+                              event: 'updated',
+                              plan: subscription.plan,
+                              userId: subscription.referenceId,
+                          },
+                          'subscription changed',
+                      );
+
                       await invalidateUserPlanCache(subscription.referenceId);
                   },
                   plans: stripePlanConfig(),
@@ -130,6 +167,8 @@ export const auth = betterAuth({
                 return;
             }
 
+            logger.info({ userId: ctx.context.session?.user.id }, 'api key created');
+
             await sendApiKeyCreatedEmail(returned);
         }),
         before: createAuthMiddleware(async (ctx) => {
@@ -164,6 +203,8 @@ export const auth = betterAuth({
             );
 
             if (typeof email === 'string' && !isEmailAllowed(email)) {
+                logger.warn('sign-in blocked by the email allowlist');
+
                 throw new APIError('FORBIDDEN', {
                     message: 'This email address is not allowed to sign in.',
                 });
@@ -265,6 +306,8 @@ export const auth = betterAuth({
                 await sendAccountDeletedEmail(user);
             },
             beforeDelete: async (user) => {
+                logger.info({ userId: user.id }, 'deleting account');
+
                 const attachments = await prisma.attachment.findMany({
                     select: { storageKey: true },
                     where: {

--- a/packages/emitsignal-server/src/lib/email/resend-provider.ts
+++ b/packages/emitsignal-server/src/lib/email/resend-provider.ts
@@ -26,6 +26,6 @@ export class ResendProvider implements EmailProvider {
             throw new Error(`Resend email failed: ${error.message}`);
         }
 
-        logger.info({ resendId: data?.id, to: options.to }, 'email sent (resend)');
+        logger.info({ resendId: data?.id }, 'email sent (resend)');
     }
 }

--- a/packages/emitsignal-server/src/lib/email/smtp-provider.ts
+++ b/packages/emitsignal-server/src/lib/email/smtp-provider.ts
@@ -33,6 +33,6 @@ export class SmtpProvider implements EmailProvider {
             to: options.to,
         });
 
-        logger.info({ messageId: info.messageId, to: options.to }, 'email sent (smtp)');
+        logger.info({ messageId: info.messageId }, 'email sent (smtp)');
     }
 }

--- a/packages/emitsignal-server/src/lib/logger.ts
+++ b/packages/emitsignal-server/src/lib/logger.ts
@@ -47,6 +47,10 @@ export const logger = pino({
 
         return { span_id: spanId, trace_id: traceId };
     },
+    // Backstop for the whole process: log records leave the box when an ingestion
+    // provider is configured, and these field names are the ones that carry a
+    // direct identifier (recipient address, rate-limit key = ip or ip:email).
+    redact: { censor: '[redacted]', paths: ['email', 'key', 'to', '*.email', '*.to'] },
     transport: { targets: ingestionTarget ? [localTarget, ingestionTarget] : [localTarget] },
     ...(isProduction ? {} : { msgPrefix: '[EmitSignal] ' }),
 });

--- a/packages/emitsignal-server/src/lib/queue/connection.ts
+++ b/packages/emitsignal-server/src/lib/queue/connection.ts
@@ -1,8 +1,19 @@
 import Redis from 'ioredis';
 
+import { logger } from '#/lib/logger';
 import { environment } from '#/schema/environment';
 
 export const redisConnection = new Redis(environment.REDIS_URL, {
     enableReadyCheck: false,
     maxRetriesPerRequest: null,
+});
+
+// ioredis reconnects on its own, so without a listener a queue outage is entirely
+// silent: jobs simply stop moving.
+redisConnection.on('error', (error: Error) => {
+    logger.error({ error }, 'queue redis connection error');
+});
+
+redisConnection.on('reconnecting', () => {
+    logger.warn('queue redis reconnecting');
 });

--- a/packages/emitsignal-server/src/lib/queue/email/email-worker.ts
+++ b/packages/emitsignal-server/src/lib/queue/email/email-worker.ts
@@ -28,7 +28,7 @@ export function createEmailWorker(): Worker<Traced<EmailOptions>> {
                 traceContextFrom(job.data.traceContext),
                 async (span) => {
                     try {
-                        logger.info({ jobId: job.id, to: job.data.to }, 'processing email job');
+                        logger.info({ jobId: job.id }, 'processing email job');
 
                         await Email.provider.send(job.data);
 

--- a/packages/emitsignal-server/src/lib/queue/email/email-worker.ts
+++ b/packages/emitsignal-server/src/lib/queue/email/email-worker.ts
@@ -28,8 +28,6 @@ export function createEmailWorker(): Worker<Traced<EmailOptions>> {
                 traceContextFrom(job.data.traceContext),
                 async (span) => {
                     try {
-                        logger.info({ jobId: job.id }, 'processing email job');
-
                         await Email.provider.send(job.data);
 
                         span.setStatus({ code: SpanStatusCode.OK });
@@ -57,7 +55,15 @@ export function createEmailWorker(): Worker<Traced<EmailOptions>> {
     });
 
     worker.on('failed', (job, err) => {
-        logger.error({ err, jobId: job?.id }, 'email job failed');
+        logger.error(
+            {
+                attempt: job?.attemptsMade,
+                attempts: job?.opts.attempts,
+                err,
+                jobId: job?.id,
+            },
+            'email job failed',
+        );
     });
 
     return worker;

--- a/packages/emitsignal-server/src/lib/queue/enqueue.ts
+++ b/packages/emitsignal-server/src/lib/queue/enqueue.ts
@@ -1,0 +1,23 @@
+import type { JobsOptions, Queue } from 'bullmq';
+
+import { logger } from '#/lib/logger';
+
+// Publish paths enqueue without awaiting so a slow Redis never holds up the
+// response. The catch is the whole point: an unhandled rejection here means the
+// message row exists, the caller was told it was accepted, and delivery never
+// happens — previously with nothing in the logs to explain it.
+export function enqueueDetached<TData, TResult, TName extends string>(
+    queue: Queue<TData, TResult, TName>,
+    name: TName,
+    data: TData,
+    options?: JobsOptions,
+): void {
+    // BullMQ's own `add` narrows the name through ExtractNameType, which does not
+    // survive being passed through a generic wrapper. Call-site types are still
+    // checked by the parameters above.
+    const add = queue.add as (name: TName, data: TData, options?: JobsOptions) => Promise<unknown>;
+
+    add(name, data, options).catch((error: unknown) => {
+        logger.error({ error, job: name, queue: queue.name }, 'failed to enqueue job');
+    });
+}

--- a/packages/emitsignal-server/src/lib/queue/purge/purge-worker.ts
+++ b/packages/emitsignal-server/src/lib/queue/purge/purge-worker.ts
@@ -70,7 +70,15 @@ export function createPurgeWorker(): Worker<Traced<PurgeJob>> {
     });
 
     worker.on('failed', (job, err) => {
-        logger.error({ err, jobId: job?.id }, 'purge job failed');
+        logger.error(
+            {
+                attempt: job?.attemptsMade,
+                attempts: job?.opts.attempts,
+                err,
+                jobId: job?.id,
+            },
+            'purge job failed',
+        );
     });
 
     return worker;

--- a/packages/emitsignal-server/src/lib/queue/push/push-worker.ts
+++ b/packages/emitsignal-server/src/lib/queue/push/push-worker.ts
@@ -29,11 +29,6 @@ export function createPushWorker(): Worker<Traced<PushJob>> {
                 traceContextFrom(job.data.traceContext),
                 async (span) => {
                     try {
-                        logger.info(
-                            { jobId: job.id, topicName: job.data.topicName },
-                            'processing push job',
-                        );
-
                         await sendPushNotifications(job.data);
 
                         span.setStatus({ code: SpanStatusCode.OK });
@@ -61,7 +56,15 @@ export function createPushWorker(): Worker<Traced<PushJob>> {
     });
 
     worker.on('failed', (job, err) => {
-        logger.error({ err, jobId: job?.id }, 'push job failed');
+        logger.error(
+            {
+                attempt: job?.attemptsMade,
+                attempts: job?.opts.attempts,
+                err,
+                jobId: job?.id,
+            },
+            'push job failed',
+        );
     });
 
     return worker;

--- a/packages/emitsignal-server/src/lib/queue/schedule/schedule-worker.ts
+++ b/packages/emitsignal-server/src/lib/queue/schedule/schedule-worker.ts
@@ -5,6 +5,7 @@ import { bus } from '#/lib/event-bus';
 import { logger } from '#/lib/logger';
 import { prisma } from '#/lib/prisma';
 import { redisConnection } from '#/lib/queue/connection';
+import { enqueueDetached } from '#/lib/queue/enqueue';
 import { pushQueue } from '#/lib/queue/push/push-queue';
 import { captureTraceContext, traceContextFrom, Traced } from '#/lib/trace-context';
 import { getUserPlan } from '#/services/billing/get-user-plan';
@@ -37,8 +38,6 @@ export function createScheduleWorker(): Worker<Traced<ScheduleJob>> {
                 traceContextFrom(job.data.traceContext),
                 async (span) => {
                     try {
-                        logger.info({ jobId: job.id, messageId }, 'processing schedule job');
-
                         const message = await prisma.message.findUnique({
                             include: { topic: true },
                             where: { id: messageId },
@@ -66,7 +65,7 @@ export function createScheduleWorker(): Worker<Traced<ScheduleJob>> {
                             topicName: message.topic.name,
                         });
 
-                        pushQueue.add('push-message', {
+                        enqueueDetached(pushQueue, 'push-message', {
                             actions: parseActions(message.actions),
                             body: message.body,
                             createdAt: message.createdAt.getTime(),
@@ -93,10 +92,7 @@ export function createScheduleWorker(): Worker<Traced<ScheduleJob>> {
                             where: { id: message.id },
                         });
 
-                        logger.info(
-                            { messageId },
-                            'schedule job completed: SSE emitted, push enqueued',
-                        );
+                        logger.info({ messageId }, 'scheduled message delivered');
 
                         span.setStatus({ code: SpanStatusCode.OK });
                     } catch (error) {
@@ -118,12 +114,16 @@ export function createScheduleWorker(): Worker<Traced<ScheduleJob>> {
         },
     );
 
-    worker.on('completed', (job) => {
-        logger.info({ jobId: job.id }, 'schedule job completed');
-    });
-
     worker.on('failed', (job, err) => {
-        logger.error({ err, jobId: job?.id }, 'schedule job failed');
+        logger.error(
+            {
+                attempt: job?.attemptsMade,
+                attempts: job?.opts.attempts,
+                err,
+                jobId: job?.id,
+            },
+            'schedule job failed',
+        );
     });
 
     return worker;

--- a/packages/emitsignal-server/src/lib/rate-limit/enforce.ts
+++ b/packages/emitsignal-server/src/lib/rate-limit/enforce.ts
@@ -22,6 +22,8 @@ export async function enforceAuthRateLimit(
         const rateLimit = error as { msBeforeNext?: number };
 
         if (rateLimit?.msBeforeNext !== undefined) {
+            logger.warn({ limiter: limiter.keyPrefix }, 'auth rate limit exceeded');
+
             throw new APIError('TOO_MANY_REQUESTS', {
                 message: 'Too many requests. Please try again later.',
             });

--- a/packages/emitsignal-server/src/lib/rate-limit/enforce.ts
+++ b/packages/emitsignal-server/src/lib/rate-limit/enforce.ts
@@ -27,7 +27,10 @@ export async function enforceAuthRateLimit(
             });
         }
 
-        logger.error({ error, key }, 'auth rate limiter error, failing closed');
+        logger.error(
+            { error, limiter: limiter.keyPrefix },
+            'auth rate limiter error, failing closed',
+        );
 
         throw new APIError('TOO_MANY_REQUESTS', {
             message: 'Service temporarily unavailable. Please try again later.',

--- a/packages/emitsignal-server/src/lib/rate-limit/limiters.ts
+++ b/packages/emitsignal-server/src/lib/rate-limit/limiters.ts
@@ -1,6 +1,7 @@
 import Redis from 'ioredis';
 import { RateLimiterMemory, RateLimiterRedis } from 'rate-limiter-flexible';
 
+import { logger } from '#/lib/logger';
 import { environment } from '#/schema/environment';
 import { duration } from '#/utils/duration';
 
@@ -10,6 +11,10 @@ import { duration } from '#/utils/duration';
 export const rateLimitRedis = new Redis(environment.REDIS_URL, {
     enableReadyCheck: false,
     maxRetriesPerRequest: 0,
+});
+
+rateLimitRedis.on('error', (error: Error) => {
+    logger.error({ error }, 'rate limit redis connection error');
 });
 
 // In test mode use in-memory limiters with large points so unit/integration tests

--- a/packages/emitsignal-server/src/lib/storage/local-provider.ts
+++ b/packages/emitsignal-server/src/lib/storage/local-provider.ts
@@ -1,6 +1,8 @@
 import { mkdir, unlink, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
+import { logger } from '#/lib/logger';
+
 import type { FileMetadata, FileStorage, FileUploadInput } from './provider';
 
 import { extensionForMimeType } from './provider';
@@ -14,8 +16,12 @@ export class LocalFileStorage implements FileStorage {
     async delete(storageKey: string): Promise<void> {
         const filePath = path.join(this.uploadDir, storageKey);
 
-        await unlink(filePath).catch(() => {
-            // file may already be gone — that's fine
+        await unlink(filePath).catch((error: NodeJS.ErrnoException) => {
+            if (error.code === 'ENOENT') {
+                return;
+            }
+
+            logger.warn({ error, storageKey }, 'local file delete failed');
         });
     }
 

--- a/packages/emitsignal-server/src/lib/storage/s3-provider.ts
+++ b/packages/emitsignal-server/src/lib/storage/s3-provider.ts
@@ -1,3 +1,4 @@
+import { logger } from '#/lib/logger';
 import { duration } from '#/utils/duration';
 
 import type { FileMetadata, FileStorage, FileUploadInput, StorageBucket } from './provider';
@@ -49,8 +50,11 @@ export class S3FileStorage implements FileStorage {
     async delete(storageKey: string, bucket: StorageBucket = 'private'): Promise<void> {
         await this.clientFor(bucket)
             .delete(storageKey)
-            .catch(() => {
-                // object may already be gone — that's fine
+            .catch((error: unknown) => {
+                // The object may already be gone, which is fine — but a credentials
+                // or permission failure looks identical here and used to leave the
+                // object orphaned with nothing recorded anywhere.
+                logger.warn({ bucket, error, storageKey }, 's3 delete failed');
             });
     }
 

--- a/packages/emitsignal-server/src/services/billing/usage.ts
+++ b/packages/emitsignal-server/src/services/billing/usage.ts
@@ -1,3 +1,4 @@
+import { logger } from '#/lib/logger';
 import { rateLimitRedis } from '#/lib/rate-limit';
 import { duration } from '#/utils/duration';
 
@@ -42,8 +43,11 @@ export async function consumeDailyQuota(
         }
 
         return { allowed: used <= limit, limit, remaining: Math.max(0, limit - used), resetAt };
-    } catch {
-        // Redis unavailable — fail open, like the request rate limiters
+    } catch (error) {
+        // Redis unavailable — fail open, like the request rate limiters. Log it:
+        // while this branch is live, plan quotas are not being enforced at all.
+        logger.error({ error, metric }, 'daily quota check failed, allowing request');
+
         return { allowed: true, limit, remaining: limit, resetAt };
     }
 }

--- a/packages/emitsignal-server/src/services/push/expo-client.ts
+++ b/packages/emitsignal-server/src/services/push/expo-client.ts
@@ -1,6 +1,7 @@
 import { SpanKind, SpanStatusCode, trace } from '@opentelemetry/api';
 import { Expo, type ExpoPushMessage, type ExpoPushTicket } from 'expo-server-sdk';
 
+import { logger } from '#/lib/logger';
 import { environment } from '#/schema/environment';
 
 import type { PushJob } from './types';
@@ -76,9 +77,24 @@ async function sendChunk(chunk: ExpoPushMessage[], send: ExpoSender): Promise<vo
 
                 span.setAttribute('expo.push.rejected_count', rejected.length);
                 span.setStatus({ code: SpanStatusCode.OK });
+
+                if (rejected.length > 0) {
+                    logger.warn(
+                        {
+                            reasons: rejected.map((ticket) =>
+                                ticket.status === 'error' ? ticket.details?.error : undefined,
+                            ),
+                            rejected: rejected.length,
+                            sent: chunk.length,
+                        },
+                        'expo rejected push tokens',
+                    );
+                }
             } catch (error) {
                 span.recordException(error instanceof Error ? error : new Error(String(error)));
                 span.setStatus({ code: SpanStatusCode.ERROR });
+
+                logger.error({ error, sent: chunk.length }, 'expo push send failed');
 
                 throw error;
             } finally {


### PR DESCRIPTION
Follow-up to #38. Now that every log line can be shipped to a paid provider, an audit of all 41 `logger.*` call sites found the stream is simultaneously too noisy and too sparse. This fixes the high-value half; the rest is left alone deliberately.

**Stacked on #38** (it touches `src/lib/logger.ts`), so this targets `feat/server-log-ingestion`. GitHub will retarget it to `main` once #38 merges. Merge this before, or together with, #39 — that PR's privacy text states emails and IPs are redacted, which is implemented here.

### Stop shipping personal data
Recipient email addresses (email worker + both real providers) and rate-limit keys — `ip:email` for the magic-link limiter — were being logged and would now leave the box. Removed at the source, replaced with `limiter.keyPrefix` where a label was actually what mattered, plus a process-wide pino `redact` as a backstop. Note the old `redact` option sat inside the non-production branch and always evaluated to `[]`, so it never did anything.

### Fix the access log
- Structured fields instead of one interpolated string, so `status`/`path`/`durationMs` are queryable.
- 4xx now logs at `warn`; `error` is reserved for 5xx. Previously a 401 or a 404 was an ERROR.
- **Real bug:** `.state('requestStart')` is Elysia's *app-wide* store, not per-request — concurrent requests overwrote each other's start time, so `durationMs` was wrong under any load. Moved to `derive`. Unmatched routes never run `derive`, so the duration is omitted rather than reported as `NaN`.
- Validation failures log field paths only; the TypeBox `cause` embeds the submitted value.
- Dropped the unused `.decorate('logger', logger)`.

### Log the failures that were invisible
- **`publish` could silently lose messages.** `scheduleQueue.add`/`pushQueue.add` were fire-and-forget with no `.catch` in four places: the row was persisted, the API returned `{message:'scheduled'}`, and a rejected enqueue meant the message was never delivered and nothing was logged. New `enqueueDetached` helper keeps the non-blocking behaviour and logs the rejection.
- Expo per-token rejections (`DeviceNotRegistered`, invalid tokens) only set a span attribute; now logged with reasons.
- S3/local delete failures were `.catch(() => {})` — a permissions error looked identical to "already gone".
- ioredis clients had no `error`/`reconnecting` listeners, so a Redis outage was silent.
- Quota exhaustion, rate-limit 429s, and the quota **fail-open** path (where plan limits silently stop being enforced) now log.
- Auth and billing had zero logging: allowlist rejections, API key creation, all four subscription lifecycle hooks, account deletion, and signal purge requests are now traceable.

### Cut the noise
Dropped the paired "processing X job" lines for the email and push workers and the duplicated schedule completion line (2–3 lines per message became 1), and added `attempt`/`attempts` to the four `failed` handlers so a transient retry is distinguishable from final exhaustion.

### Verification
- 474 tests pass (7 new in `src/http/plugins/__tests__/logger-plugin.spec.ts` covering level mapping, per-request timing, the omitted duration, and that validation logs carry no submitted values).
- `bunx tsc --noEmit`, `eslint src`, and `bun format:check` clean.
- Against a local ingest sink: the shipped msgpack shows `to: [redacted]` and `key: [redacted]` while `durationMs`/`method`/`path`/`status` arrive as queryable fields.

### Deliberately not done
SSE lifecycle logging, per-parse-failure logs in `utils/`, worker `stalled`/dead-letter handlers, and the remaining silent catches in `sse-slot.ts` and `get-user-plan.ts`. Happy to take those in a follow-up.