### PR TITLE
feat(mobile): skeleton loading for topic and message screens

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,14 +34,8 @@
         "lint:fix": "eslint . --fix",
         "test": "bun --filter '*' test"
     },
-    "trustedDependencies": [
-        "@sentry/cli",
-        "protobufjs",
-        "unrs-resolver"
-    ],
+    "trustedDependencies": ["@sentry/cli", "protobufjs", "unrs-resolver"],
     "type": "module",
     "version": "1.1.1",
-    "workspaces": [
-        "packages/*"
-    ]
+    "workspaces": ["packages/*"]
 }

--- a/packages/emitsignal-cli/package.json
+++ b/packages/emitsignal-cli/package.json
@@ -15,10 +15,7 @@
         "react": "^19.0.0",
         "smol-toml": "^1.3.1"
     },
-    "files": [
-        "dist",
-        "LICENSE"
-    ],
+    "files": ["dist", "LICENSE"],
     "homepage": "https://emitsignal.com/cli",
     "license": "AGPL-3.0-only",
     "name": "@emitsignal/cli",

--- a/packages/emitsignal-mobile/app/messages/[id].tsx
+++ b/packages/emitsignal-mobile/app/messages/[id].tsx
@@ -8,6 +8,7 @@ import { AttachmentPreview } from '@/components/attachment-preview';
 import { WChip, WCode, WDot } from '@/components/base-theme';
 import { MessageMedia } from '@/components/message-media';
 import { ScreenHeader } from '@/components/screen-header';
+import { SkeletonMessageDetail } from '@/components/skeleton';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { Fonts, type Palette, PriorityColors } from '@/constants/theme';
 import { useDebugSections } from '@/ctx/debug-sections';
