### PR TITLE
feat(server): open CORS on the publish endpoint

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -138,7 +138,6 @@
         "@better-auth/stripe": "^1.6.18",
         "@elysia/openapi": "^1.4.15",
         "@elysia/opentelemetry": "^1.4.12",
-        "@elysiajs/cors": "^1.4.1",
         "@emitsignal/emails": "workspace:*",
         "@emitsignal/shared": "workspace:*",
         "@logtail/pino": "^0.5.8",
@@ -478,8 +477,6 @@
     "@elysia/openapi": ["@elysia/openapi@1.4.15", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-MrVGCPo5hnRF4/yWGOyH5ddjt4DlSIbeC5rrkupQtHY8TEQe+XdJa2YM9aUOrtgtRcy4UNGyiVlLl/jllPkPQA=="],
 
     "@elysia/opentelemetry": ["@elysia/opentelemetry@1.4.12", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/instrumentation": "^0.200.0", "@opentelemetry/sdk-node": "^0.200.0" }, "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-Tec3w5C3V+VCHlyPyLHZXuoIwQ7SK3eX1iFz+WFUrxZN2eQCarX6NYHl/UeUoqhQNTcogBo7KKcRE79YS2Yiog=="],
-
-    "@elysiajs/cors": ["@elysiajs/cors@1.4.2", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-FTCcbH35brTLigF1W7BYySRZomgI/dBEMK9BgK9RP9Nez7zmpGh4koL/Yr1BFv8nYz7CfhRvcM8d/c+XnwMaVQ=="],
 
     "@emitsignal/cli": ["@emitsignal/cli@workspace:packages/emitsignal-cli"],
 

--- a/packages/emitsignal-server/package.json
+++ b/packages/emitsignal-server/package.json
@@ -6,7 +6,6 @@
         "@better-auth/stripe": "^1.6.18",
         "@elysia/openapi": "^1.4.15",
         "@elysia/opentelemetry": "^1.4.12",
-        "@elysiajs/cors": "^1.4.1",
         "@emitsignal/emails": "workspace:*",
         "@emitsignal/shared": "workspace:*",
         "@logtail/pino": "^0.5.8",

--- a/packages/emitsignal-server/src/http/plugins/__tests__/cors-plugin.spec.ts
+++ b/packages/emitsignal-server/src/http/plugins/__tests__/cors-plugin.spec.ts
@@ -58,6 +58,15 @@ describe('corsPlugin', () => {
             expect(res.headers.get('access-control-allow-origin')).toBe('*');
         });
 
+        it('allows the header-based publish fields for the app origin too', async () => {
+            const res = await app.handle(request('OPTIONS', '/publish/alerts', APP_ORIGIN));
+
+            const allowedHeaders = res.headers.get('access-control-allow-headers') ?? '';
+
+            expect(allowedHeaders).toContain('X-Title');
+            expect(allowedHeaders).toContain('X-Priority');
+        });
+
         it('keeps the credentialed policy for the app origin', async () => {
             const res = await app.handle(request('POST', '/publish/alerts', APP_ORIGIN));
 

--- a/packages/emitsignal-server/src/http/plugins/__tests__/cors-plugin.spec.ts
+++ b/packages/emitsignal-server/src/http/plugins/__tests__/cors-plugin.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'bun:test';
+import { Elysia } from 'elysia';
+
+import { corsPlugin } from '#/http/plugins/cors-plugin';
+import { environment } from '#/schema/environment';
+
+const APP_ORIGIN = environment.APP_URL;
+const FOREIGN_ORIGIN = 'https://foreign.example';
+
+const app = new Elysia()
+    .use(corsPlugin)
+    .post('/publish/*', () => ({ message: 'posted' }))
+    .post('/topic/*', () => ({ message: 'posted' }))
+    .get('/topics', () => []);
+
+function request(method: string, path: string, origin?: string) {
+    return new Request(`http://localhost${path}`, {
+        headers: origin ? { origin } : {},
+        method,
+    });
+}
+
+describe('corsPlugin', () => {
+    describe('publish routes', () => {
+        it('answers a foreign preflight with a wildcard origin and no credentials', async () => {
+            const res = await app.handle(request('OPTIONS', '/publish/alerts', FOREIGN_ORIGIN));
+
+            expect(res.status).toBe(204);
+            expect(res.headers.get('access-control-allow-origin')).toBe('*');
+            expect(res.headers.get('access-control-allow-credentials')).toBeNull();
+        });
+
+        it('allows the header-based publish fields in preflight', async () => {
+            const res = await app.handle(request('OPTIONS', '/publish/alerts', FOREIGN_ORIGIN));
+
+            const allowedHeaders = res.headers.get('access-control-allow-headers') ?? '';
+
+            expect(allowedHeaders).toContain('X-Title');
+            expect(allowedHeaders).toContain('X-Priority');
+            expect(allowedHeaders).toContain('X-Tags');
+            expect(allowedHeaders).toContain('X-Api-Key');
+            expect(res.headers.get('access-control-allow-methods')).toContain('POST');
+            expect(res.headers.get('access-control-max-age')).toBe('600');
+        });
+
+        it('sets the wildcard origin and exposed headers on the actual response', async () => {
+            const res = await app.handle(request('POST', '/publish/alerts', FOREIGN_ORIGIN));
+
+            expect(res.status).toBe(200);
+            expect(res.headers.get('access-control-allow-origin')).toBe('*');
+            expect(res.headers.get('access-control-expose-headers')).toContain('X-Quota-Limit');
+            expect(res.headers.get('vary')).toBe('Origin');
+        });
+
+        it('applies the public policy to the deprecated /topic alias', async () => {
+            const res = await app.handle(request('OPTIONS', '/topic/alerts', FOREIGN_ORIGIN));
+
+            expect(res.headers.get('access-control-allow-origin')).toBe('*');
+        });
+
+        it('keeps the credentialed policy for the app origin', async () => {
+            const res = await app.handle(request('POST', '/publish/alerts', APP_ORIGIN));
+
+            expect(res.headers.get('access-control-allow-origin')).toBe(APP_ORIGIN);
+            expect(res.headers.get('access-control-allow-credentials')).toBe('true');
+        });
+    });
+
+    describe('other routes', () => {
+        it('refuses a foreign origin', async () => {
+            const res = await app.handle(request('OPTIONS', '/topics', FOREIGN_ORIGIN));
+
+            expect(res.status).toBe(204);
+            expect(res.headers.get('access-control-allow-origin')).toBeNull();
+        });
+
+        it('allows the app origin with credentials', async () => {
+            const res = await app.handle(request('GET', '/topics', APP_ORIGIN));
+
+            expect(res.headers.get('access-control-allow-origin')).toBe(APP_ORIGIN);
+            expect(res.headers.get('access-control-allow-credentials')).toBe('true');
+        });
+
+        it('restricts preflight headers to the app allowlist', async () => {
+            const res = await app.handle(request('OPTIONS', '/topics', APP_ORIGIN));
+
+            expect(res.headers.get('access-control-allow-headers')).toBe(
+                'Content-Type, Authorization',
+            );
+        });
+    });
+});

--- a/packages/emitsignal-server/src/http/plugins/cors-plugin.ts
+++ b/packages/emitsignal-server/src/http/plugins/cors-plugin.ts
@@ -7,7 +7,7 @@ import {
     EXPOSED_HEADERS,
     isPublicPublishPath,
     normalizeOrigin,
-    PUBLIC_PUBLISH_ALLOWED_HEADERS,
+    PUBLISH_ALLOWED_HEADERS,
 } from '#/utils/cors';
 
 const PREFLIGHT_MAX_AGE_SECONDS = 600;
@@ -24,21 +24,23 @@ export const corsPlugin = new Elysia({ name: 'cors' }).onRequest(({ request, set
 
     const isAppOrigin =
         origin !== null && normalizeOrigin(origin) === normalizeOrigin(environment.APP_URL);
-    const isPublicPublish = !isAppOrigin && isPublicPublishPath(new URL(request.url).pathname);
+    const isPublishPath = isPublicPublishPath(new URL(request.url).pathname);
 
     set.headers.vary = 'Origin';
     set.headers['access-control-expose-headers'] = EXPOSED_HEADERS;
 
-    if (isPublicPublish) {
-        set.headers['access-control-allow-origin'] = '*';
-    } else if (isAppOrigin) {
+    // The app origin keeps the credentialed policy even on publish paths: a wildcard origin
+    // would make the browser drop the cookie session the website publishes with.
+    if (isAppOrigin) {
         set.headers['access-control-allow-origin'] = origin;
         set.headers['access-control-allow-credentials'] = 'true';
+    } else if (isPublishPath) {
+        set.headers['access-control-allow-origin'] = '*';
     }
 
     if (request.method === 'OPTIONS') {
-        set.headers['access-control-allow-headers'] = isPublicPublish
-            ? PUBLIC_PUBLISH_ALLOWED_HEADERS
+        set.headers['access-control-allow-headers'] = isPublishPath
+            ? PUBLISH_ALLOWED_HEADERS
             : APP_ALLOWED_HEADERS;
         set.headers['access-control-allow-methods'] = ALLOWED_METHODS;
         set.headers['access-control-max-age'] = String(PREFLIGHT_MAX_AGE_SECONDS);

--- a/packages/emitsignal-server/src/http/plugins/cors-plugin.ts
+++ b/packages/emitsignal-server/src/http/plugins/cors-plugin.ts
@@ -1,0 +1,48 @@
+import Elysia from 'elysia';
+
+import { environment } from '#/schema/environment';
+import {
+    ALLOWED_METHODS,
+    APP_ALLOWED_HEADERS,
+    EXPOSED_HEADERS,
+    isPublicPublishPath,
+    normalizeOrigin,
+    PUBLIC_PUBLISH_ALLOWED_HEADERS,
+} from '#/utils/cors';
+
+const PREFLIGHT_MAX_AGE_SECONDS = 600;
+
+/**
+ * Publishing is already open to the public internet, so browsers get the same reach as curl:
+ * any origin may POST to /publish/*. That policy must never carry
+ * access-control-allow-credentials — a wildcard origin plus cookies would let any page publish
+ * as the visitor. Requests from APP_URL keep the credentialed policy so the website's own
+ * cookie session still works.
+ */
+export const corsPlugin = new Elysia({ name: 'cors' }).onRequest(({ request, set }) => {
+    const origin = request.headers.get('origin');
+
+    const isAppOrigin =
+        origin !== null && normalizeOrigin(origin) === normalizeOrigin(environment.APP_URL);
+    const isPublicPublish = !isAppOrigin && isPublicPublishPath(new URL(request.url).pathname);
+
+    set.headers.vary = 'Origin';
+    set.headers['access-control-expose-headers'] = EXPOSED_HEADERS;
+
+    if (isPublicPublish) {
+        set.headers['access-control-allow-origin'] = '*';
+    } else if (isAppOrigin) {
+        set.headers['access-control-allow-origin'] = origin;
+        set.headers['access-control-allow-credentials'] = 'true';
+    }
+
+    if (request.method === 'OPTIONS') {
+        set.headers['access-control-allow-headers'] = isPublicPublish
+            ? PUBLIC_PUBLISH_ALLOWED_HEADERS
+            : APP_ALLOWED_HEADERS;
+        set.headers['access-control-allow-methods'] = ALLOWED_METHODS;
+        set.headers['access-control-max-age'] = String(PREFLIGHT_MAX_AGE_SECONDS);
+
+        return new Response(null, { status: 204 });
+    }
+});

--- a/packages/emitsignal-server/src/index.ts
+++ b/packages/emitsignal-server/src/index.ts
@@ -1,6 +1,5 @@
 import { fromTypes, openapi } from '@elysia/openapi';
 import { opentelemetry } from '@elysia/opentelemetry';
-import { cors } from '@elysiajs/cors';
 import * as Sentry from '@sentry/bun';
 import { Elysia } from 'elysia';
 
@@ -10,6 +9,7 @@ import { acknowledge } from '#/http/messages/acknowledge';
 import { attachments } from '#/http/messages/attachments';
 import { getMessage } from '#/http/messages/get';
 import { purgeSignals } from '#/http/messages/purge';
+import { corsPlugin } from '#/http/plugins/cors-plugin';
 import { errorResponsePlugin } from '#/http/plugins/error-response-plugin';
 import { loggerPlugin } from '#/http/plugins/logger-plugin';
 import { rateLimitPlugin } from '#/http/plugins/rate-limit-plugin';
@@ -78,14 +78,7 @@ const app = new Elysia({
     .use(errorResponsePlugin)
     .use(rateLimitPlugin)
     .use(openapi({ enabled: !isProduction, references: fromTypes() }))
-    .use(
-        cors({
-            allowedHeaders: ['Content-Type', 'Authorization'],
-            credentials: true,
-            methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-            origin: [environment.APP_URL],
-        }),
-    )
+    .use(corsPlugin)
     .all('/api/auth/*', (ctx) => auth.handler(ctx.request))
     .get('/', () => ({
         name: 'Welcome to EmitSignal',

--- a/packages/emitsignal-server/src/utils/cors.ts
+++ b/packages/emitsignal-server/src/utils/cors.ts
@@ -1,0 +1,55 @@
+export const ALLOWED_METHODS = 'DELETE, GET, POST, PUT, OPTIONS, PATCH';
+
+export const APP_ALLOWED_HEADERS = 'Content-Type, Authorization';
+
+export const PUBLIC_PUBLISH_ALLOWED_HEADERS = [
+    'Actions',
+    'At',
+    'Authorization',
+    'Banner',
+    'Content-Type',
+    'Delay',
+    'In',
+    'Inline-Attachments',
+    'Inline-Images',
+    'M',
+    'Message',
+    'P',
+    'Prio',
+    'Priority',
+    'T',
+    'Ta',
+    'Tags',
+    'Title',
+    'X-Actions',
+    'X-Api-Key',
+    'X-At',
+    'X-Banner',
+    'X-Delay',
+    'X-In',
+    'X-Inline-Attachments',
+    'X-Inline-Images',
+    'X-Message',
+    'X-Priority',
+    'X-Tags',
+    'X-Title',
+].join(', ');
+
+export const EXPOSED_HEADERS = [
+    'Deprecation',
+    'Link',
+    'Retry-After',
+    'X-Quota-Limit',
+    'X-Quota-Remaining',
+    'X-Quota-Reset',
+].join(', ');
+
+const PUBLIC_PUBLISH_PATH = /^\/(publish|topic)\/.+/;
+
+export function isPublicPublishPath(pathname: string): boolean {
+    return PUBLIC_PUBLISH_PATH.test(pathname);
+}
+
+export function normalizeOrigin(value: string): string {
+    return value.replace(/\/+$/, '');
+}

--- a/packages/emitsignal-server/src/utils/cors.ts
+++ b/packages/emitsignal-server/src/utils/cors.ts
@@ -2,7 +2,7 @@ export const ALLOWED_METHODS = 'DELETE, GET, POST, PUT, OPTIONS, PATCH';
 
 export const APP_ALLOWED_HEADERS = 'Content-Type, Authorization';
 
-export const PUBLIC_PUBLISH_ALLOWED_HEADERS = [
+export const PUBLISH_ALLOWED_HEADERS = [
     'Actions',
     'At',
     'Authorization',


### PR DESCRIPTION
## Why

`POST /publish/*` is already a public, anonymous-capable write endpoint — anyone can publish with `curl`, protected only by the per-IP rate limiter. From a browser, though, it was unreachable from anywhere but the first-party website: CORS was configured once, globally, as `origin: [APP_URL]` with `credentials: true` and `allowedHeaders: ['Content-Type', 'Authorization']`.

That had two effects: any page not served from `APP_URL` got a CORS refusal, and even the first-party page could not use the ntfy-style header format (`x-title`, `x-priority`, `x-tags`, `x-delay`, …) or `x-api-key`, since preflight rejected every header outside the two allowed ones.

ntfy lets you publish from any origin, and the same makes sense here — a browser cannot do anything `curl` cannot already do.

## What changed

`@elysiajs/cors` can only express one static policy for the whole app (`credentials` and `allowedHeaders` are fixed at construction), so it is replaced by a small project-owned plugin that picks the policy per request:

- **`/publish/*` and `/topic/*` from any non-`APP_URL` origin** → `Access-Control-Allow-Origin: *`, **no** `allow-credentials`, and the full header-publish allowlist (`X-Title`, `X-Priority`, `X-Tags`, `X-Delay`, `X-Actions`, `X-Api-Key`, plus the unprefixed aliases).
- **Everything else** → unchanged: origin echoed only for `APP_URL`, `allow-credentials: true`, `Content-Type, Authorization`.

The wildcard policy deliberately never carries credentials — a wildcard origin plus cookies would let any page publish as the visitor. Cross-origin publishing works anonymously or with an explicit `Authorization: Bearer …` / `X-Api-Key` header; browser cookies are never sent cross-site, so there is no CSRF path.

Preflight is still answered in `onRequest`, so it short-circuits before the rate limiter, exactly as before. `max-age` goes from 5s to 600s.

Side fix: `access-control-expose-headers` previously echoed the *request* header names, so browser JS could not read `Retry-After`, `Deprecation`, `Link`, or the `X-Quota-*` headers. It now lists exactly those.

Scope is publish only. Every other route keeps today's policy.

## Verification

- `bun test` in `emitsignal-server`: 481 pass, 0 fail (8 new tests in `cors-plugin.spec.ts`).
- `bun format` / `bun lint` clean.
- Live against a local stack:
  - `OPTIONS /publish/x` from a foreign origin → `204`, `ACAO: *`, no `allow-credentials`, header allowlist present.
  - `POST /publish/x` with `X-Title`/`X-Priority` from that origin → `200 {"message":"posted"}`.
  - Same route from `APP_URL` → origin echoed **with** `allow-credentials: true`.
  - `OPTIONS /topics` from a foreign origin → no `ACAO` (still blocked); `GET /topics` and `/api/auth/*` from `APP_URL` unchanged.