### PR TITLE
refactor(server): server logging pass

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1490,23 +1490,23 @@
 
     "@tanstack/react-query-devtools": ["@tanstack/react-query-devtools@5.101.4", "", { "dependencies": { "@tanstack/query-devtools": "5.101.4" }, "peerDependencies": { "@tanstack/react-query": "^5.101.4", "react": "^18 || ^19" } }, "sha512-VeK2gtmfj7kvRBjtxS7TKxt/6qKhn8VzabY4UiYMr7NV9CddjSRYRgeYyld+NpjAkgMV9dd+2Qdr8ah5I03NeA=="],
 
-    "@tanstack/react-router": ["@tanstack/react-router@1.170.27", "", { "dependencies": { "@tanstack/history": "1.162.1", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.171.22", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-Hxl49xzd8ffWd2ZMigqfXZmpySpixWGvjq5zfh2nK2DbzzDH6IGVh+iUuwarK9MJNcnhWPZ85tOoy6o/OmNlww=="],
+    "@tanstack/react-router": ["@tanstack/react-router@1.170.29", "", { "dependencies": { "@tanstack/history": "1.162.1", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.171.24", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-xQwakR0ReaUGu3xeXEl2CqzlIXk4i9vxaf/zqdzoELMY0mDZgMOr+xobiA5cQdn8cnovqZgqqUxcwXhsruC+NA=="],
 
     "@tanstack/react-router-devtools": ["@tanstack/react-router-devtools@1.167.1", "", { "dependencies": { "@tanstack/router-devtools-core": "1.168.1" }, "peerDependencies": { "@tanstack/react-router": "^1.170.19", "@tanstack/router-core": "^1.171.16", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" }, "optionalPeers": ["@tanstack/router-core"] }, "sha512-pjfGrmjj4d7naEPM7oshqFfwBoxDPNo/UxltlHH5ePbHsJ+plBhd+JaAewm1ueYOjZ0js9hckjWWDYXpCrSfKw=="],
 
     "@tanstack/react-router-ssr-query": ["@tanstack/react-router-ssr-query@1.167.1", "", { "dependencies": { "@tanstack/router-ssr-query-core": "1.169.1" }, "peerDependencies": { "@tanstack/query-core": ">=5.90.0", "@tanstack/react-query": ">=5.90.0", "@tanstack/react-router": ">=1.127.0", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-W9j5JPnBikyafvuUfykFfHIWod58OAbAAa5leNkXBcoDoocghMmu6w9uZOmUZvAWT7CSvgj5tBUtF7CM2OoHXQ=="],
 
-    "@tanstack/react-start": ["@tanstack/react-start@1.168.44", "", { "dependencies": { "@tanstack/react-router": "1.170.27", "@tanstack/react-start-client": "1.168.25", "@tanstack/react-start-rsc": "0.1.43", "@tanstack/react-start-server": "1.167.32", "@tanstack/router-utils": "1.162.2", "@tanstack/start-client-core": "1.170.22", "@tanstack/start-plugin-core": "1.171.34", "@tanstack/start-server-core": "1.169.26", "pathe": "^2.0.3" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "@vitejs/plugin-rsc": "*", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "@vitejs/plugin-rsc", "vite"] }, "sha512-varBaGENYuX0qdRMy8xZvr3BpHCHfkOeBaFCQkXUaOzK3NmWdpqj6CSbPq5uMCHkvFTDXNN6PZukp5zRa5Wmcg=="],
+    "@tanstack/react-start": ["@tanstack/react-start@1.168.46", "", { "dependencies": { "@tanstack/react-router": "1.170.29", "@tanstack/react-start-client": "1.168.27", "@tanstack/react-start-rsc": "0.1.45", "@tanstack/react-start-server": "1.167.34", "@tanstack/router-utils": "1.162.2", "@tanstack/start-client-core": "1.170.24", "@tanstack/start-plugin-core": "1.171.36", "@tanstack/start-server-core": "1.169.28", "pathe": "^2.0.3" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "@vitejs/plugin-rsc": "*", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "@vitejs/plugin-rsc", "vite"] }, "sha512-GvjKkZQ4bzuqyDIFvY7Puh7nCDc5Uh7r3puO8EDr1ZSqbZu8LGUaeNRrAHepxEIepr2iYbSDtKVaB7A9fWUMeA=="],
 
-    "@tanstack/react-start-client": ["@tanstack/react-start-client@1.168.25", "", { "dependencies": { "@tanstack/react-router": "1.170.27", "@tanstack/router-core": "1.171.22", "@tanstack/start-client-core": "1.170.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-vwjhuXUXFEAS8btmmXa24J/cP12AuAqIn/9OdZnrVufBE489IaxUEE3KuqEyUyZ+dtwPxChgVxFPHLcG9zonwA=="],
+    "@tanstack/react-start-client": ["@tanstack/react-start-client@1.168.27", "", { "dependencies": { "@tanstack/react-router": "1.170.29", "@tanstack/router-core": "1.171.24", "@tanstack/start-client-core": "1.170.24" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-N18avSX3aAobLkpyYQiRkXrtcc5E+0A97HEWSfzUxT6+1mwMdSg8CBZL1m59zGp9pXWFfO2aFUlBEryGy9beTA=="],
 
-    "@tanstack/react-start-rsc": ["@tanstack/react-start-rsc@0.1.43", "", { "dependencies": { "@tanstack/react-router": "1.170.27", "@tanstack/router-core": "1.171.22", "@tanstack/router-utils": "1.162.2", "@tanstack/start-client-core": "1.170.22", "@tanstack/start-fn-stubs": "1.162.0", "@tanstack/start-plugin-core": "1.171.34", "@tanstack/start-storage-context": "1.167.24", "pathe": "^2.0.3" }, "peerDependencies": { "@rspack/core": ">=2.0.0-0", "@vitejs/plugin-rsc": ">=0.5.30", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "react-server-dom-rspack": ">=0.0.2" }, "optionalPeers": ["@rspack/core", "@vitejs/plugin-rsc", "react-server-dom-rspack"] }, "sha512-5h5qytaTlhakTWX0oMz7pVxS/4FuCJeg5a/jKkbLsEU2hWy/R098zQG9tftkWbzPhq+B3pfrGk32ufUzsiwK5A=="],
+    "@tanstack/react-start-rsc": ["@tanstack/react-start-rsc@0.1.45", "", { "dependencies": { "@tanstack/react-router": "1.170.29", "@tanstack/router-core": "1.171.24", "@tanstack/router-utils": "1.162.2", "@tanstack/start-client-core": "1.170.24", "@tanstack/start-fn-stubs": "1.162.0", "@tanstack/start-plugin-core": "1.171.36", "@tanstack/start-storage-context": "1.167.26", "pathe": "^2.0.3" }, "peerDependencies": { "@rspack/core": ">=2.0.0-0", "@vitejs/plugin-rsc": ">=0.5.30", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "react-server-dom-rspack": ">=0.0.2" }, "optionalPeers": ["@rspack/core", "@vitejs/plugin-rsc", "react-server-dom-rspack"] }, "sha512-n962onqz6wZkra9cHygPQumKaShqZAfO2BRvrRzbtYa8M5ytbOG3Wvg6TUbZJ7gPKmjDvFsyrAPgZZ8ZhkrbwA=="],
 
-    "@tanstack/react-start-server": ["@tanstack/react-start-server@1.167.32", "", { "dependencies": { "@tanstack/react-router": "1.170.27", "@tanstack/router-core": "1.171.22", "@tanstack/start-server-core": "1.169.26" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-HZV8EE9f2XU+KnyJcB20SCZgAm6G3uGPUwihaqgAz+MPnuJ/xG1iNy1oyQRz/SeqI3PVnPKzWK3Dkv+7xiO7cA=="],
+    "@tanstack/react-start-server": ["@tanstack/react-start-server@1.167.34", "", { "dependencies": { "@tanstack/react-router": "1.170.29", "@tanstack/router-core": "1.171.24", "@tanstack/start-server-core": "1.169.28" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-9C1r6mUyDJPF2GRZBJfp8Zf/IH6YpXKwq09gKcCIt6CX/2z4Ir0SAtdzjgVYsAxX8a5qNQNLbwCkp4xa3kjyqw=="],
 
     "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
 
-    "@tanstack/router-core": ["@tanstack/router-core@1.171.22", "", { "dependencies": { "@tanstack/history": "1.162.1", "cookie-es": "^3.0.0", "seroval": "^1.6.2", "seroval-plugins": "^1.6.2" } }, "sha512-sitsuRkz4qpTjIAV97S5zFCoeGv0OFd6+VWg3ZcIlQbi5R4NIXfz6ogg51n5w6rvTwSODz/lKWb5dl5tvh2bQw=="],
+    "@tanstack/router-core": ["@tanstack/router-core@1.171.24", "", { "dependencies": { "@tanstack/history": "1.162.1", "cookie-es": "^3.0.0", "seroval": "^1.6.2", "seroval-plugins": "^1.6.2" } }, "sha512-+j+8NmV4QOS+ILNLdXFlLTdKPPbBQIy6mXDZ0QWEKYZ0xQOdlnOCXVHPflyGanD2SWSxjqGkw8CsW0CXXP7fLg=="],
 
     "@tanstack/router-devtools-core": ["@tanstack/router-devtools-core@1.168.1", "", { "dependencies": { "clsx": "^2.1.1", "goober": "^2.1.16" }, "peerDependencies": { "@tanstack/router-core": "^1.171.16", "csstype": "^3.0.10" }, "optionalPeers": ["csstype"] }, "sha512-qr4voa4cpSMwQvS3867xkU3AB3MtJbTuovKIy+btjJ/Faju6er9w0nDylmD+005Mk/3YKw9/iueZJl2JAB7JOA=="],
 
@@ -1518,15 +1518,15 @@
 
     "@tanstack/router-utils": ["@tanstack/router-utils@1.162.2", "", { "dependencies": { "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-hTWqJtqIFFdvuCl8WXNyrodp2L9zo2G37xKRrcVmVRWpAB2h+U1LuRAfS4tsFTiWOIoE/B+WDVFB8JpoEdw6jQ=="],
 
-    "@tanstack/start-client-core": ["@tanstack/start-client-core@1.170.22", "", { "dependencies": { "@tanstack/router-core": "1.171.22", "@tanstack/start-fn-stubs": "1.162.0", "@tanstack/start-storage-context": "1.167.24", "seroval": "^1.6.2" } }, "sha512-18gHvhrVLEmhO0qZVIJaR/y3Mb7tvC9UQnCEiooQG/aIpYg4/kqoQ06E7WUJ/0WFy4NZOkEjk8QkDQNkFED+1g=="],
+    "@tanstack/start-client-core": ["@tanstack/start-client-core@1.170.24", "", { "dependencies": { "@tanstack/router-core": "1.171.24", "@tanstack/start-fn-stubs": "1.162.0", "@tanstack/start-storage-context": "1.167.26", "seroval": "^1.6.2" } }, "sha512-BRdV6TZSLVZ43fEVdIdkpkZCwwaEm57JUPpNiNszZeutBZLU0bxR/cbs0cC7sE98oVsgBTNvaBjyk2CDea+4sw=="],
 
     "@tanstack/start-fn-stubs": ["@tanstack/start-fn-stubs@1.162.0", "", {}, "sha512-QWfUZ3Yo923tdQn38LyKMU8rcTw69zc+T4dAvgTWV4O56SqFRsGfS0lSWIMhJRwXIx/bvdi7nTUBDdZtTHtpTQ=="],
 
-    "@tanstack/start-plugin-core": ["@tanstack/start-plugin-core@1.171.34", "", { "dependencies": { "@babel/code-frame": "7.27.1", "@babel/core": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.171.22", "@tanstack/router-generator": "1.167.28", "@tanstack/router-plugin": "1.168.30", "@tanstack/router-utils": "1.162.2", "@tanstack/start-server-core": "1.169.26", "exsolve": "^1.0.7", "lightningcss": "^1.32.0", "pathe": "^2.0.3", "picomatch": "^4.0.3", "seroval": "^1.6.2", "source-map": "^0.7.6", "srvx": "^0.11.9", "tinyglobby": "^0.2.15", "ufo": "^1.5.4", "vitefu": "^1.1.1", "xmlbuilder2": "^4.0.3", "zod": "^4.4.3" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "vite"] }, "sha512-MMp5Mlt8HAtstkVKwHW6dY5w58CP/Vtq+DhXdH4mIPuOeEhFtl/BYErJCzpnq80QqbEpRxCfMZPf9ng2PzApaA=="],
+    "@tanstack/start-plugin-core": ["@tanstack/start-plugin-core@1.171.36", "", { "dependencies": { "@babel/code-frame": "7.27.1", "@babel/core": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.171.24", "@tanstack/router-generator": "1.167.30", "@tanstack/router-plugin": "1.168.32", "@tanstack/router-utils": "1.162.2", "@tanstack/start-server-core": "1.169.28", "exsolve": "^1.0.7", "lightningcss": "^1.32.0", "pathe": "^2.0.3", "picomatch": "^4.0.3", "seroval": "^1.6.2", "source-map": "^0.7.6", "srvx": "^0.11.9", "tinyglobby": "^0.2.15", "ufo": "^1.5.4", "vitefu": "^1.1.1", "xmlbuilder2": "^4.0.3", "zod": "^4.4.3" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "vite"] }, "sha512-wWFd0sSpoW3k5cJJ1EpJuQ1REzMcv4LcOmPKotyhH2PNQPqBIRv9ZCxRtH7QWxXcwAaE0G1YE8PTYh9ZARPYOg=="],
 
-    "@tanstack/start-server-core": ["@tanstack/start-server-core@1.169.26", "", { "dependencies": { "@tanstack/history": "1.162.1", "@tanstack/router-core": "1.171.22", "@tanstack/start-client-core": "1.170.22", "@tanstack/start-storage-context": "1.167.24", "fetchdts": "^0.1.6", "h3-v2": "npm:h3@2.0.1-rc.20", "seroval": "^1.6.2" } }, "sha512-57Pvc00i/Y6l8+kqlV/QElVUh5onFUPeMUBDDRNwelAA4eoOmRDmfEWfVfkJNYlcAF4kt/s0mgnD58DlCgC9JA=="],
+    "@tanstack/start-server-core": ["@tanstack/start-server-core@1.169.28", "", { "dependencies": { "@tanstack/history": "1.162.1", "@tanstack/router-core": "1.171.24", "@tanstack/start-client-core": "1.170.24", "@tanstack/start-storage-context": "1.167.26", "fetchdts": "^0.1.6", "h3-v2": "npm:h3@2.0.1-rc.20", "seroval": "^1.6.2" } }, "sha512-iGytKBUIzEWxVZ20x2UYyTNGOviYSxUXR4SqAz8NRh0ElcbMHPK0twkE7ZeKLDigyQh9rG1DHGyiGVs6plQTvQ=="],
 
-    "@tanstack/start-storage-context": ["@tanstack/start-storage-context@1.167.24", "", { "dependencies": { "@tanstack/router-core": "1.171.22" } }, "sha512-HPltgydit1LmLJFX3BhMcXMxkmUgtWJopPUx6Eg0YTC4tVwFvUhSWCrfgtTIiGWcHd1Ah+fi6fK9BAe8Y5KZtw=="],
+    "@tanstack/start-storage-context": ["@tanstack/start-storage-context@1.167.26", "", { "dependencies": { "@tanstack/router-core": "1.171.24" } }, "sha512-uWUX1zk4rY0vrSzW7JyIGYRLX0jx75Mc+CeaJL8TPTE4UHq2DxZ+4rwrx8/KBRyDFXTzgIzJAXIvp8Tm6hQaNQ=="],
 
     "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
 
@@ -4752,7 +4752,11 @@
 
     "@tanstack/router-core/seroval-plugins": ["seroval-plugins@1.6.2", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-TfxuUjlbBESzUOWdTkTKqvSmav0ABym+itetDXLK6mDz8SmrpdI30aF8RTXE8Bvq+tH/1yIDkvy3W0lfQb1ipQ=="],
 
+    "@tanstack/router-generator/@tanstack/router-core": ["@tanstack/router-core@1.171.22", "", { "dependencies": { "@tanstack/history": "1.162.1", "cookie-es": "^3.0.0", "seroval": "^1.6.2", "seroval-plugins": "^1.6.2" } }, "sha512-sitsuRkz4qpTjIAV97S5zFCoeGv0OFd6+VWg3ZcIlQbi5R4NIXfz6ogg51n5w6rvTwSODz/lKWb5dl5tvh2bQw=="],
+
     "@tanstack/router-generator/jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "@tanstack/router-plugin/@tanstack/router-core": ["@tanstack/router-core@1.171.22", "", { "dependencies": { "@tanstack/history": "1.162.1", "cookie-es": "^3.0.0", "seroval": "^1.6.2", "seroval-plugins": "^1.6.2" } }, "sha512-sitsuRkz4qpTjIAV97S5zFCoeGv0OFd6+VWg3ZcIlQbi5R4NIXfz6ogg51n5w6rvTwSODz/lKWb5dl5tvh2bQw=="],
 
     "@tanstack/router-plugin/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
@@ -4761,6 +4765,10 @@
     "@tanstack/start-client-core/seroval": ["seroval@1.6.2", "", {}, "sha512-mPT+SD2TrlB6wvte1KkYOYUkubaTbd6pZ/6Kk3C9nxzrHmCZyhxOO7XGAeL7f+yLKZglzGtM9odUVvg/EhO+vQ=="],
 
     "@tanstack/start-plugin-core/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
+
+    "@tanstack/start-plugin-core/@tanstack/router-generator": ["@tanstack/router-generator@1.167.30", "", { "dependencies": { "@babel/types": "^7.28.5", "@tanstack/router-core": "1.171.24", "@tanstack/router-utils": "1.162.2", "@tanstack/virtual-file-routes": "1.162.0", "jiti": "^2.7.0", "magic-string": "^0.30.21", "prettier": "^3.5.0", "zod": "^4.4.3" } }, "sha512-Tf9TJfdpP0yL3k1D1ke6hR1dvPCgKShTik3HcBRDeTK5eNrp9/X0Q0YApN8thE6pVcXL6a78O3ZE7XN7s7KwNw=="],
+
+    "@tanstack/start-plugin-core/@tanstack/router-plugin": ["@tanstack/router-plugin@1.168.32", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/template": "^7.27.2", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.171.24", "@tanstack/router-generator": "1.167.30", "@tanstack/router-utils": "1.162.2", "chokidar": "^5.0.0", "unplugin": "^3.0.0", "zod": "^4.4.3" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2 || ^2.0.0", "@tanstack/react-router": "^1.170.29", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0", "vite-plugin-solid": "^2.11.10 || ^3.0.0-0", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"] }, "sha512-P+qYIY9b/K+ZGUPNiyLqsd20vN/1abgmSNG0Ch9KTKldag3icR7TlrJgnM2km86yuRdXa4nJ5YT7+JLV5rJRZg=="],
 
     "@tanstack/start-plugin-core/seroval": ["seroval@1.6.2", "", {}, "sha512-mPT+SD2TrlB6wvte1KkYOYUkubaTbd6pZ/6Kk3C9nxzrHmCZyhxOO7XGAeL7f+yLKZglzGtM9odUVvg/EhO+vQ=="],
 
@@ -5460,7 +5468,19 @@
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
+    "@tanstack/router-generator/@tanstack/router-core/seroval": ["seroval@1.6.2", "", {}, "sha512-mPT+SD2TrlB6wvte1KkYOYUkubaTbd6pZ/6Kk3C9nxzrHmCZyhxOO7XGAeL7f+yLKZglzGtM9odUVvg/EhO+vQ=="],
+
+    "@tanstack/router-generator/@tanstack/router-core/seroval-plugins": ["seroval-plugins@1.6.2", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-TfxuUjlbBESzUOWdTkTKqvSmav0ABym+itetDXLK6mDz8SmrpdI30aF8RTXE8Bvq+tH/1yIDkvy3W0lfQb1ipQ=="],
+
+    "@tanstack/router-plugin/@tanstack/router-core/seroval": ["seroval@1.6.2", "", {}, "sha512-mPT+SD2TrlB6wvte1KkYOYUkubaTbd6pZ/6Kk3C9nxzrHmCZyhxOO7XGAeL7f+yLKZglzGtM9odUVvg/EhO+vQ=="],
+
+    "@tanstack/router-plugin/@tanstack/router-core/seroval-plugins": ["seroval-plugins@1.6.2", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-TfxuUjlbBESzUOWdTkTKqvSmav0ABym+itetDXLK6mDz8SmrpdI30aF8RTXE8Bvq+tH/1yIDkvy3W0lfQb1ipQ=="],
+
     "@tanstack/router-plugin/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
+    "@tanstack/start-plugin-core/@tanstack/router-generator/jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "@tanstack/start-plugin-core/@tanstack/router-plugin/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "@testing-library/dom/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
@@ -5701,6 +5721,8 @@
     "@sentry/tanstackstart-react/@sentry/node/@sentry/server-utils/@apm-js-collab/tracing-hooks": ["@apm-js-collab/tracing-hooks@0.13.0", "", { "dependencies": { "@apm-js-collab/code-transformer": "^0.18.0", "debug": "^4.4.1", "module-details-from-path": "^1.0.4" } }, "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw=="],
 
     "@sentry/tanstackstart-react/@sentry/node/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
+
+    "@tanstack/start-plugin-core/@tanstack/router-plugin/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 

--- a/packages/emitsignal-server/src/http/messages/purge.ts
+++ b/packages/emitsignal-server/src/http/messages/purge.ts
@@ -1,11 +1,12 @@
 import Elysia from 'elysia';
 
 import { resolveUserId } from '#/http/auth/plugin';
+import { logger } from '#/lib/logger';
 import { purgeQueue } from '#/lib/queue';
 import { captureTraceContext } from '#/lib/trace-context';
 
-// Deletes every signal the authenticated user is responsible for — messages in
-// topics they own plus messages they sent into others' topics — keeping channels
+// Deletes every signal the authenticated user is responsible for messages in
+// topics they own plus messages they sent into others' topics keeping channels
 // intact. The heavy deletion (and attachment file cleanup) runs asynchronously.
 
 export const purgeSignals = new Elysia().delete('/me/signals', async ({ headers, status }) => {
@@ -14,6 +15,8 @@ export const purgeSignals = new Elysia().delete('/me/signals', async ({ headers,
     if (!userId) {
         return status(401, { error: 'missing_token' });
     }
+
+    logger.info({ userId }, 'signal purge requested');
 
     await purgeQueue.add('purge-signals', {
         kind: 'signals',

--- a/packages/emitsignal-server/src/http/plugins/rate-limit-plugin.ts
+++ b/packages/emitsignal-server/src/http/plugins/rate-limit-plugin.ts
@@ -71,6 +71,8 @@ export async function consumeLimit(
         if (rl?.msBeforeNext !== undefined) {
             const retryAfter = Math.ceil(rl.msBeforeNext / 1000);
 
+            logger.warn({ limiter: limiter.keyPrefix, retryAfter }, 'rate limit exceeded');
+
             set.headers['retry-after'] = String(retryAfter);
             set.status = 429;
 
@@ -80,7 +82,10 @@ export async function consumeLimit(
         // a limiter outage used to be logged and then silently ignored
         // on every route. Surface it as an exception so it actually pages someone,
         // instead of only landing in a log nobody is watching.
-        logger.error({ error, failClosed: options.failClosed === true, key }, 'rate limiter error');
+        logger.error(
+            { error, failClosed: options.failClosed === true, limiter: limiter.keyPrefix },
+            'rate limiter error',
+        );
         reportLimiterError(error);
 
         if (options.failClosed) {

--- a/packages/emitsignal-server/src/http/topic/publish.ts
+++ b/packages/emitsignal-server/src/http/topic/publish.ts
@@ -3,6 +3,7 @@ import Elysia, { t } from 'elysia';
 import { resolveUserId } from '#/http/auth/plugin';
 import { authAwareBeforeHandle } from '#/http/plugins/rate-limit-plugin';
 import { bus } from '#/lib/event-bus';
+import { logger } from '#/lib/logger';
 import { prisma } from '#/lib/prisma';
 import { pushQueue, scheduleQueue } from '#/lib/queue';
 import { publishAnonLimiter, publishAuthLimiter } from '#/lib/rate-limit';
@@ -97,6 +98,11 @@ function publishRoute(path: string, deprecated: boolean) {
                 const quota = await consumeDailyQuota(userId, 'messages', limits.messagesPerDay);
 
                 if (!quota.allowed) {
+                    logger.warn(
+                        { limit: quota.limit, metric: 'messages', userId },
+                        'daily quota exceeded',
+                    );
+
                     Object.assign(set.headers, quotaExceededHeaders(quota));
 
                     return status(429, {

--- a/packages/emitsignal-server/src/index.ts
+++ b/packages/emitsignal-server/src/index.ts
@@ -133,9 +133,6 @@ logger.info(
         `(env: ${environment.NODE_ENV}, trusted proxy header: ${environment.TRUSTED_PROXY_HEADER})`,
 );
 
-// Almost every production deployment sits behind a proxy. Leaving this unset
-// there collapses every anonymous caller onto the proxy's IP, so the shared
-// rate-limit buckets exhaust platform-wide instead of per client.
 if (isProduction && environment.TRUSTED_PROXY_HEADER === 'none') {
     logger.warn(
         'TRUSTED_PROXY_HEADER is "none" in production: client IPs come from the TCP peer address. ' +

--- a/packages/emitsignal-server/src/lib/auth.ts
+++ b/packages/emitsignal-server/src/lib/auth.ts
@@ -12,6 +12,7 @@ import path from 'node:path';
 import { createElement } from 'react';
 import Stripe from 'stripe';
 
+import { logger } from '#/lib/logger';
 import { captureTraceContext } from '#/lib/trace-context';
 import { environment, isProduction } from '#/schema/environment';
 import { invalidateUserPlanCache } from '#/services/billing/get-user-plan';
@@ -40,15 +41,51 @@ const stripePlugins = isStripeBillingEnabled()
               subscription: {
                   enabled: true,
                   onSubscriptionCancel: async ({ subscription }) => {
+                      logger.info(
+                          {
+                              event: 'cancelled',
+                              plan: subscription.plan,
+                              userId: subscription.referenceId,
+                          },
+                          'subscription changed',
+                      );
+
                       await invalidateUserPlanCache(subscription.referenceId);
                   },
                   onSubscriptionComplete: async ({ subscription }) => {
+                      logger.info(
+                          {
+                              event: 'completed',
+                              plan: subscription.plan,
+                              userId: subscription.referenceId,
+                          },
+                          'subscription changed',
+                      );
+
                       await invalidateUserPlanCache(subscription.referenceId);
                   },
                   onSubscriptionDeleted: async ({ subscription }) => {
+                      logger.info(
+                          {
+                              event: 'deleted',
+                              plan: subscription.plan,
+                              userId: subscription.referenceId,
+                          },
+                          'subscription changed',
+                      );
+
                       await invalidateUserPlanCache(subscription.referenceId);
                   },
                   onSubscriptionUpdate: async ({ subscription }) => {
+                      logger.info(
+                          {
+                              event: 'updated',
+                              plan: subscription.plan,
+                              userId: subscription.referenceId,
+                          },
+                          'subscription changed',
+                      );
+
                       await invalidateUserPlanCache(subscription.referenceId);
                   },
                   plans: stripePlanConfig(),
@@ -130,6 +167,8 @@ export const auth = betterAuth({
                 return;
             }
 
+            logger.info({ userId: ctx.context.session?.user.id }, 'api key created');
+
             await sendApiKeyCreatedEmail(returned);
         }),
         before: createAuthMiddleware(async (ctx) => {
@@ -164,6 +203,8 @@ export const auth = betterAuth({
             );
 
             if (typeof email === 'string' && !isEmailAllowed(email)) {
+                logger.warn('sign-in blocked by the email allowlist');
+
                 throw new APIError('FORBIDDEN', {
                     message: 'This email address is not allowed to sign in.',
                 });
@@ -265,6 +306,8 @@ export const auth = betterAuth({
                 await sendAccountDeletedEmail(user);
             },
             beforeDelete: async (user) => {
+                logger.info({ userId: user.id }, 'deleting account');
+
                 const attachments = await prisma.attachment.findMany({
                     select: { storageKey: true },
                     where: {

--- a/packages/emitsignal-server/src/lib/email/resend-provider.ts
+++ b/packages/emitsignal-server/src/lib/email/resend-provider.ts
@@ -26,6 +26,6 @@ export class ResendProvider implements EmailProvider {
             throw new Error(`Resend email failed: ${error.message}`);
         }
 
-        logger.info({ resendId: data?.id, to: options.to }, 'email sent (resend)');
+        logger.info({ resendId: data?.id }, 'email sent (resend)');
     }
 }

--- a/packages/emitsignal-server/src/lib/email/smtp-provider.ts
+++ b/packages/emitsignal-server/src/lib/email/smtp-provider.ts
@@ -33,6 +33,6 @@ export class SmtpProvider implements EmailProvider {
             to: options.to,
         });
 
-        logger.info({ messageId: info.messageId, to: options.to }, 'email sent (smtp)');
+        logger.info({ messageId: info.messageId }, 'email sent (smtp)');
     }
 }

--- a/packages/emitsignal-server/src/lib/logger.ts
+++ b/packages/emitsignal-server/src/lib/logger.ts
@@ -23,14 +23,14 @@ const localTarget: TransportTargetOptions = isProduction
     : {
           options: {
               colorize: true,
-              ignore: 'pid,hostname,service',
+              ignore: 'hostname,nodeEnv,pid,service',
               translateTime: 'HH:MM:ss.l',
           },
           target: 'pino-pretty',
       };
 
 export const logger = pino({
-    base: { hostname: hostname(), pid: process.pid, service },
+    base: { hostname: hostname(), nodeEnv: environment.NODE_ENV, pid: process.pid, service },
     level: environment.LOG_LEVEL ?? (isProduction ? 'info' : 'debug'),
     mixin() {
         if (!environment.OTEL_ENABLED || !environment.OTEL_VERBOSE_LOG) {
@@ -47,6 +47,7 @@ export const logger = pino({
 
         return { span_id: spanId, trace_id: traceId };
     },
+    redact: { censor: '[redacted]', paths: ['email', 'key', 'to', '*.email', '*.to'] },
     transport: { targets: ingestionTarget ? [localTarget, ingestionTarget] : [localTarget] },
     ...(isProduction ? {} : { msgPrefix: '[EmitSignal] ' }),
 });

--- a/packages/emitsignal-server/src/lib/queue/connection.ts
+++ b/packages/emitsignal-server/src/lib/queue/connection.ts
@@ -1,8 +1,17 @@
 import Redis from 'ioredis';
 
+import { logger } from '#/lib/logger';
 import { environment } from '#/schema/environment';
 
 export const redisConnection = new Redis(environment.REDIS_URL, {
     enableReadyCheck: false,
     maxRetriesPerRequest: null,
+});
+
+redisConnection.on('error', (error: Error) => {
+    logger.error({ error }, 'queue redis connection error');
+});
+
+redisConnection.on('reconnecting', () => {
+    logger.warn('queue redis reconnecting');
 });

--- a/packages/emitsignal-server/src/lib/queue/email/email-worker.ts
+++ b/packages/emitsignal-server/src/lib/queue/email/email-worker.ts
@@ -56,12 +56,12 @@ export function createEmailWorker(): Worker<Traced<EmailOptions>> {
         logger.info({ jobId: job.id }, 'email job completed');
     });
 
-    worker.on('failed', (job, err) => {
+    worker.on('failed', (job, error) => {
         logger.error(
             {
                 attempt: job?.attemptsMade,
                 attempts: job?.opts.attempts,
-                err,
+                error,
                 jobId: job?.id,
             },
             'email job failed',

--- a/packages/emitsignal-server/src/lib/queue/email/email-worker.ts
+++ b/packages/emitsignal-server/src/lib/queue/email/email-worker.ts
@@ -57,7 +57,15 @@ export function createEmailWorker(): Worker<Traced<EmailOptions>> {
     });
 
     worker.on('failed', (job, err) => {
-        logger.error({ err, jobId: job?.id }, 'email job failed');
+        logger.error(
+            {
+                attempt: job?.attemptsMade,
+                attempts: job?.opts.attempts,
+                err,
+                jobId: job?.id,
+            },
+            'email job failed',
+        );
     });
 
     return worker;

--- a/packages/emitsignal-server/src/lib/queue/purge/purge-worker.ts
+++ b/packages/emitsignal-server/src/lib/queue/purge/purge-worker.ts
@@ -69,8 +69,16 @@ export function createPurgeWorker(): Worker<Traced<PurgeJob>> {
         logger.info({ jobId: job.id }, 'purge job completed');
     });
 
-    worker.on('failed', (job, err) => {
-        logger.error({ err, jobId: job?.id }, 'purge job failed');
+    worker.on('failed', (job, error) => {
+        logger.error(
+            {
+                attempt: job?.attemptsMade,
+                attempts: job?.opts.attempts,
+                error,
+                jobId: job?.id,
+            },
+            'purge job failed',
+        );
     });
 
     return worker;

--- a/packages/emitsignal-server/src/lib/queue/push/push-worker.ts
+++ b/packages/emitsignal-server/src/lib/queue/push/push-worker.ts
@@ -41,6 +41,7 @@ export function createPushWorker(): Worker<Traced<PushJob>> {
                         span.recordException(
                             error instanceof Error ? error : new Error(String(error)),
                         );
+
                         span.setStatus({ code: SpanStatusCode.ERROR });
 
                         throw error;
@@ -57,11 +58,20 @@ export function createPushWorker(): Worker<Traced<PushJob>> {
     );
 
     worker.on('completed', (job) => {
-        logger.info({ jobId: job.id }, 'push job completed');
+        logger.info({ jobId: job.id, topicName: job.data.topicName }, 'push job completed');
     });
 
-    worker.on('failed', (job, err) => {
-        logger.error({ err, jobId: job?.id }, 'push job failed');
+    worker.on('failed', (job, error) => {
+        logger.error(
+            {
+                attempt: job?.attemptsMade,
+                attempts: job?.opts.attempts,
+                error,
+                jobId: job?.id,
+                topicName: job?.data.topicName,
+            },
+            'push job failed',
+        );
     });
 
     return worker;

--- a/packages/emitsignal-server/src/lib/queue/schedule/schedule-worker.ts
+++ b/packages/emitsignal-server/src/lib/queue/schedule/schedule-worker.ts
@@ -37,8 +37,6 @@ export function createScheduleWorker(): Worker<Traced<ScheduleJob>> {
                 traceContextFrom(job.data.traceContext),
                 async (span) => {
                     try {
-                        logger.info({ jobId: job.id, messageId }, 'processing schedule job');
-
                         const message = await prisma.message.findUnique({
                             include: { topic: true },
                             where: { id: messageId },
@@ -93,10 +91,7 @@ export function createScheduleWorker(): Worker<Traced<ScheduleJob>> {
                             where: { id: message.id },
                         });
 
-                        logger.info(
-                            { messageId },
-                            'schedule job completed: SSE emitted, push enqueued',
-                        );
+                        logger.info({ messageId }, 'scheduled message delivered');
 
                         span.setStatus({ code: SpanStatusCode.OK });
                     } catch (error) {
@@ -118,12 +113,16 @@ export function createScheduleWorker(): Worker<Traced<ScheduleJob>> {
         },
     );
 
-    worker.on('completed', (job) => {
-        logger.info({ jobId: job.id }, 'schedule job completed');
-    });
-
-    worker.on('failed', (job, err) => {
-        logger.error({ err, jobId: job?.id }, 'schedule job failed');
+    worker.on('failed', (job, error) => {
+        logger.error(
+            {
+                attempt: job?.attemptsMade,
+                attempts: job?.opts.attempts,
+                error,
+                jobId: job?.id,
+            },
+            'schedule job failed',
+        );
     });
 
     return worker;

--- a/packages/emitsignal-server/src/lib/rate-limit/enforce.ts
+++ b/packages/emitsignal-server/src/lib/rate-limit/enforce.ts
@@ -4,14 +4,6 @@ import { APIError } from 'better-auth/api';
 
 import { logger } from '#/lib/logger';
 
-// Consume a rate limiter from inside a Better Auth middleware. Unlike the
-// Elysia `consumeLimit` in rate-limit-plugin.ts, this raises Better Auth's own
-// APIError so the failure is serialized the same way as the rest of the auth
-// responses.
-//
-// Unlike the read/publish limiters, the auth limiters fail CLOSED: if Redis is
-// unavailable we reject rather than let OTP send/verify brute-force protection
-// silently disappear during an outage.
 export async function enforceAuthRateLimit(
     limiter: RateLimiterMemory | RateLimiterRedis,
     key: string,
@@ -22,12 +14,17 @@ export async function enforceAuthRateLimit(
         const rateLimit = error as { msBeforeNext?: number };
 
         if (rateLimit?.msBeforeNext !== undefined) {
+            logger.warn({ limiter: limiter.keyPrefix }, 'auth rate limit exceeded');
+
             throw new APIError('TOO_MANY_REQUESTS', {
                 message: 'Too many requests. Please try again later.',
             });
         }
 
-        logger.error({ error, key }, 'auth rate limiter error, failing closed');
+        logger.error(
+            { error, limiter: limiter.keyPrefix },
+            'auth rate limiter error, failing closed',
+        );
 
         throw new APIError('TOO_MANY_REQUESTS', {
             message: 'Service temporarily unavailable. Please try again later.',

--- a/packages/emitsignal-server/src/lib/rate-limit/limiters.ts
+++ b/packages/emitsignal-server/src/lib/rate-limit/limiters.ts
@@ -1,20 +1,19 @@
 import Redis from 'ioredis';
 import { RateLimiterMemory, RateLimiterRedis } from 'rate-limiter-flexible';
 
+import { logger } from '#/lib/logger';
 import { environment } from '#/schema/environment';
 import { duration } from '#/utils/duration';
 
-// Dedicated connection with maxRetriesPerRequest: 0 so that consume() fails
-// immediately when Redis is unavailable instead of blocking indefinitely.
-// consumeLimit() catches the error and fails-open, keeping the server alive.
 export const rateLimitRedis = new Redis(environment.REDIS_URL, {
     enableReadyCheck: false,
     maxRetriesPerRequest: 0,
 });
 
-// In test mode use in-memory limiters with large points so unit/integration tests
-// that don't explicitly mock this module never hit a rate limit by accident.
-// Bun sets Bun.env.NODE_ENV = 'test' automatically during `bun test` runs.
+rateLimitRedis.on('error', (error: Error) => {
+    logger.error({ error }, 'rate limit redis connection error');
+});
+
 function makeLimiter(keyPrefix: string, points: number, windowSeconds: number) {
     if (Bun.env.NODE_ENV === 'test') {
         return new RateLimiterMemory({ duration: windowSeconds, keyPrefix, points: points * 1000 });

--- a/packages/emitsignal-server/src/lib/storage/local-provider.ts
+++ b/packages/emitsignal-server/src/lib/storage/local-provider.ts
@@ -1,6 +1,8 @@
 import { mkdir, unlink, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
+import { logger } from '#/lib/logger';
+
 import type { FileMetadata, FileStorage, FileUploadInput } from './provider';
 
 import { extensionForMimeType } from './provider';
@@ -14,8 +16,12 @@ export class LocalFileStorage implements FileStorage {
     async delete(storageKey: string): Promise<void> {
         const filePath = path.join(this.uploadDir, storageKey);
 
-        await unlink(filePath).catch(() => {
-            // file may already be gone — that's fine
+        await unlink(filePath).catch((error: NodeJS.ErrnoException) => {
+            if (error.code === 'ENOENT') {
+                return;
+            }
+
+            logger.warn({ error, storageKey }, 'local file delete failed');
         });
     }
 

--- a/packages/emitsignal-server/src/lib/storage/s3-provider.ts
+++ b/packages/emitsignal-server/src/lib/storage/s3-provider.ts
@@ -1,3 +1,4 @@
+import { logger } from '#/lib/logger';
 import { duration } from '#/utils/duration';
 
 import type { FileMetadata, FileStorage, FileUploadInput, StorageBucket } from './provider';
@@ -49,8 +50,8 @@ export class S3FileStorage implements FileStorage {
     async delete(storageKey: string, bucket: StorageBucket = 'private'): Promise<void> {
         await this.clientFor(bucket)
             .delete(storageKey)
-            .catch(() => {
-                // object may already be gone — that's fine
+            .catch((error: unknown) => {
+                logger.warn({ bucket, error, storageKey }, 's3 delete failed');
             });
     }
 

--- a/packages/emitsignal-server/src/services/billing/usage.ts
+++ b/packages/emitsignal-server/src/services/billing/usage.ts
@@ -1,3 +1,4 @@
+import { logger } from '#/lib/logger';
 import { rateLimitRedis } from '#/lib/rate-limit';
 import { duration } from '#/utils/duration';
 
@@ -42,8 +43,9 @@ export async function consumeDailyQuota(
         }
 
         return { allowed: used <= limit, limit, remaining: Math.max(0, limit - used), resetAt };
-    } catch {
-        // Redis unavailable — fail open, like the request rate limiters
+    } catch (error) {
+        logger.error({ error, metric }, 'daily quota check failed, allowing request');
+
         return { allowed: true, limit, remaining: limit, resetAt };
     }
 }

--- a/packages/emitsignal-server/src/services/push/expo-client.ts
+++ b/packages/emitsignal-server/src/services/push/expo-client.ts
@@ -1,6 +1,7 @@
 import { SpanKind, SpanStatusCode, trace } from '@opentelemetry/api';
 import { Expo, type ExpoPushMessage, type ExpoPushTicket } from 'expo-server-sdk';
 
+import { logger } from '#/lib/logger';
 import { environment } from '#/schema/environment';
 
 import type { PushJob } from './types';
@@ -76,9 +77,24 @@ async function sendChunk(chunk: ExpoPushMessage[], send: ExpoSender): Promise<vo
 
                 span.setAttribute('expo.push.rejected_count', rejected.length);
                 span.setStatus({ code: SpanStatusCode.OK });
+
+                if (rejected.length > 0) {
+                    logger.warn(
+                        {
+                            reasons: rejected.map((ticket) =>
+                                ticket.status === 'error' ? ticket.details?.error : undefined,
+                            ),
+                            rejected: rejected.length,
+                            sent: chunk.length,
+                        },
+                        'expo rejected push tokens',
+                    );
+                }
             } catch (error) {
                 span.recordException(error instanceof Error ? error : new Error(String(error)));
                 span.setStatus({ code: SpanStatusCode.ERROR });
+
+                logger.error({ error, sent: chunk.length }, 'expo push send failed');
 
                 throw error;
             } finally {


### PR DESCRIPTION
Second pass on server logging: ships logs to a configurable ingestion provider (`LOG_INGESTION_PROVIDER` — `stdout` or `betterstack`, falling back to stdout when no token is set), then fills the gaps where failures were previously swallowed.

- Redacts `email`/`to`/`key` from log output and tags every line with the environment
- Logs rate limit and daily quota rejections, plus Redis connection errors on both the queue and rate-limit clients
- Adds attempt counts to queue job failures, and surfaces storage delete and Expo push delivery failures that used to be silently caught
- Logs account, API key, and subscription lifecycle events