### PR TITLE
Copy CHANGELOG.md into the website Docker build stage

### DIFF
--- a/packages/emitsignal-docker/website/Dockerfile
+++ b/packages/emitsignal-docker/website/Dockerfile
@@ -32,6 +32,9 @@ RUN bun install --frozen-lockfile
 COPY packages/emitsignal-shared/  ./packages/emitsignal-shared/
 COPY packages/emitsignal-website/ ./packages/emitsignal-website/
 
+# The website's prebuild hook generates the changelog page from this file.
+COPY CHANGELOG.md ./
+
 WORKDIR /app/packages/emitsignal-website
 
 # VITE_API_URL is read via import.meta.env.VITE_API_URL and baked into the


### PR DESCRIPTION
The production website image build fails at `bun run build` with `ENOENT: /app/CHANGELOG.md`.

The release-please merge added a repo-root `CHANGELOG.md` and a website `prebuild` hook (`changelog:sync`) that reads it, but `packages/emitsignal-docker/website/Dockerfile` never copied that file into the build stage. This adds the missing `COPY`, placed after `bun install --frozen-lockfile` so release commits don't invalidate the dependency-install layer.

Verified by building the image and running it: `/` responds and `/changelog` lists 1.0.0 through 1.2.0, matching the root changelog.