### PR TITLE
ci: fold the release format into release-please's own commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,10 +41,14 @@ jobs:
             #
             # Guarded on the `prs` output rather than `prs_created` so this also runs
             # when release-please updates an existing release PR, not just on creation.
+            #
+            # Full history: the formatting is folded into release-please's own commit
+            # with `--amend`, which needs the real parent rather than a shallow graft.
             - name: Check out the release PR
               if: steps.release.outputs.prs != '' && steps.release.outputs.prs != '[]'
               uses: actions/checkout@v4
               with:
+                  fetch-depth: 0
                   ref: ${{ fromJSON(steps.release.outputs.prs)[0].headBranchName }}
 
             - name: Set up Bun
@@ -72,8 +76,12 @@ jobs:
                       exit 0
                   fi
 
-                  git commit -m "chore: Source Format"
-                  git push
+                  # Folded into release-please's own commit rather than added on top: the
+                  # repo rebase-merges, so a second commit would land on main as a separate
+                  # entry. Force-pushing this branch is safe — release-please rewrites it
+                  # from main on every run anyway.
+                  git commit --amend --no-edit
+                  git push --force-with-lease
 
     publish-cli:
         needs: release-please

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,20 +34,13 @@ jobs:
                   config-file: release-please-config.json
                   manifest-file: .release-please-manifest.json
 
-            # release-please serializes package.json with its own JSON writer, which
-            # expands short arrays that Prettier collapses. Left alone, merging the
-            # release PR lands unformatted files on main, and `format:check` then fails
-            # on main and on every branch cut from it until someone formats by hand.
-            #
-            # Guarded on the `prs` output rather than `prs_created` so this also runs
-            # when release-please updates an existing release PR, not just on creation.
-            #
-            # Full history: the formatting is folded into release-please's own commit
-            # with `--amend`, which needs the real parent rather than a shallow graft.
+            # release-please writes package.json with expanded arrays that Prettier
+            # collapses, so an unformatted release PR turns main red on merge.
             - name: Check out the release PR
               if: steps.release.outputs.prs != '' && steps.release.outputs.prs != '[]'
               uses: actions/checkout@v4
               with:
+                  # `--amend` below needs the real parent, not a shallow graft.
                   fetch-depth: 0
                   ref: ${{ fromJSON(steps.release.outputs.prs)[0].headBranchName }}
 
@@ -63,8 +56,7 @@ jobs:
                   bun install
                   bun format
 
-                  # bun install rewrites bun.lock off the bumped versions; that belongs to
-                  # release-please, not to a formatting commit.
+                  # Lockfile churn from the install is release-please's business.
                   git checkout -- bun.lock
 
                   git config user.name "github-actions[bot]"
@@ -76,10 +68,8 @@ jobs:
                       exit 0
                   fi
 
-                  # Folded into release-please's own commit rather than added on top: the
-                  # repo rebase-merges, so a second commit would land on main as a separate
-                  # entry. Force-pushing this branch is safe — release-please rewrites it
-                  # from main on every run anyway.
+                  # Amended, not added: the repo rebase-merges, so a second commit would
+                  # land on main separately. release-please rewrites this branch anyway.
                   git commit --amend --no-edit
                   git push --force-with-lease
 


### PR DESCRIPTION
## Why

Follow-up to #49. That version added the formatting as a *second* commit on the release PR. Since this repo rebase-merges (`main` is linear, every commit single-parent), those two commits land on `main` as two separate entries — `chore(main): release X.Y.Z` followed by `chore: Source Format` — where one is enough.

## Change

`git commit --amend --no-edit` + `git push --force-with-lease`, so the formatting is folded into release-please's own release commit. The release PR now carries exactly one commit and `main` gains one entry per release, with release-please's message and author preserved.

`fetch-depth: 0` is added to the checkout because `--amend` rewrites HEAD and needs the real parent rather than a shallow graft.

## Why force-pushing is safe here

- release-please rewrites its branch from `main` on every run regardless, so it never reads back what it previously pushed.
- The release commit is already unsigned (`verified: false`), so amending costs no signature verification.
- `main` has no branch protection, so no signed-commit or force-push rule is in play.
- `--force-with-lease` rather than `--force`, so a concurrent update aborts the push instead of clobbering it.

## Unchanged limitation

The push still uses the default `GITHUB_TOKEN`, which does not re-trigger workflows, so the release PR's own checks may show the run from before the amend. The merged result on `main` is correct either way.