### PR TITLE
ci: format the release PR after release-please updates it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,47 @@ jobs:
                   config-file: release-please-config.json
                   manifest-file: .release-please-manifest.json
 
+            # release-please serializes package.json with its own JSON writer, which
+            # expands short arrays that Prettier collapses. Left alone, merging the
+            # release PR lands unformatted files on main, and `format:check` then fails
+            # on main and on every branch cut from it until someone formats by hand.
+            #
+            # Guarded on the `prs` output rather than `prs_created` so this also runs
+            # when release-please updates an existing release PR, not just on creation.
+            - name: Check out the release PR
+              if: steps.release.outputs.prs != '' && steps.release.outputs.prs != '[]'
+              uses: actions/checkout@v4
+              with:
+                  ref: ${{ fromJSON(steps.release.outputs.prs)[0].headBranchName }}
+
+            - name: Set up Bun
+              if: steps.release.outputs.prs != '' && steps.release.outputs.prs != '[]'
+              uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: '1.3.13'
+
+            - name: Format the release PR
+              if: steps.release.outputs.prs != '' && steps.release.outputs.prs != '[]'
+              run: |
+                  bun install
+                  bun format
+
+                  # bun install rewrites bun.lock off the bumped versions; that belongs to
+                  # release-please, not to a formatting commit.
+                  git checkout -- bun.lock
+
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git add -A
+
+                  if git diff --cached --quiet; then
+                      echo "release PR is already formatted"
+                      exit 0
+                  fi
+
+                  git commit -m "chore: Source Format"
+                  git push
+
     publish-cli:
         needs: release-please
         if: needs.release-please.outputs.release_created == 'true'

--- a/package.json
+++ b/package.json
@@ -34,14 +34,8 @@
         "lint:fix": "eslint . --fix",
         "test": "bun --filter '*' test"
     },
-    "trustedDependencies": [
-        "@sentry/cli",
-        "protobufjs",
-        "unrs-resolver"
-    ],
+    "trustedDependencies": ["@sentry/cli", "protobufjs", "unrs-resolver"],
     "type": "module",
     "version": "1.1.1",
-    "workspaces": [
-        "packages/*"
-    ]
+    "workspaces": ["packages/*"]
 }

--- a/packages/emitsignal-cli/package.json
+++ b/packages/emitsignal-cli/package.json
@@ -15,10 +15,7 @@
         "react": "^19.0.0",
         "smol-toml": "^1.3.1"
     },
-    "files": [
-        "dist",
-        "LICENSE"
-    ],
+    "files": ["dist", "LICENSE"],
     "homepage": "https://emitsignal.com/cli",
     "license": "AGPL-3.0-only",
     "name": "@emitsignal/cli",

--- a/packages/emitsignal-website/package.json
+++ b/packages/emitsignal-website/package.json
@@ -57,10 +57,7 @@
     "license": "AGPL-3.0-only",
     "name": "@emitsignal/website",
     "pnpm": {
-        "onlyBuiltDependencies": [
-            "esbuild",
-            "lightningcss"
-        ]
+        "onlyBuiltDependencies": ["esbuild", "lightningcss"]
     },
     "private": true,
     "scripts": {


### PR DESCRIPTION
## Problem

release-please serializes `package.json` with its own JSON writer, which expands short arrays that Prettier (`printWidth: 100`, `prettier-plugin-sort-json`) collapses. Merging a release PR therefore lands unformatted files on `main`.

That is what happened with #47 → `c2dbd3c chore(main): release 1.1.1`: `format:check` has been failing on `main` since, and every branch cut from it inherits the failure — #48 hit it and needed a hand-written `chore: Source Format` commit to go green. Without a fix this recurs on every release.

## Fix

After release-please creates or updates its PR, check that branch out, run `bun format`, and commit back to it. The release PR then merges clean and `main` stays formatted.

Details worth noting:

- Guarded on the `prs` output rather than `prs_created`, so it also runs when release-please *updates* an existing release PR, not only on first creation.
- `bun install` is needed for the Prettier plugin, but it also rewrites `bun.lock` off the bumped versions — that is release-please's business, not a formatting commit's, so the lockfile is restored before committing.
- No-ops cleanly when the release PR is already formatted.

## Known limitation

The push uses the default `GITHUB_TOKEN`, which does not re-trigger workflows. The release PR's own checks may still show the run from before the formatting commit; the merged result on `main` is correct either way. Re-running that PR's checks manually will show green.