@@ -26,7 +27,7 @@ export default function MessageDetailScreen() {
     const { id } = useLocalSearchParams<{ id: string }>();
     const { sections } = useDebugSections();
 
-    const { data: message } = useQuery({
+    const { data: message, isLoading } = useQuery({
         enabled: Boolean(id),
         queryFn: () => api.getMessage(id),
         queryKey: queryKeys.message(id),
@@ -56,8 +57,14 @@ export default function MessageDetailScreen() {
 
     if (!message) {
         return (
-            <SafeAreaView style={styles.root}>
-                <Text style={styles.loading}>loading…</Text>
+            <SafeAreaView edges={['top']} style={styles.root}>
+                <ScreenHeader altName="" title="message" />
+
+                {isLoading ? (
+                    <SkeletonMessageDetail />
+                ) : (
+                    <Text style={styles.loading}>message unavailable</Text>
+                )}
             </SafeAreaView>
         );
     }

--- a/packages/emitsignal-mobile/app/topics/[...topic].tsx
+++ b/packages/emitsignal-mobile/app/topics/[...topic].tsx
@@ -4,6 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { WChip } from '@/components/base-theme';
 import { ScreenHeader } from '@/components/screen-header';
+import { SkeletonMessageList } from '@/components/skeleton';
 import { TopicActionsMenu } from '@/components/topic-actions-menu';
 import { Fonts, type Palette, PriorityColors } from '@/constants/theme';
 import { useTopicMessages } from '@/hooks/use-emit-signal';
@@ -31,11 +32,15 @@ export default function TopicScreen() {
             />
 
             <FlatList
-                contentContainerStyle={messages.length === 0 ? { flex: 1 } : { paddingBottom: 40 }}
+                contentContainerStyle={
+                    messages.length === 0 && !loading ? { flex: 1 } : { paddingBottom: 40 }
+                }
                 data={messages}
                 keyExtractor={(message) => message.id}
                 ListEmptyComponent={
-                    loading ? null : (
+                    loading ? (
+                        <SkeletonMessageList />
+                    ) : (
                         <View style={styles.empty}>
                             <Text style={styles.emptyTitle}>No messages yet</Text>
                             <Text style={styles.emptyBody}>

--- a/packages/emitsignal-mobile/components/skeleton.tsx
+++ b/packages/emitsignal-mobile/components/skeleton.tsx
@@ -1,0 +1,145 @@
+import { useEffect } from 'react';
+import { type DimensionValue, StyleSheet, View, type ViewStyle } from 'react-native';
+import Animated, {
+    Easing,
+    useAnimatedStyle,
+    useReducedMotion,
+    useSharedValue,
+    withRepeat,
+    withTiming,
+} from 'react-native-reanimated';
+
+import { type Palette } from '@/constants/theme';
+import { useThemedStyles } from '@/hooks/use-themed-styles';
+
+interface SkeletonProps {
+    height?: number;
+    radius?: number;
+    style?: ViewStyle;
+    width?: DimensionValue;
+}
+
+export function Skeleton({ height = 12, radius = 6, style, width = '100%' }: SkeletonProps) {
+    const { styles } = useThemedStyles(createStyles);
+    const reducedMotion = useReducedMotion();
+    const pulse = useSharedValue(0.5);
+
+    useEffect(() => {
+        if (reducedMotion) {
+            return;
+        }
+
+        pulse.value = withRepeat(
+            withTiming(1, { duration: 850, easing: Easing.inOut(Easing.ease) }),
+            -1,
+            true,
+        );
+    }, [pulse, reducedMotion]);
+
+    const animatedStyle = useAnimatedStyle(() => ({ opacity: pulse.value }));
+
+    return (
+        <Animated.View
+            style={[
+                styles.block,
+                { borderRadius: radius, height, width },
+                style,
+                reducedMotion ? { opacity: 0.5 } : animatedStyle,
+            ]}
+        />
+    );
+}
+
+export function SkeletonMessageDetail() {
+    const { styles } = useThemedStyles(createStyles);
+
+    return (
+        <View style={styles.detail}>
+            <Skeleton height={11} radius={4} width={128} />
+            <Skeleton height={24} style={styles.detailTitle} width="82%" />
+            <Skeleton height={13} style={styles.detailLine} width="97%" />
+            <Skeleton height={13} style={styles.detailLine} width="90%" />
+            <Skeleton height={13} style={styles.detailLine} width="64%" />
+
+            <View style={styles.detailTags}>
+                <Skeleton height={20} radius={10} width={62} />
+                <Skeleton height={20} radius={10} width={48} />
+                <Skeleton height={20} radius={10} width={70} />
+            </View>
+
+            <View style={styles.detailActions}>
+                <Skeleton height={38} radius={8} style={styles.detailAction} />
+                <Skeleton height={38} radius={8} style={styles.detailAction} />
+            </View>
+        </View>
+    );
+}
+
+export function SkeletonMessageList({ count = 6 }: { count?: number }) {
+    return (
+        <View>
+            {Array.from({ length: count }).map((_, index) => (
+                <SkeletonMessageRow key={index} />
+            ))}
+        </View>
+    );
+}
+
+export function SkeletonMessageRow() {
+    const { styles } = useThemedStyles(createStyles);
+
+    return (
+        <View style={styles.row}>
+            <View style={styles.ribbon} />
+
+            <View style={styles.rowBody}>
+                <Skeleton height={9} radius={4} width={64} />
+                <Skeleton height={13} style={styles.rowTitle} width="72%" />
+                <Skeleton height={11} style={styles.rowLine} width="94%" />
+                <Skeleton height={11} style={styles.rowLine} width="58%" />
+
+                <View style={styles.rowTags}>
+                    <Skeleton height={18} radius={9} width={54} />
+                    <Skeleton height={18} radius={9} width={38} />
+                </View>
+            </View>
+        </View>
+    );
+}
+
+const createStyles = (palette: Palette) =>
+    StyleSheet.create({
+        block: { backgroundColor: palette.skeleton },
+        detail: {
+            borderBottomColor: palette.bgLine,
+            borderBottomWidth: StyleSheet.hairlineWidth,
+            paddingBottom: 18,
+            paddingHorizontal: 20,
+            paddingTop: 20,
+        },
+        detailAction: { flex: 1 },
+        detailActions: { flexDirection: 'row', gap: 8, marginTop: 14 },
+        detailLine: { marginTop: 8 },
+        detailTags: { flexDirection: 'row', gap: 6, marginTop: 14 },
+        detailTitle: { marginTop: 12 },
+        ribbon: {
+            backgroundColor: palette.bgLine,
+            bottom: 0,
+            left: 0,
+            position: 'absolute',
+            top: 0,
+            width: 2,
+        },
+        row: {
+            borderBottomColor: palette.bgLine,
+            borderBottomWidth: StyleSheet.hairlineWidth,
+            flexDirection: 'row',
+            paddingHorizontal: 20,
+            paddingVertical: 14,
+            position: 'relative',
+        },
+        rowBody: { flex: 1, paddingLeft: 12 },
+        rowLine: { marginTop: 6 },
+        rowTags: { flexDirection: 'row', gap: 6, marginTop: 8 },
+        rowTitle: { marginTop: 8 },
+    });

--- a/packages/emitsignal-mobile/constants/theme.ts
+++ b/packages/emitsignal-mobile/constants/theme.ts
@@ -39,6 +39,7 @@ export const darkPalette = {
     red: '#f87171',
     // Dialog scrim
     scrim: 'rgba(3,3,4,0.72)',
+    skeleton: '#191a1d',
     // Accents
     violet: '#a78bfa',
     violetBg: 'rgba(124,58,237,0.12)',
@@ -80,6 +81,7 @@ export const lightPalette: Palette = {
     pink: '#c026d3',
     red: '#dc2626',
     scrim: 'rgba(24,24,27,0.45)',
+    skeleton: '#e4e4e7',
     // Accents
     violet: '#7c3aed',
     violetBg: 'rgba(124,58,237,0.10)',

--- a/packages/emitsignal-website/package.json
+++ b/packages/emitsignal-website/package.json
@@ -57,10 +57,7 @@
     "license": "AGPL-3.0-only",
     "name": "@emitsignal/website",
     "pnpm": {
-        "onlyBuiltDependencies": [
-            "esbuild",
-            "lightningcss"
-        ]
+        "onlyBuiltDependencies": ["esbuild", "lightningcss"]
     },
     "private": true,
     "scripts": {


### PR DESCRIPTION
## What

Replaces the two placeholder loading states in the mobile app with skeletons that match the real layouts.

- **New** `components/skeleton.tsx` — a `Skeleton` primitive (reanimated opacity pulse, honors `useReducedMotion` by holding a static 0.5 opacity) plus `SkeletonMessageRow`, `SkeletonMessageList` and `SkeletonMessageDetail`. Geometry mirrors the real rows and hero (priority ribbon, 20px gutters, hairline separators) so nothing shifts on swap.
- `app/topics/[...topic].tsx` — renders the skeleton list while loading instead of `null`. The `flex: 1` container style is now applied only when the list is genuinely empty; it exists to center the empty state and would otherwise stretch the skeleton rows.
- `app/messages/[id].tsx` — replaces the bare `loading…` text with a header shell plus the detail skeleton. `isLoading` is now read off the query so the `!message` branch can tell loading apart from a failed fetch; the non-loading case reads `message unavailable` rather than showing a permanent "loading…" on error.

## Theme token

Adds a `skeleton` palette token rather than reusing `bgElev2`. Elevation moves toward white in both palettes, so on light it landed at `#f4f4f5` on a `#fafafa` background — effectively invisible. A skeleton needs a contrast step whose direction flips per theme:

| | `bg` | `skeleton` | step |
| --- | --- | --- | --- |
| dark | `#000000` | `#191a1d` | +25 |
| light | `#fafafa` | `#e4e4e7` | −25 |

Dark is unchanged from the previous `bgElev2` value.

## Verification

Run on the iOS simulator (iPhone 17) against a dev client; both skeleton states confirmed visually in dark and light. `tsc --noEmit` clean, `expo lint` 0 errors, Prettier clean.