### PR TITLE
feat: manage push notification devices from web settings

### DIFF
--- a/packages/emitsignal-mobile/app/(tabs)/settings.tsx
+++ b/packages/emitsignal-mobile/app/(tabs)/settings.tsx
@@ -10,7 +10,6 @@ import { useMemo, useState } from 'react';
 import {
     ActivityIndicator,
     Alert,
-    Platform,
     Pressable,
     ScrollView,
     StyleSheet,
@@ -35,6 +34,7 @@ import { useTheme } from '@/ctx/theme';
 import { useTabBarInset } from '@/hooks/use-tab-bar-inset';
 import { useThemedStyles } from '@/hooks/use-themed-styles';
 import { api } from '@/lib/api';
+import { getAppIdentity } from '@/lib/app-identity';
 import { queryKeys } from '@/lib/query-client';
 
 const THEME_OPTIONS: { label: string; value: ThemePreference }[] = [
@@ -295,13 +295,9 @@ function NotificationsSection() {
             const token = await refreshPushToken();
 
             if (token) {
-                const platform = (
-                    Platform.OS === 'ios' || Platform.OS === 'android' ? Platform.OS : 'web'
-                ) as 'android' | 'ios' | 'web';
-
                 await api.registerPushToken({
+                    ...getAppIdentity(),
                     deviceId,
-                    platform,
                     token,
                 });
 

--- a/packages/emitsignal-mobile/app/auth/perms.tsx
+++ b/packages/emitsignal-mobile/app/auth/perms.tsx
@@ -2,7 +2,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import * as Notifications from 'expo-notifications';
 import { router } from 'expo-router';
 import { useState } from 'react';
-import { ActivityIndicator, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { WLogo } from '@/components/base-theme';
@@ -13,6 +13,7 @@ import { useDevice } from '@/ctx/device';
 import { useSession } from '@/ctx/session';
 import { useThemedStyles } from '@/hooks/use-themed-styles';
 import { api, type PushToken } from '@/lib/api';
+import { getAppIdentity } from '@/lib/app-identity';
 import { queryKeys } from '@/lib/query-client';
 
 const PLATFORM_LABEL: Record<string, string> = {
@@ -56,13 +57,9 @@ export default function AuthPerms() {
         }
 
         if (pushToken && deviceId) {
-            const platform = (
-                Platform.OS === 'ios' || Platform.OS === 'android' ? Platform.OS : 'web'
-            ) as 'android' | 'ios' | 'web';
-
             api.registerPushToken({
+                ...getAppIdentity(),
                 deviceId,
-                platform,
                 token: pushToken,
             })
                 .then(() => queryClient.invalidateQueries({ queryKey: queryKeys.pushTokens }))

--- a/packages/emitsignal-mobile/ctx/session.tsx
+++ b/packages/emitsignal-mobile/ctx/session.tsx
@@ -1,9 +1,9 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createContext, type ReactNode, useContext, useEffect } from 'react';
-import { Platform } from 'react-native';
 
 import { clearOnboardingComplete } from '@/hooks/use-onboarding';
 import { api, setAuthToken } from '@/lib/api';
+import { getAppIdentity } from '@/lib/app-identity';
 import { authClient } from '@/lib/auth-client';
 import { queryClient, queryKeys } from '@/lib/query-client';
 import { clearWidgetSnapshot } from '@/lib/widget-storage';
@@ -57,10 +57,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
                 return;
             }
 
-            const platform =
-                Platform.OS === 'ios' ? 'ios' : Platform.OS === 'android' ? 'android' : 'web';
-
-            api.registerPushToken({ deviceId, platform, token }).catch(() => {});
+            api.registerPushToken({ ...getAppIdentity(), deviceId, token }).catch(() => {});
         };
         linkToken();
     }, [data?.user?.id]);

--- a/packages/emitsignal-mobile/lib/app-identity.ts
+++ b/packages/emitsignal-mobile/lib/app-identity.ts
@@ -1,0 +1,19 @@
+import ExpoConstants from 'expo-constants';
+import * as Device from 'expo-device';
+import { Platform } from 'react-native';
+
+export interface AppIdentity {
+    appId?: string;
+    deviceName?: string;
+    platform: 'android' | 'ios' | 'web';
+}
+
+export function getAppIdentity(): AppIdentity {
+    const config = ExpoConstants.expoConfig;
+
+    return {
+        appId: config?.ios?.bundleIdentifier ?? config?.android?.package,
+        deviceName: Device.modelName ?? Device.deviceName ?? undefined,
+        platform: Platform.OS === 'ios' || Platform.OS === 'android' ? Platform.OS : 'web',
+    };
+}

--- a/packages/emitsignal-server/prisma/migrations/20260815142022_extend_push_token_fields/migration.sql
+++ b/packages/emitsignal-server/prisma/migrations/20260815142022_extend_push_token_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "PushToken" ADD COLUMN     "appId" TEXT,
+ADD COLUMN     "deviceName" TEXT;

--- a/packages/emitsignal-server/prisma/schema.prisma
+++ b/packages/emitsignal-server/prisma/schema.prisma
@@ -241,9 +241,11 @@ model Message {
 model PushToken {
     id        String   @id @default(cuid())
 
+    appId       String?
     createdAt   DateTime @default(now())
     deviceId    String
-    platform    String // "ios" | "android" | "web"
+    deviceName  String? 
+    platform    String
     pushEnabled Boolean  @default(true)
     token       String
     updatedAt   DateTime @updatedAt

--- a/packages/emitsignal-server/src/__tests__/mocks.ts
+++ b/packages/emitsignal-server/src/__tests__/mocks.ts
@@ -41,6 +41,7 @@ export const prismaMock = {
         ),
     },
     pushToken: {
+        delete: mock<() => Promise<object>>(() => Promise.resolve({ id: 'pt-1' })),
         findMany: mock<() => Promise<object[]>>(() => Promise.resolve([])),
         findUnique: mock<() => Promise<null | object>>(() => Promise.resolve(null)),
         update: mock<() => Promise<object>>(() =>

--- a/packages/emitsignal-server/src/http/push-tokens/__tests__/delete.spec.ts
+++ b/packages/emitsignal-server/src/http/push-tokens/__tests__/delete.spec.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { Elysia } from 'elysia';
+
+import { prismaMock } from '#/__tests__/mocks';
+
+mock.module('#/lib/prisma', () => ({ prisma: prismaMock }));
+
+const resolveUserIdMock = mock<() => Promise<null | string>>(() => Promise.resolve(null));
+mock.module('#/http/auth/plugin', () => ({ resolveUserId: resolveUserIdMock }));
+
+import { deletePushToken } from '#/http/push-tokens/delete';
+
+describe('DELETE /push-tokens/:id', () => {
+    const app = new Elysia().use(deletePushToken);
+
+    function request(id: string) {
+        return app.handle(new Request(`http://localhost/push-tokens/${id}`, { method: 'DELETE' }));
+    }
+
+    beforeEach(() => {
+        prismaMock.pushToken.findUnique.mockImplementation(() => Promise.resolve(null));
+        prismaMock.pushToken.delete.mockClear();
+    });
+
+    it('removes the token for the owner', async () => {
+        resolveUserIdMock.mockResolvedValueOnce('user-1');
+        prismaMock.pushToken.findUnique.mockResolvedValueOnce({ userId: 'user-1' });
+
+        const res = await request('pt-1');
+
+        expect(res.status).toBe(204);
+        expect(prismaMock.pushToken.delete).toHaveBeenCalledWith({ where: { id: 'pt-1' } });
+    });
+
+    it('returns 401 when no auth', async () => {
+        const res = await request('pt-1');
+
+        expect(res.status).toBe(401);
+
+        const data = await res.json();
+
+        expect(data).toEqual({ error: 'missing_token' });
+        expect(prismaMock.pushToken.delete).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when token not found', async () => {
+        resolveUserIdMock.mockResolvedValueOnce('user-1');
+
+        const res = await request('pt-nonexistent');
+
+        expect(res.status).toBe(404);
+
+        const data = await res.json();
+
+        expect(data).toEqual({ error: 'not_found' });
+        expect(prismaMock.pushToken.delete).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when user is not the owner', async () => {
+        resolveUserIdMock.mockResolvedValueOnce('user-1');
+        prismaMock.pushToken.findUnique.mockResolvedValueOnce({ userId: 'other-user' });
+
+        const res = await request('pt-1');
+
+        expect(res.status).toBe(403);
+
+        const data = await res.json();
+
+        expect(data).toEqual({ error: 'forbidden' });
+        expect(prismaMock.pushToken.delete).not.toHaveBeenCalled();
+    });
+});

--- a/packages/emitsignal-server/src/http/push-tokens/__tests__/list.spec.ts
+++ b/packages/emitsignal-server/src/http/push-tokens/__tests__/list.spec.ts
@@ -20,14 +20,44 @@ describe('GET /push-tokens', () => {
     it('returns push tokens for authenticated user', async () => {
         resolveUserIdMock.mockResolvedValueOnce('user-1');
         prismaMock.pushToken.findMany.mockResolvedValueOnce([
-            { deviceId: 'd1', id: 'pt-1', platform: 'ios', pushEnabled: true },
+            {
+                appId: 'com.emitsignal.preview',
+                createdAt: new Date('2026-08-01T00:00:00.000Z'),
+                deviceId: 'd1',
+                deviceName: 'iPhone 15 Pro',
+                id: 'pt-1',
+                platform: 'ios',
+                pushEnabled: true,
+                updatedAt: new Date('2026-08-10T00:00:00.000Z'),
+            },
         ]);
 
         const res = await request();
         expect(res.status).toBe(200);
 
         const data = await res.json();
-        expect(data).toEqual([{ deviceId: 'd1', id: 'pt-1', platform: 'ios', pushEnabled: true }]);
+        expect(data).toEqual([
+            {
+                appId: 'com.emitsignal.preview',
+                createdAt: '2026-08-01T00:00:00.000Z',
+                deviceId: 'd1',
+                deviceName: 'iPhone 15 Pro',
+                id: 'pt-1',
+                platform: 'ios',
+                pushEnabled: true,
+                updatedAt: '2026-08-10T00:00:00.000Z',
+            },
+        ]);
+    });
+
+    it('never selects the delivery token', async () => {
+        resolveUserIdMock.mockResolvedValueOnce('user-1');
+        await request();
+
+        const calls = prismaMock.pushToken.findMany.mock.calls;
+        const [args] = calls[calls.length - 1] as unknown as [{ select: Record<string, boolean> }];
+
+        expect(args.select.token).toBeUndefined();
     });
 
     it('returns 401 when no auth header', async () => {

--- a/packages/emitsignal-server/src/http/push-tokens/__tests__/register.spec.ts
+++ b/packages/emitsignal-server/src/http/push-tokens/__tests__/register.spec.ts
@@ -24,7 +24,13 @@ describe('POST /push-tokens', () => {
     function lastUpsertCreate() {
         const calls = prismaMock.pushToken.upsert.mock.calls;
         const callArgs = calls[calls.length - 1] as unknown as [
-            { create: { userId: null | string } },
+            {
+                create: {
+                    appId?: string;
+                    deviceName?: string;
+                    userId: null | string;
+                };
+            },
         ];
         return callArgs[0].create;
     }
@@ -45,7 +51,7 @@ describe('POST /push-tokens', () => {
 
     it('derives userId from the session and ignores a body userId', async () => {
         // The caller is authenticated as user-1 but tries to bind the token to
-        // victim-2 via the body. The body value must be ignored.
+        // user-2 via the body. The body value must be ignored.
         resolveUserIdMock.mockResolvedValueOnce('user-1');
 
         await app.handle(
@@ -53,7 +59,7 @@ describe('POST /push-tokens', () => {
                 deviceId: 'dev-1',
                 platform: 'android',
                 token: 'token-2',
-                userId: 'victim-2',
+                userId: 'user-2',
             }),
         );
 
@@ -66,13 +72,32 @@ describe('POST /push-tokens', () => {
         expect(lastUpsertCreate().userId).toBeNull();
     });
 
+    it('stores the device identity when the client sends it', async () => {
+        await app.handle(
+            request({
+                appId: 'com.emitsignal.preview',
+                deviceId: 'dev-1',
+                deviceName: 'iPhone 15 Pro',
+                platform: 'ios',
+                token: 'token-4',
+            }),
+        );
+
+        const create = lastUpsertCreate();
+
+        expect(create.appId).toBe('com.emitsignal.preview');
+        expect(create.deviceName).toBe('iPhone 15 Pro');
+    });
+
     it('returns 422 for missing required fields', async () => {
         const res = await app.handle(request({ platform: 'ios' }));
+
         expect(res.status).toBe(422);
     });
 
     it('returns 422 for invalid platform', async () => {
         const res = await app.handle(request({ deviceId: 'd1', platform: 'unknown', token: 't1' }));
+
         expect(res.status).toBe(422);
     });
 });

--- a/packages/emitsignal-server/src/http/push-tokens/delete.ts
+++ b/packages/emitsignal-server/src/http/push-tokens/delete.ts
@@ -1,0 +1,37 @@
+import Elysia, { t } from 'elysia';
+
+import { resolveUserId } from '#/http/auth/plugin';
+import { prisma } from '#/lib/prisma';
+
+export const deletePushToken = new Elysia({ prefix: '/push-tokens' }).delete(
+    '/:id',
+    async ({ headers, params: { id }, status }) => {
+        const userId = await resolveUserId({ headers });
+
+        if (!userId) {
+            return status(401, { error: 'missing_token' });
+        }
+
+        const pushToken = await prisma.pushToken.findUnique({
+            select: { userId: true },
+            where: { id },
+        });
+
+        if (!pushToken) {
+            return status(404, { error: 'not_found' });
+        }
+
+        if (pushToken.userId !== userId) {
+            return status(403, { error: 'forbidden' });
+        }
+
+        await prisma.pushToken.delete({ where: { id } });
+
+        return status(204);
+    },
+    {
+        params: t.Object({
+            id: t.String(),
+        }),
+    },
+);

--- a/packages/emitsignal-server/src/http/push-tokens/list.ts
+++ b/packages/emitsignal-server/src/http/push-tokens/list.ts
@@ -12,9 +12,20 @@ export const listPushTokens = new Elysia({ prefix: '/push-tokens' }).get(
             return status(401, { error: 'missing_token' });
         }
 
+        // `token` is deliberately absent: it is the delivery credential, and returning
+        // it would let anyone reading this response push to the user's devices.
         const tokens = await prisma.pushToken.findMany({
             orderBy: { createdAt: 'desc' },
-            select: { deviceId: true, id: true, platform: true, pushEnabled: true },
+            select: {
+                appId: true,
+                createdAt: true,
+                deviceId: true,
+                deviceName: true,
+                id: true,
+                platform: true,
+                pushEnabled: true,
+                updatedAt: true,
+            },
             where: { userId },
         });
 

--- a/packages/emitsignal-server/src/http/push-tokens/register.ts
+++ b/packages/emitsignal-server/src/http/push-tokens/register.ts
@@ -24,12 +24,16 @@ export const registerPushToken = new Elysia({ prefix: '/push-tokens' }).post(
 
         const token = await prisma.pushToken.upsert({
             create: {
+                appId: body.appId,
                 deviceId: body.deviceId,
+                deviceName: body.deviceName,
                 platform: body.platform,
                 token: body.token,
                 userId,
             },
             update: {
+                appId: body.appId,
+                deviceName: body.deviceName,
                 platform: body.platform,
                 // Never downgrade an owned token to anonymous; only set ownership
                 // when adopting a previously unowned token.
@@ -47,7 +51,9 @@ export const registerPushToken = new Elysia({ prefix: '/push-tokens' }).post(
     },
     {
         body: t.Object({
+            appId: t.Optional(t.String({ maxLength: 200, minLength: 1 })),
             deviceId: t.String({ minLength: 1 }),
+            deviceName: t.Optional(t.String({ maxLength: 200, minLength: 1 })),
             platform: t.Union([t.Literal('ios'), t.Literal('android'), t.Literal('web')]),
             token: t.String({ minLength: 1 }),
         }),

--- a/packages/emitsignal-server/src/http/push-tokens/update.ts
+++ b/packages/emitsignal-server/src/http/push-tokens/update.ts
@@ -27,7 +27,16 @@ export const updatePushToken = new Elysia({ prefix: '/push-tokens' }).patch(
 
         const updated = await prisma.pushToken.update({
             data: { pushEnabled: body.pushEnabled },
-            select: { deviceId: true, id: true, platform: true, pushEnabled: true },
+            select: {
+                appId: true,
+                createdAt: true,
+                deviceId: true,
+                deviceName: true,
+                id: true,
+                platform: true,
+                pushEnabled: true,
+                updatedAt: true,
+            },
             where: { id },
         });
 

--- a/packages/emitsignal-server/src/index.ts
+++ b/packages/emitsignal-server/src/index.ts
@@ -13,6 +13,7 @@ import { purgeSignals } from '#/http/messages/purge';
 import { errorResponsePlugin } from '#/http/plugins/error-response-plugin';
 import { loggerPlugin } from '#/http/plugins/logger-plugin';
 import { rateLimitPlugin } from '#/http/plugins/rate-limit-plugin';
+import { deletePushToken } from '#/http/push-tokens/delete';
 import { listPushTokens } from '#/http/push-tokens/list';
 import { registerPushToken } from '#/http/push-tokens/register';
 import { updatePushToken } from '#/http/push-tokens/update';
@@ -94,6 +95,7 @@ const app = new Elysia({
     .use(claimSubscriptions)
     .use(claimTopic)
     .use(createWebhook)
+    .use(deletePushToken)
     .use(deleteWebhook)
     .use(getBilling)
     .use(getMessage)

--- a/packages/emitsignal-shared/src/api.ts
+++ b/packages/emitsignal-shared/src/api.ts
@@ -54,10 +54,14 @@ export interface PaginatedResponse<T> {
 }
 
 export interface PushToken {
+    appId: null | string;
+    createdAt: string;
     deviceId: string;
+    deviceName: null | string;
     id: string;
     platform: string;
     pushEnabled: boolean;
+    updatedAt: string;
 }
 
 export interface Subscription {
@@ -247,6 +251,12 @@ export function createApiClient(baseUrl: string) {
             });
         },
 
+        deletePushToken(id: string) {
+            return request<{ ok: boolean }>(`/push-tokens/${encodeURIComponent(id)}`, {
+                method: 'DELETE',
+            });
+        },
+
         deleteWebhook(id: string) {
             return request<void>(`/webhooks/${encodeURIComponent(id)}`, { method: 'DELETE' });
         },
@@ -388,7 +398,9 @@ export function createApiClient(baseUrl: string) {
         },
 
         registerPushToken(input: {
+            appId?: string;
             deviceId: string;
+            deviceName?: string;
             platform: 'android' | 'ios' | 'web';
             token: string;
         }) {

--- a/packages/emitsignal-website/src/components/app/settings/device-row.test.tsx
+++ b/packages/emitsignal-website/src/components/app/settings/device-row.test.tsx
@@ -1,0 +1,75 @@
+import type { PushToken } from '@emitsignal/shared/api';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { DeviceRow } from './device-row';
+
+const SECRET_TOKEN = 'ExponentPushToken[secret-value]';
+
+function makeToken(overrides: Partial<PushToken> = {}): PushToken {
+    return {
+        appId: 'com.emitsignal.preview',
+        createdAt: new Date().toISOString(),
+        deviceId: 'device-abc123',
+        deviceName: 'iPhone 15 Pro',
+        id: 'pt-1',
+        platform: 'ios',
+        pushEnabled: true,
+        updatedAt: new Date().toISOString(),
+        ...overrides,
+    };
+}
+
+function renderRow(token: PushToken, onToggle = vi.fn(), onRemove = vi.fn()) {
+    const result = render(<DeviceRow onRemove={onRemove} onToggle={onToggle} token={token} />);
+
+    return { onRemove, onToggle, ...result };
+}
+
+describe('DeviceRow', () => {
+    test('never renders the push token', () => {
+        // The token is not even part of the props, so the only way it could leak
+        // is a future change widening PushToken — this guards that.
+        const { container } = renderRow(
+            makeToken({ ...({ token: SECRET_TOKEN } as Partial<PushToken>) }),
+        );
+
+        expect(container.textContent).not.toContain(SECRET_TOKEN);
+        expect(container.textContent).not.toContain('ExponentPushToken');
+    });
+
+    test('falls back to platform and a deviceId suffix when unnamed', () => {
+        renderRow(makeToken({ deviceName: null, platform: 'android' }));
+
+        expect(screen.getByText('Android · …abc123')).toBeTruthy();
+    });
+
+    test('toggling reports the inverted flag', () => {
+        const { onToggle } = renderRow(makeToken({ pushEnabled: true }));
+
+        fireEvent.click(screen.getByRole('switch'));
+
+        expect(onToggle).toHaveBeenCalledWith('pt-1', false);
+    });
+
+    test('removal requires a second confirming click', () => {
+        const { onRemove } = renderRow(makeToken());
+
+        fireEvent.click(screen.getByText('Remove'));
+        expect(onRemove).not.toHaveBeenCalled();
+
+        fireEvent.click(screen.getByText('Yes, remove'));
+        expect(onRemove).toHaveBeenCalledWith('pt-1');
+    });
+
+    test('cancelling leaves the device in place', () => {
+        const { onRemove } = renderRow(makeToken());
+
+        fireEvent.click(screen.getByText('Remove'));
+        fireEvent.click(screen.getByText('Cancel'));
+
+        expect(onRemove).not.toHaveBeenCalled();
+        expect(screen.getByRole('switch')).toBeTruthy();
+    });
+});

--- a/packages/emitsignal-website/src/components/app/settings/device-row.tsx
+++ b/packages/emitsignal-website/src/components/app/settings/device-row.tsx
@@ -1,0 +1,120 @@
+import type { PushToken } from '@emitsignal/shared/api';
+
+import { Monitor, Smartphone } from 'lucide-react';
+import { useState } from 'react';
+
+import { relativeTime } from '#/lib/format';
+
+import { SettingsButton } from './settings-button';
+
+interface DeviceRowProps {
+    onRemove: (id: string) => void;
+    onToggle: (id: string, pushEnabled: boolean) => void;
+    removing?: boolean;
+    toggling?: boolean;
+    token: PushToken;
+}
+
+const PLATFORM_LABEL: Record<string, string> = {
+    android: 'Android',
+    ios: 'iOS',
+    web: 'Browser',
+};
+
+export function deviceLabel(token: PushToken): string {
+    if (token.deviceName) {
+        return token.deviceName;
+    }
+
+    const platform = PLATFORM_LABEL[token.platform] ?? token.platform;
+
+    return `${platform} · …${token.deviceId.slice(-6)}`;
+}
+
+export function DeviceRow({
+    onRemove,
+    onToggle,
+    removing = false,
+    toggling = false,
+    token,
+}: DeviceRowProps) {
+    const [confirming, setConfirming] = useState(false);
+
+    const Icon = token.platform === 'web' ? Monitor : Smartphone;
+    const busy = removing || toggling;
+
+    return (
+        <div className="flex items-center gap-3.5 border-b border-line px-4 py-3.5 last:border-b-0">
+            <div className="flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[7px] border border-line bg-elev">
+                <Icon className="text-accent" size={15} />
+            </div>
+
+            <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                    <span className="truncate text-[13.5px] font-medium">{deviceLabel(token)}</span>
+                </div>
+
+                <div className="mt-0.5 truncate font-mono text-[11px] text-dim">
+                    {token.appId ? `${token.appId} · ` : ''}
+                    Registered {relativeTime(token.createdAt)} · Last seen{' '}
+                    {relativeTime(token.updatedAt)}
+                </div>
+            </div>
+
+            {confirming ? (
+                <div className="flex shrink-0 gap-2">
+                    <SettingsButton
+                        disabled={busy}
+                        onClick={() => setConfirming(false)}
+                        size="sm"
+                        variant="ghost"
+                    >
+                        Cancel
+                    </SettingsButton>
+
+                    <SettingsButton
+                        disabled={busy}
+                        onClick={() => onRemove(token.id)}
+                        size="sm"
+                        variant="danger"
+                    >
+                        {removing ? 'Removing…' : 'Yes, remove'}
+                    </SettingsButton>
+                </div>
+            ) : (
+                <>
+                    <button
+                        aria-checked={token.pushEnabled}
+                        aria-label={`Push notifications for ${deviceLabel(token)}`}
+                        className="shrink-0 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+                        disabled={busy}
+                        onClick={() => onToggle(token.id, !token.pushEnabled)}
+                        role="switch"
+                        type="button"
+                    >
+                        <div
+                            className={`flex h-5 w-9 items-center rounded-full border px-0.5 transition-all ${
+                                token.pushEnabled
+                                    ? 'justify-end border-accent bg-accent'
+                                    : 'justify-start border-line bg-chip'
+                            }`}
+                        >
+                            <div
+                                className={`h-3.5 w-3.5 rounded-full ${token.pushEnabled ? 'bg-bg' : 'bg-dim'}`}
+                            />
+                        </div>
+                    </button>
+
+                    <SettingsButton
+                        disabled={busy}
+                        onClick={() => setConfirming(true)}
+                        size="sm"
+                        variant="danger"
+                    >
+                        Remove
+                    </SettingsButton>
+                </>
+            )}
+        </div>
+    );
+}

--- a/packages/emitsignal-website/src/components/app/settings/devices-page.tsx
+++ b/packages/emitsignal-website/src/components/app/settings/devices-page.tsx
@@ -1,0 +1,55 @@
+import { usePushTokens } from '#/hooks/use-push-tokens';
+
+import { DeviceRow } from './device-row';
+import { SettingsCard } from './settings-card';
+import { SettingsGroup } from './settings-group';
+
+export function DevicesPage() {
+    const { error, loading, remove, removingId, toggle, togglingId, tokens } = usePushTokens();
+
+    return (
+        <>
+            <div className="mb-[26px] border-b border-line pb-[18px]">
+                <h1 className="text-[22px] font-semibold tracking-[-0.4px]">Devices</h1>
+                <p className="mt-1 max-w-[620px] text-[13px] leading-[1.55] text-muted">
+                    Every phone and browser registered to receive push notifications. Turn one off
+                    to stop delivery to it without signing out, or remove it entirely. Push tokens
+                    themselves are never displayed here.
+                </p>
+            </div>
+
+            <div>
+                <SettingsCard
+                    description="A device stops receiving push notifications the moment you turn it off, across every channel."
+                    title="Push targets"
+                >
+                    {error ? (
+                        <p className="mb-3 font-mono text-[12px] text-danger">{error}</p>
+                    ) : null}
+
+                    {loading ? (
+                        <p className="font-mono text-[12px] text-dim">Loading…</p>
+                    ) : tokens.length === 0 ? (
+                        <p className="font-mono text-[12px] text-dim">
+                            No devices registered yet. Sign in on the mobile app and allow
+                            notifications to see it here.
+                        </p>
+                    ) : (
+                        <SettingsGroup>
+                            {tokens.map((token) => (
+                                <DeviceRow
+                                    key={token.id}
+                                    onRemove={remove}
+                                    onToggle={toggle}
+                                    removing={removingId === token.id}
+                                    toggling={togglingId === token.id}
+                                    token={token}
+                                />
+                            ))}
+                        </SettingsGroup>
+                    )}
+                </SettingsCard>
+            </div>
+        </>
+    );
+}

--- a/packages/emitsignal-website/src/components/app/settings/settings-shell.tsx
+++ b/packages/emitsignal-website/src/components/app/settings/settings-shell.tsx
@@ -12,6 +12,7 @@ interface SubNavItem {
 const NAV_ITEMS: SubNavItem[] = [
     { group: 'YOU', key: 'profile', label: 'Profile', path: '/app/settings/profile' },
     { group: 'YOU', key: 'account', label: 'Account', path: '/app/settings/account' },
+    { group: 'YOU', key: 'devices', label: 'Devices', path: '/app/settings/devices' },
     { group: 'TEAM', key: 'billing', label: 'Billing & plan', path: '/app/settings/billing' },
     { group: 'DANGER', key: 'advanced', label: 'Advanced', path: '/app/settings/advanced' },
 ];

--- a/packages/emitsignal-website/src/hooks/use-push-tokens.ts
+++ b/packages/emitsignal-website/src/hooks/use-push-tokens.ts
@@ -1,0 +1,55 @@
+import type { PushToken } from '@emitsignal/shared/api';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '#/lib/api';
+import { apiErrorMessage } from '#/lib/api-error';
+import { queryKeys } from '#/lib/query-client';
+
+export function usePushTokens() {
+    const queryClient = useQueryClient();
+
+    const { data, error, isPending } = useQuery({
+        queryFn: () => api.listMyPushTokens(),
+        queryKey: queryKeys.pushTokens,
+    });
+
+    const toggleMutation = useMutation({
+        mutationFn: ({ id, pushEnabled }: { id: string; pushEnabled: boolean }) =>
+            api.updatePushToken(id, pushEnabled),
+        onSuccess: (updated) => {
+            queryClient.setQueryData<PushToken[]>(queryKeys.pushTokens, (previous) =>
+                (previous ?? []).map((token) => (token.id === updated.id ? updated : token)),
+            );
+        },
+    });
+
+    const removeMutation = useMutation({
+        mutationFn: async (id: string) => {
+            await api.deletePushToken(id);
+
+            return id;
+        },
+        onSuccess: (id) => {
+            queryClient.setQueryData<PushToken[]>(queryKeys.pushTokens, (previous) =>
+                (previous ?? []).filter((token) => token.id !== id),
+            );
+        },
+    });
+
+    const mutationError = toggleMutation.error ?? removeMutation.error;
+
+    return {
+        error: error
+            ? apiErrorMessage(error, 'Failed to load devices')
+            : mutationError
+              ? apiErrorMessage(mutationError, 'Failed to update device')
+              : null,
+        loading: isPending,
+        remove: (id: string) => removeMutation.mutate(id),
+        removingId: removeMutation.isPending ? removeMutation.variables : null,
+        toggle: (id: string, pushEnabled: boolean) => toggleMutation.mutate({ id, pushEnabled }),
+        togglingId: toggleMutation.isPending ? toggleMutation.variables.id : null,
+        tokens: data ?? [],
+    };
+}

--- a/packages/emitsignal-website/src/lib/query-client.ts
+++ b/packages/emitsignal-website/src/lib/query-client.ts
@@ -17,6 +17,7 @@ import { authClient } from '#/lib/auth-client';
  *   ['auth', 'sessions']          → authClient.listSessions()
  *   ['billing']                   → api.getBilling()
  *   ['feed', scope]               → api.listSubscriptionMessages()
+ *   ['push-tokens']               → api.listMyPushTokens()
  *   ['session']                   → authClient.getSession()
  *   ['subscriptions', scope]      → api.listSubscriptions()    (scope = userId ?? deviceId)
  *   ['topic-messages', name, filters] → api.listSubscriptionMessages(deviceId, { topicName, ...filters })
@@ -34,6 +35,7 @@ export const queryKeys = {
     authSessions: ['auth', 'sessions'] as const,
     billing: ['billing'] as const,
     feed: (scope: string) => ['feed', scope] as const,
+    pushTokens: ['push-tokens'] as const,
     session: ['session'] as const,
     subscriptions: (scope: string) => ['subscriptions', scope] as const,
     topicMessages: (topicName: string, filters?: MessageFilterParams) =>

--- a/packages/emitsignal-website/src/routeTree.gen.ts
+++ b/packages/emitsignal-website/src/routeTree.gen.ts
@@ -34,6 +34,7 @@ import { Route as AppSettingsIndexRouteImport } from './routes/app/settings/inde
 import { Route as AppSettingsAccountRouteImport } from './routes/app/settings/account'
 import { Route as AppSettingsAdvancedRouteImport } from './routes/app/settings/advanced'
 import { Route as AppSettingsBillingRouteImport } from './routes/app/settings/billing'
+import { Route as AppSettingsDevicesRouteImport } from './routes/app/settings/devices'
 import { Route as AppSettingsProfileRouteImport } from './routes/app/settings/profile'
 import { Route as AppWebhooksIndexRouteImport } from './routes/app/webhooks/index'
 import { Route as AppWebhooksWebhookIdRouteImport } from './routes/app/webhooks/$webhookId'
@@ -165,6 +166,11 @@ const AppSettingsBillingRoute = AppSettingsBillingRouteImport.update({
   path: '/billing',
   getParentRoute: () => AppSettingsRoute,
 } as any)
+const AppSettingsDevicesRoute = AppSettingsDevicesRouteImport.update({
+  id: '/devices',
+  path: '/devices',
+  getParentRoute: () => AppSettingsRoute,
+} as any)
 const AppSettingsProfileRoute = AppSettingsProfileRouteImport.update({
   id: '/profile',
   path: '/profile',
@@ -216,6 +222,7 @@ export interface FileRoutesByFullPath {
   '/app/settings/account': typeof AppSettingsAccountRoute
   '/app/settings/advanced': typeof AppSettingsAdvancedRoute
   '/app/settings/billing': typeof AppSettingsBillingRoute
+  '/app/settings/devices': typeof AppSettingsDevicesRoute
   '/app/settings/profile': typeof AppSettingsProfileRoute
   '/app/webhooks/$webhookId': typeof AppWebhooksWebhookIdRouteWithChildren
   '/app/webhooks/new': typeof AppWebhooksNewRoute
@@ -245,6 +252,7 @@ export interface FileRoutesByTo {
   '/app/settings/account': typeof AppSettingsAccountRoute
   '/app/settings/advanced': typeof AppSettingsAdvancedRoute
   '/app/settings/billing': typeof AppSettingsBillingRoute
+  '/app/settings/devices': typeof AppSettingsDevicesRoute
   '/app/settings/profile': typeof AppSettingsProfileRoute
   '/app/webhooks/$webhookId': typeof AppWebhooksWebhookIdRouteWithChildren
   '/app/webhooks/new': typeof AppWebhooksNewRoute
@@ -278,6 +286,7 @@ export interface FileRoutesById {
   '/app/settings/account': typeof AppSettingsAccountRoute
   '/app/settings/advanced': typeof AppSettingsAdvancedRoute
   '/app/settings/billing': typeof AppSettingsBillingRoute
+  '/app/settings/devices': typeof AppSettingsDevicesRoute
   '/app/settings/profile': typeof AppSettingsProfileRoute
   '/app/webhooks/$webhookId': typeof AppWebhooksWebhookIdRouteWithChildren
   '/app/webhooks/new': typeof AppWebhooksNewRoute
@@ -312,6 +321,7 @@ export interface FileRouteTypes {
     | '/app/settings/account'
     | '/app/settings/advanced'
     | '/app/settings/billing'
+    | '/app/settings/devices'
     | '/app/settings/profile'
     | '/app/webhooks/$webhookId'
     | '/app/webhooks/new'
@@ -341,6 +351,7 @@ export interface FileRouteTypes {
     | '/app/settings/account'
     | '/app/settings/advanced'
     | '/app/settings/billing'
+    | '/app/settings/devices'
     | '/app/settings/profile'
     | '/app/webhooks/$webhookId'
     | '/app/webhooks/new'
@@ -373,6 +384,7 @@ export interface FileRouteTypes {
     | '/app/settings/account'
     | '/app/settings/advanced'
     | '/app/settings/billing'
+    | '/app/settings/devices'
     | '/app/settings/profile'
     | '/app/webhooks/$webhookId'
     | '/app/webhooks/new'
@@ -574,6 +586,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppSettingsBillingRouteImport
       parentRoute: typeof AppSettingsRoute
     }
+    '/app/settings/devices': {
+      id: '/app/settings/devices'
+      path: '/devices'
+      fullPath: '/app/settings/devices'
+      preLoaderRoute: typeof AppSettingsDevicesRouteImport
+      parentRoute: typeof AppSettingsRoute
+    }
     '/app/settings/profile': {
       id: '/app/settings/profile'
       path: '/profile'
@@ -616,6 +635,7 @@ interface AppSettingsRouteChildren {
   AppSettingsAccountRoute: typeof AppSettingsAccountRoute
   AppSettingsAdvancedRoute: typeof AppSettingsAdvancedRoute
   AppSettingsBillingRoute: typeof AppSettingsBillingRoute
+  AppSettingsDevicesRoute: typeof AppSettingsDevicesRoute
   AppSettingsProfileRoute: typeof AppSettingsProfileRoute
   AppSettingsIndexRoute: typeof AppSettingsIndexRoute
 }
@@ -624,6 +644,7 @@ const AppSettingsRouteChildren: AppSettingsRouteChildren = {
   AppSettingsAccountRoute: AppSettingsAccountRoute,
   AppSettingsAdvancedRoute: AppSettingsAdvancedRoute,
   AppSettingsBillingRoute: AppSettingsBillingRoute,
+  AppSettingsDevicesRoute: AppSettingsDevicesRoute,
   AppSettingsProfileRoute: AppSettingsProfileRoute,
   AppSettingsIndexRoute: AppSettingsIndexRoute,
 }

--- a/packages/emitsignal-website/src/routes/app/settings/devices.tsx
+++ b/packages/emitsignal-website/src/routes/app/settings/devices.tsx
@@ -1,0 +1,5 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { DevicesPage } from '#/components/app/settings/devices-page';
+
+export const Route = createFileRoute('/app/settings/devices')({ component: DevicesPage });


### PR DESCRIPTION
Adds a **Devices** page under `/app/settings` so a user can see every phone and browser registered to receive push notifications, toggle delivery per device, and remove one — without the push token ever being exposed.

### Why

Push tokens were registered by every client but had no management surface. The only place to toggle one was the mobile app's own settings, which can only see the device it runs on. A user signed in on web plus an iPhone plus an Android had no way to answer "which devices can push me, and can I turn one off?"

### Changes

- **Server** — `PushToken` gains nullable `appId` and `deviceName` so a device can be labelled; `GET /push-tokens` now returns those plus `createdAt`/`updatedAt`; new `DELETE /push-tokens/:id` reusing the same 401 → 404 → 403 ownership ladder as the existing PATCH.
- **Shared** — `PushToken` widened, `deletePushToken()` added, `registerPushToken()` accepts the new optional fields.
- **Mobile** — new `lib/app-identity.ts` derives `{ appId, deviceName, platform }` from `expo-constants` + `expo-device` (no new dependencies) and is spread into all three `registerPushToken` call sites, which also removes the duplicated `Platform.OS` ternary from each.
- **Website** — `/app/settings/devices` route and nav entry, `use-push-tokens` hook, and a `DeviceRow` that falls back to `Android · …abc123` for rows registered before this change. Delete uses the inline two-step confirm already used in the danger zone rather than a modal.

The `token` column stays out of every `select`. `list.spec.ts` asserts that directly against the Prisma call arguments, so a future widening of the select fails the suite rather than silently leaking the credential.

No change was needed to push fan-out — `services/push/recipients.ts` already filtered on `pushEnabled`, so the toggle was wired end to end already.

### Verification

`bun format:check`, server suite (473 pass), website suite (22 pass), and typechecks across server/website/mobile are all clean. The migration has been applied locally; it is additive and nullable, so existing rows are unaffected.
