### PR TITLE
feat(showcase): add the mobile store screenshot harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
+.agents/skills/expedito
+.agents/skills/tanstack-start
+.agents/skills/vercel-*
 .cache
+.docs
 .DS_Store
 .env
 .env.development.local
@@ -6,24 +10,12 @@
 .env.production.local
 .env.test.local
 .eslintcache
+.expedito
+.vercel
+artifacts/
 *.tgz
 *.tsbuildinfo
 dist
 dist-bin
 node_modules
 out
-
-.expedito
-.agents/skills/expedito
-
-# Disabling for now
-
-.agents/skills/tanstack-start
-.agents/skills/vercel-*
-
-.docs
-
-
-
-scripts/*
-.vercel

--- a/bun.lock
+++ b/bun.lock
@@ -7,11 +7,13 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/bun": "^1.3.14",
+        "@types/pngjs": "^6.0.5",
         "eslint": "^9.25.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-jsonc": "^3.1.2",
         "eslint-plugin-perfectionist": "^5.9.0",
         "eslint-plugin-prettier": "^5.5.5",
+        "pngjs": "^7.0.0",
         "prettier": "^3.8.3",
         "prettier-plugin-sort-json": "^4.2.0",
         "typescript-eslint": "^8.59.1",
@@ -1599,6 +1601,8 @@
     "@types/nodemailer": ["@types/nodemailer@6.4.24", "", { "dependencies": { "@types/node": "*" } }, "sha512-Ww4u0rT9wQNXh4JiQaIwx3QWdcOFXzOjQA2zc+jtFYNmQiT4mIUqcDin51bDFdkzKubFnQCZNK7FIHlPKQ/q9w=="],
 
     "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
+
+    "@types/pngjs": ["@types/pngjs@6.0.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
@@ -3456,7 +3460,7 @@
 
     "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
 
-    "pngjs": ["pngjs@3.4.0", "", {}, "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="],
+    "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
 
     "pony-cause": ["pony-cause@1.1.1", "", {}, "sha512-PxkIc/2ZpLiEzQXu5YRDOUgBlfGYBY8156HY5ZcRAwwonMk5W/MrJP2LLkG/hF7GEQzaHo2aS7ho6ZLCOvf+6g=="],
 
@@ -5037,6 +5041,8 @@
     "oxc-parser/@oxc-project/types": ["@oxc-project/types@0.120.0", "", {}, "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "parse-png/pngjs": ["pngjs@3.4.0", "", {}, "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="],
 
     "pg-types/postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
 

--- a/package.json
+++ b/package.json
@@ -2,11 +2,13 @@
     "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/bun": "^1.3.14",
+        "@types/pngjs": "^6.0.5",
         "eslint": "^9.25.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-jsonc": "^3.1.2",
         "eslint-plugin-perfectionist": "^5.9.0",
         "eslint-plugin-prettier": "^5.5.5",
+        "pngjs": "^7.0.0",
         "prettier": "^3.8.3",
         "prettier-plugin-sort-json": "^4.2.0",
         "typescript-eslint": "^8.59.1"
@@ -32,6 +34,7 @@
         "format:check": "prettier --check .",
         "lint": "eslint .",
         "lint:fix": "eslint . --fix",
+        "showcase": "bun scripts/mobile-showcase/showcase.ts",
         "test": "bun --filter '*' test"
     },
     "trustedDependencies": ["@sentry/cli", "protobufjs", "unrs-resolver"],

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,121 @@
+# Publish test scripts
+
+Manual test harness for the publish route, `POST /topic/:name`
+([`packages/emitsignal-server/src/http/topic/publish.ts`](../packages/emitsignal-server/src/http/topic/publish.ts)).
+Every branch of that route — JSON body, header-based publish, priorities, tags, actions, media,
+scheduling and each rejection path — has a scenario here.
+
+| File                   | What it is                                                |
+| ---------------------- | --------------------------------------------------------- |
+| `publish.ts`           | Bun runner: sends every scenario and asserts the outcome  |
+| `publish-scenarios.ts` | The scenario catalogue — add cases here                   |
+| `publish-curl.sh`      | Copy-pasteable curl recipes for poking at the API by hand |
+
+## Requirements
+
+A running server (`docker compose -f packages/emitsignal-docker/docker-compose.dev.yml up`, or
+`bun run dev` inside `packages/emitsignal-server`). Redis must be up: the publish limiter
+**fails closed for anonymous publishers**, so with Redis down every anonymous publish is rejected.
+
+## Bun runner
+
+```bash
+bun scripts/publish.ts --list                 # show scenarios, publish nothing
+bun scripts/publish.ts                        # run all of them
+bun scripts/publish.ts --group errors         # only the rejection paths
+bun scripts/publish.ts --only action,header   # name substrings
+bun scripts/publish.ts --only header-basic --dry-run   # print the curl command instead
+```
+
+| Option           | Default                                              |
+| ---------------- | ---------------------------------------------------- |
+| `--url <base>`   | `$EMITSIGNAL_API_URL` or `http://localhost:5001`     |
+| `--topic <name>` | `$EMITSIGNAL_TOPIC` or `publish-playground`          |
+| `--token <t>`    | `$EMITSIGNAL_TOKEN` — session token or `es_` API key |
+| `--group <g>`    | `errors`, `headers`, `json`, `media`, `schedule`     |
+| `--only <names>` | comma-separated names or substrings                  |
+| `--delay <ms>`   | derived from the server rate limit                   |
+| `--no-retry`     | fail fast on 429 instead of waiting out the limiter  |
+| `--dry-run`      | print the equivalent `curl` and send nothing         |
+
+Exit code is `1` if any scenario's outcome differs from what the route should return.
+
+### Outcomes, not status codes
+
+Each scenario declares one of `posted`, `scheduled` or `error`. That indirection matters because
+publish reports failures two different ways:
+
+- real HTTP errors — `400 missing_content`, `400 invalid_media`, `403 forbidden`,
+  `429 daily_quota_exceeded`, `422` from the TypeBox body schema;
+- **HTTP 200 with an `error` field in the body** — the `scheduledAt` more-than-a-year check and
+  every `validateActions` rejection return `{ error, status: 400 }`, which Elysia serializes as a
+  200 response.
+
+The runner treats both as `error`, so the suite passes today and will flag it if that 200-with-error
+quirk is ever tightened.
+
+### Rate limits
+
+Publishing is limited to **10/min anonymous** and **60/min authenticated**, so the runner paces
+itself accordingly (~6s between requests anonymously, ~1s with a token) and, on a 429, waits out
+`Retry-After` once before retrying. A full anonymous run therefore takes ~4 minutes — pass
+`--token` to cut it to about one.
+
+Get a token from the CLI (`bun packages/emitsignal-cli/src/index.ts auth login`, then read
+`~/.config/emitsignal/config.json`) or create an API key in the web dashboard. Authenticated runs
+also consume the plan's daily message quota (100/day on free).
+
+## curl recipes
+
+```bash
+./scripts/publish-curl.sh list        # what's available
+./scripts/publish-curl.sh basic       # one recipe
+./scripts/publish-curl.sh all         # everything, 1s apart
+```
+
+Same environment variables as the runner (`EMITSIGNAL_API_URL`, `EMITSIGNAL_TOPIC`,
+`EMITSIGNAL_TOKEN`), plus `EMITSIGNAL_SLEEP` for the pause `all` inserts between recipes.
+
+## Watching the messages arrive
+
+The non-scheduled scenarios fan out over SSE immediately:
+
+```bash
+curl -N http://localhost:5001/topics/publish-playground/listen
+# or
+bun packages/emitsignal-cli/src/index.ts listen publish-playground
+```
+
+Scheduled ones skip the bus and land on the `schedule` queue, so they only show up once the
+schedule worker (`bun run dev:worker`) fires them.
+
+## Adding a scenario
+
+Append to `scenarios` in `publish-scenarios.ts`:
+
+```ts
+{
+    build: ({ topic }) => jsonRequest(topic, { body: 'Body', title: 'Title' }),
+    description: 'What this covers',
+    expect: 'posted',
+    group: 'json',
+    name: 'my-scenario',
+}
+```
+
+`jsonRequest` sends `application/json`; `headerRequest` sends any other content type, which is what
+routes the request through the header parser in `src/lib/header-publish.ts`.
+
+## Note on version control
+
+`.gitignore` still ends with `scripts/*`, so new files here are ignored by default. The
+entries this folder needs are un-ignored explicitly:
+
+```gitignore
+scripts/*
+!scripts/mobile-showcase/
+!scripts/README.md
+!scripts/publish*
+```
+
+Add an exception when you add a script that should be tracked.

--- a/scripts/mobile-showcase/LICENSE.upstream
+++ b/scripts/mobile-showcase/LICENSE.upstream
@@ -1,0 +1,34 @@
+The store screenshot harness in this directory is derived from the mobile
+screenshot harness in https://github.com/pingdotgg/t3code, used under the MIT
+license reproduced below.
+
+Portions carried over largely intact: the store-asset validators
+(normalizeStorePng, readPngMetadata, validateStoreAsset, validateStoreAssetCount),
+the subprocess helpers (runCommand, commandOutput, spawnProcess, delay,
+waitForPort), the simulator and emulator normalisation (normalizeIosSimulator,
+normalizeAndroidEmulator, the Expo dev-menu suppression), and the
+ShowcaseStoreAssetSpec shape of the device matrix.
+
+---
+
+MIT License
+
+Copyright (c) 2026 T3 Tools Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/mobile-showcase/README.md
+++ b/scripts/mobile-showcase/README.md
@@ -1,0 +1,121 @@
+# Mobile showcase — store screenshots
+
+Boots each configured simulator/emulator, puts the app into a known anonymous state, walks
+the screens by deep link, and writes upload-ready PNGs validated against the App Store and
+Google Play specs.
+
+```bash
+bun run showcase --list                          # print the matrix, capture nothing
+bun run showcase                                 # every device, every scene
+bun run showcase --device iphone-6.9             # one device
+bun run showcase --device pixel --scene feed     # one scene
+bun run showcase --device ipad-13 --skip-metro   # reuse a running showcase Metro
+```
+
+Output lands in `artifacts/app-store/screenshots/` (gitignored):
+
+```
+apple/iphone-6.9/     1320×2868   landing, sign-in, feed, message, channels, publish, settings
+apple/ipad-13/        2064×2752   (same)
+google-play/phone/    1080×1920   (same)
+```
+
+## Requirements
+
+- The stack: `docker compose -f packages/emitsignal-docker/docker-compose.dev.yml up`.
+  **Redis must be up** — the publish limiter fails closed for anonymous publishers, so
+  without it every message is rejected.
+- The app installed once on each device (`bun run ios` / `bun run android` inside
+  `packages/emitsignal-mobile`). The harness reinstalls from the copy already on the
+  device; it never builds. Set `appMode` per device in `showcase.config.ts` if the
+  variants differ — here the simulators carry `com.emitsignal` and the emulator carries
+  `com.emitsignal.development`.
+- The simulators and AVD named in `showcase.config.ts`.
+- Nothing else listening on `:8199` or `:8198`. A Metro left over from an earlier run would
+  serve a stale bundle — including a stale `EXPO_PUBLIC_API_URL` — so the harness refuses to
+  start rather than capture the wrong data. Your day-to-day `expo start` on `:8081` is fine.
+
+Environment: `EMITSIGNAL_API_URL` (default `http://127.0.0.1:5001`) and `APP_MODE`
+(`production` | `preview` | `development`, default `production`) which selects the bundle
+id and URL scheme, mirroring `packages/emitsignal-mobile/app.config.ts`.
+
+The harness starts its own Metro with `EXPO_PUBLIC_API_URL` pointed at `EMITSIGNAL_API_URL`
+and `--clear`. Both matter: the package's `.env` points at production, `.env` never
+overrides an already-set variable, and Metro's transform cache would otherwise keep serving
+a bundle with the old value inlined. With `--skip-metro` you are responsible for starting
+Metro the same way.
+
+## How it works
+
+**There is no UI automation.** An earlier version drove the app with Maestro; the subscribe
+sheet turned out to be unusable that way — XCUITest's `viewHierarchy` endpoint returns HTTP
+500 on that screen, and Maestro retry-loops on it for five minutes before failing. The
+harness instead owns the two pieces of app state the screenshots depend on:
+
+| State                             | How                                                                                                                                 |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `@emitsignal/device_id`           | Read out of AsyncStorage (`showcase-app-state.ts`). The app mints it on first launch and scopes every anonymous subscription to it. |
+| `@emitsignal/onboarding_complete` | Written into AsyncStorage while the app is stopped. It is the only thing gating the tabs for a device with no account.              |
+| Subscriptions                     | `POST /subscriptions` with that device id — exactly what the sheet in `app/modal.tsx` does.                                         |
+| Navigation                        | Deep links.                                                                                                                         |
+
+Reading the device id doubles as the readiness signal for the cold bundle, which is why the
+first launch waits on it rather than on a fixed timer.
+
+Two orderings are load-bearing:
+
+- **`landing` and `sign-in` are captured first**, on the freshly wiped device, so a run needs
+  one app reset at the start rather than a sign-out in the middle.
+- **Content is published after the device subscribes.** A subscription only surfaces messages
+  newer than itself, so this is what keeps the feed at exactly this run's twelve even though
+  the topics are long-lived and every previous run left its messages behind. Publishing is
+  therefore per device (~80s each) rather than once per run.
+
+Demo content is the `showcase` group already catalogued in `../publish-scenarios.ts`,
+published over the public API — no database access, no server changes. Anonymous publishing
+is capped at 10/min, so it is paced.
+
+Those messages carry banner images from `packages/emitsignal-website/public/static/showcase/`,
+which are **not deployed** — pointing at production yields 404s and blank cards. The harness
+serves that folder itself on `:8198` (reverse-tunnelled for Android) and sets
+`EMITSIGNAL_MEDIA_BASE` accordingly. The harness prints which assets were requested and
+not found at the end of a run.
+
+That folder is itself gitignored (`packages/emitsignal-website/.gitignore`), so a fresh
+clone has **no** showcase media and every banner renders empty until the files are put
+back. Only `latency-p99.png` exists locally today — the message-detail chart — and the
+other four the catalogue references (`pool-saturation.webp`, `error-rate.webp`,
+`build-4821.log`, `backup-manifest.txt`) do not exist at all.
+
+Android gets `adb reverse` for all three host ports (Metro, media, and the API), so
+`127.0.0.1` means the same thing on both platforms and the published URLs stay identical.
+
+## Known differences from the hand-made screenshots
+
+**Settings shows the signed-out state.** `app/(tabs)/settings.tsx` renders the account card
+only when a user is set; an anonymous device gets a _Sign in_ row instead. The previously
+submitted screenshot showed an account with an email address. Capturing that version needs
+a real session, which means signing in by hand — the harness deliberately has no OTP path.
+
+**Android keeps one status-bar icon.** SystemUI demo mode fixes the clock and battery and
+hides notifications, but the Safety Center shield is an ongoing system notification it will
+not drop. It is small and dark-on-dark; the alternative is cropping the status bar, which
+would cost the native 9:16 framing.
+
+## Adding a device or scene
+
+Edit `showcase.config.ts`. Each device declares its exact store upload spec, and every
+capture is validated against it before the run is allowed to succeed, so a new Xcode or
+emulator release cannot silently produce a file the store will reject.
+
+For a new scene, add it to `SHOWCASE_SCENES` and give it a URL in `sceneUrl()` in
+`showcase.ts`. Expo Router omits route groups from URLs, so `app/(tabs)/channels.tsx` is
+`/channels`.
+
+## Credit
+
+Derived from the mobile screenshot harness in
+[pingdotgg/t3code](https://github.com/pingdotgg/t3code), MIT licensed — see
+`LICENSE.upstream`. The store-asset validators, the simulator and emulator
+normalisation, and the device-matrix shape came from there; the scene navigation, the
+AsyncStorage handling and the content pipeline are specific to EmitSignal.

--- a/scripts/mobile-showcase/showcase-app-state.ts
+++ b/scripts/mobile-showcase/showcase-app-state.ts
@@ -1,0 +1,122 @@
+// Reads and writes the app's AsyncStorage from the host.
+//
+// Two keys decide what the screenshots show: the anonymous device id that scopes
+// every subscription, and the onboarding flag that app/(tabs)/_layout.tsx gates
+// the tab screens on. Owning both from here is what lets the harness drive the
+// whole run with deep links instead of UI automation.
+
+import { Database } from 'bun:sqlite';
+import * as NodeChildProcess from 'node:child_process';
+import * as NodeFSP from 'node:fs/promises';
+import * as NodeOS from 'node:os';
+import * as NodePath from 'node:path';
+import * as NodeUtil from 'node:util';
+
+export type AppStorage = Record<string, string>;
+
+const execFile = NodeUtil.promisify(NodeChildProcess.execFile);
+
+export const DEVICE_ID_KEY = '@emitsignal/device_id';
+export const ONBOARDING_KEY = '@emitsignal/onboarding_complete';
+
+// react-native-async-storage keeps small values inline in this manifest and
+// spills larger ones to sibling files. Both of ours are tiny.
+const IOS_STORAGE_PATH =
+    'Library/Application Support/{appId}/RCTAsyncLocalStorage_V1/manifest.json';
+const ANDROID_DATABASE = 'databases/RKStorage';
+const ANDROID_TABLE = 'catalystLocalStorage';
+
+export async function patchAndroidStorage(
+    adb: string,
+    serial: string,
+    appId: string,
+    patch: AppStorage,
+): Promise<void> {
+    const { local, staged } = await pullAndroidDatabase(adb, serial, appId);
+    const database = new Database(local);
+    try {
+        const statement = database.prepare(
+            `INSERT INTO ${ANDROID_TABLE} (key, value) VALUES (?, ?)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+        );
+        for (const [key, value] of Object.entries(patch)) statement.run(key, value);
+    } finally {
+        database.close();
+    }
+
+    await execFile(adb, ['-s', serial, 'push', local, '/data/local/tmp/RKStorage']);
+    await execFile(adb, [
+        '-s',
+        serial,
+        'shell',
+        // The write-ahead log would otherwise replay over the file just pushed.
+        `run-as ${appId} sh -c 'cp /data/local/tmp/RKStorage ${ANDROID_DATABASE} && rm -f ${ANDROID_DATABASE}-wal ${ANDROID_DATABASE}-shm'`,
+    ]);
+    await NodeFSP.rm(staged, { force: true, recursive: true });
+}
+
+export async function patchIosStorage(
+    udid: string,
+    appId: string,
+    patch: AppStorage,
+): Promise<void> {
+    const path = await iosStoragePath(udid, appId);
+    const current = await readIosStorage(udid, appId);
+    await NodeFSP.mkdir(NodePath.dirname(path), { recursive: true });
+    await NodeFSP.writeFile(path, JSON.stringify({ ...current, ...patch }));
+}
+
+export async function readAndroidStorage(
+    adb: string,
+    serial: string,
+    appId: string,
+): Promise<AppStorage> {
+    const { local, staged } = await pullAndroidDatabase(adb, serial, appId);
+    const database = new Database(local, { readonly: true });
+    try {
+        const rows = database.prepare(`SELECT key, value FROM ${ANDROID_TABLE}`).all() as Array<{
+            key: string;
+            value: string;
+        }>;
+        return Object.fromEntries(rows.map((row) => [row.key, row.value]));
+    } finally {
+        database.close();
+        await NodeFSP.rm(staged, { force: true, recursive: true });
+    }
+}
+
+export async function readIosStorage(udid: string, appId: string): Promise<AppStorage> {
+    const path = await iosStoragePath(udid, appId);
+    const raw = await NodeFSP.readFile(path, 'utf8').catch(() => '');
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    return typeof parsed === 'object' && parsed !== null ? (parsed as AppStorage) : {};
+}
+
+async function iosStoragePath(udid: string, appId: string): Promise<string> {
+    const { stdout } = await execFile('xcrun', [
+        'simctl',
+        'get_app_container',
+        udid,
+        appId,
+        'data',
+    ]);
+    return NodePath.join(stdout.trim(), IOS_STORAGE_PATH.replace('{appId}', appId));
+}
+
+async function pullAndroidDatabase(
+    adb: string,
+    serial: string,
+    appId: string,
+): Promise<{ local: string; staged: string }> {
+    const staged = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), 'emitsignal-storage-'));
+    const local = NodePath.join(staged, 'RKStorage');
+    // `adb pull` cannot read inside the app sandbox, so stream it out via run-as.
+    const { stdout } = await execFile(
+        adb,
+        ['-s', serial, 'exec-out', `run-as ${appId} cat ${ANDROID_DATABASE}`],
+        { encoding: 'buffer', maxBuffer: 64 * 1024 * 1024 },
+    );
+    await NodeFSP.writeFile(local, stdout as unknown as Uint8Array);
+    return { local, staged };
+}

--- a/scripts/mobile-showcase/showcase-content.ts
+++ b/scripts/mobile-showcase/showcase-content.ts
@@ -1,0 +1,202 @@
+// Publishes the demo feed the screenshots show, using nothing but the public
+// publish API. The message set is the `showcase` group already catalogued in
+// scripts/publish-scenarios.ts, so the store screenshots and the manual publish
+// harness stay in sync by construction.
+
+import * as NodeFSP from 'node:fs/promises';
+import * as NodePath from 'node:path';
+import * as NodeURL from 'node:url';
+
+import type { ScenarioRequest } from '../publish-scenarios.ts';
+
+export interface PublishedMessage {
+    readonly messageId: string;
+    readonly title: string;
+    readonly topic: string;
+}
+
+export interface ShowcaseMediaServer {
+    readonly origin: string;
+    readonly port: number;
+    stop: () => void;
+}
+
+const SCRIPT_DIRECTORY = NodePath.dirname(NodeURL.fileURLToPath(import.meta.url));
+const MEDIA_DIRECTORY = NodePath.resolve(
+    SCRIPT_DIRECTORY,
+    '../../packages/emitsignal-website/public/static/showcase',
+);
+
+export const SHOWCASE_MEDIA_PORT = 8198;
+
+// Anonymous publishing is capped at 10/min server-side. Pace just under that;
+// a 429 still gets one Retry-After honoured below.
+const PUBLISH_INTERVAL_MS = 6_500;
+const MAXIMUM_RETRY_WAIT_MS = 90_000;
+
+export function findShowcaseMessage(
+    published: ReadonlyArray<PublishedMessage>,
+    title: string,
+): PublishedMessage {
+    const match = published.find((message) => message.title === title);
+    if (!match) {
+        throw new Error(
+            `No published showcase message is titled '${title}'. Published: ${published
+                .map((message) => message.title)
+                .join(', ')}`,
+        );
+    }
+    return match;
+}
+
+export async function publishShowcaseContent(
+    apiUrl: string,
+    log: (line: string) => void,
+): Promise<ReadonlyArray<PublishedMessage>> {
+    // publish-scenarios.ts resolves its media base at import time, so the media
+    // server has to be running and EMITSIGNAL_MEDIA_BASE already set before this
+    // module is pulled in. Hence the dynamic import.
+    const { scenarios } = await import('../publish-scenarios.ts');
+    const showcaseScenarios = scenarios.filter((scenario) => scenario.group === 'showcase');
+    if (showcaseScenarios.length === 0) {
+        throw new Error('No showcase scenarios are defined in scripts/publish-scenarios.ts.');
+    }
+
+    const published: PublishedMessage[] = [];
+    for (const [index, scenario] of showcaseScenarios.entries()) {
+        if (index > 0) await delay(PUBLISH_INTERVAL_MS);
+
+        const request = scenario.build({ now: Date.now(), topic: scenario.name });
+        const messageId = await publishOnce(apiUrl, request);
+        const title = titleOf(request);
+        published.push({ messageId, title, topic: request.topic });
+        log(
+            `  ${String(index + 1).padStart(2)}/${showcaseScenarios.length} ${request.topic} — ${title}`,
+        );
+    }
+    return published;
+}
+
+/**
+ * Serves the website's showcase media to the simulator. The assets are not
+ * deployed, so pointing publish-scenarios.ts at production yields messages whose
+ * banner images 404 — which is what left the message-detail chart blank before.
+ * Stays up for the whole run: the app fetches these while each scene renders.
+ */
+export async function startShowcaseMediaServer(
+    warn: (line: string) => void,
+): Promise<ShowcaseMediaServer> {
+    const available = new Set(await NodeFSP.readdir(MEDIA_DIRECTORY).catch(() => [] as string[]));
+    const missing = new Set<string>();
+    const server = Bun.serve({
+        fetch: (request) => {
+            const name = NodePath.basename(new URL(request.url).pathname);
+            if (!available.has(name)) {
+                missing.add(name);
+                return new Response('Not found', { status: 404 });
+            }
+            return new Response(Bun.file(NodePath.join(MEDIA_DIRECTORY, name)));
+        },
+        port: SHOWCASE_MEDIA_PORT,
+    });
+    const origin = `http://127.0.0.1:${SHOWCASE_MEDIA_PORT}`;
+    process.env.EMITSIGNAL_MEDIA_BASE = origin;
+    return {
+        origin,
+        port: SHOWCASE_MEDIA_PORT,
+        stop: () => {
+            if (missing.size > 0) {
+                warn(
+                    `Missing showcase media (those cards render without an image): ${[...missing].sort().join(', ')}`,
+                );
+            }
+            server.stop(true);
+        },
+    };
+}
+
+/**
+ * Subscribes the anonymous device over the public API, which is all the sheet in
+ * app/modal.tsx does. Leaving listenSince at its default means the device only
+ * ever sees messages published after this call, so a topic that has accumulated
+ * demo feeds from earlier runs still yields exactly one clean feed.
+ */
+export async function subscribeDevice(
+    apiUrl: string,
+    deviceId: string,
+    topicName: string,
+): Promise<void> {
+    const response = await fetch(`${apiUrl}/subscriptions`, {
+        body: JSON.stringify({
+            deviceId,
+            pushEnabled: true,
+            topicName,
+        }),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST',
+    });
+    if (!response.ok) {
+        throw new Error(
+            `Subscribing ${deviceId} to ${topicName} failed (HTTP ${response.status}): ${await response.text()}`,
+        );
+    }
+}
+
+function delay(milliseconds: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function publishOnce(apiUrl: string, request: ScenarioRequest): Promise<string> {
+    const response = await send(apiUrl, request);
+
+    if (response.status === 429) {
+        const waitMs = Math.min(
+            (Number(response.headers.get('retry-after') ?? 10) || 10) * 1_000,
+            MAXIMUM_RETRY_WAIT_MS,
+        );
+        await delay(waitMs);
+        return await readMessageId(await send(apiUrl, request), request);
+    }
+
+    return await readMessageId(response, request);
+}
+
+async function readMessageId(response: Response, request: ScenarioRequest): Promise<string> {
+    const payload: unknown = await response.json().catch(() => null);
+
+    // Publish reports some failures as HTTP 200 with an `error` field, so the
+    // status alone cannot tell a success from a rejection.
+    if (
+        !response.ok ||
+        typeof payload !== 'object' ||
+        payload === null ||
+        !('messageId' in payload) ||
+        typeof payload.messageId !== 'string'
+    ) {
+        throw new Error(
+            `Publishing to ${request.topic} failed (HTTP ${response.status}): ${JSON.stringify(payload)}`,
+        );
+    }
+
+    return payload.messageId;
+}
+
+function send(apiUrl: string, request: ScenarioRequest): Promise<Response> {
+    return fetch(`${apiUrl}/publish/${request.topic}`, {
+        body: request.body,
+        headers: request.headers,
+        method: 'POST',
+    });
+}
+
+function titleOf(request: ScenarioRequest): string {
+    try {
+        const payload: unknown = JSON.parse(request.body);
+        if (typeof payload === 'object' && payload !== null && 'title' in payload) {
+            return String(payload.title);
+        }
+    } catch {
+        // Header-format requests carry no JSON body; fall back to the topic.
+    }
+    return request.topic;
+}

--- a/scripts/mobile-showcase/showcase.config.ts
+++ b/scripts/mobile-showcase/showcase.config.ts
@@ -1,0 +1,160 @@
+// Capture matrix for the store screenshot harness. Edit this file — not the
+// runner — to add a device, a scene, or a channel the screenshots should show.
+
+export interface ShowcaseAndroidDevice {
+    /** Build variant installed on this device. Defaults to $APP_MODE. */
+    readonly appMode?: ShowcaseAppMode;
+    /** Exact name from `emulator -list-avds`. */
+    readonly avd: string;
+    readonly id: string;
+    readonly platform: 'android';
+    readonly storeAsset: ShowcaseStoreAssetSpec;
+    /**
+     * Forced capture size. Play caps the long side at 2× the short side, so a
+     * native 1080×2424 capture is rejected; resizing the emulator makes the
+     * screencap natively 9:16 instead of cropping one afterwards.
+     */
+    readonly viewport: {
+        readonly density: number;
+        readonly height: number;
+        readonly width: number;
+    };
+}
+
+export type ShowcaseAppMode = 'development' | 'preview' | 'production';
+
+export interface ShowcaseConfig {
+    /** Settle time after the app is up, before the first screenshot. */
+    readonly bundleLoadDelayMs: number;
+    /** How long a cold bundle may take to load before the run gives up. */
+    readonly bundleLoadTimeoutMs: number;
+    readonly devices: ReadonlyArray<ShowcaseDevice>;
+    readonly metroPort: number;
+    readonly outputDirectory: string;
+    /**
+     * Settle time after the app is restarted to pick up the onboarding flag.
+     * The dev client re-fetches the bundle here, which on Android is slow enough
+     * to otherwise capture its "Reloading…" banner.
+     */
+    readonly relaunchSettleMs: number;
+    readonly settleDelayMs: number;
+}
+
+export type ShowcaseDevice = ShowcaseAndroidDevice | ShowcaseIosDevice;
+
+export interface ShowcaseIosDevice {
+    /** Build variant installed on this device. Defaults to $APP_MODE. */
+    readonly appMode?: ShowcaseAppMode;
+    readonly id: string;
+    readonly platform: 'ios';
+    /** Exact name from `xcrun simctl list devices available`. */
+    readonly simulator: string;
+    readonly storeAsset: ShowcaseStoreAssetSpec;
+}
+
+export type ShowcaseScene = (typeof SHOWCASE_SCENES)[number];
+
+export interface ShowcaseStoreAssetSpec {
+    /** Device directory relative to ShowcaseConfig.outputDirectory. */
+    readonly directory: string;
+    readonly height: number;
+    readonly maximumFileSizeBytes?: number;
+    readonly maximumUploadCount: number;
+    readonly minimumUploadCount: number;
+    readonly store: 'apple' | 'google-play';
+    readonly width: number;
+}
+
+/**
+ * Capture order is load-bearing. The signed-out scenes come first so they can be
+ * taken on a freshly wiped device, before onboarding runs; that way the whole
+ * capture needs one app reset at the start rather than a sign-out in the middle.
+ */
+export const SHOWCASE_SCENES = [
+    'landing',
+    'sign-in',
+    'feed',
+    'message',
+    'channels',
+    'publish',
+    'settings',
+] as const;
+
+/** Scenes that must be captured before the onboarding flow runs. */
+export const PRE_ONBOARDING_SCENES: ReadonlyArray<ShowcaseScene> = ['landing', 'sign-in'];
+
+/**
+ * Channels subscribed to on top of the two `emitsignal/*` ones that onboarding
+ * picks by default (see GET /suggestions). These are the topics the `showcase`
+ * publish scenarios post to, so the feed and the channel list agree.
+ */
+export const SHOWCASE_TOPICS = [
+    'alerts/prod',
+    'deploy/prod',
+    'ci/web',
+    'cron/backup',
+    'billing/stripe',
+    'home/sensors',
+] as const;
+
+/** Picks which published message the `message` scene opens. */
+export const SHOWCASE_MESSAGE_TITLE = 'Production API latency spike';
+
+const config: ShowcaseConfig = {
+    bundleLoadDelayMs: 6_000,
+    bundleLoadTimeoutMs: 240_000,
+    devices: [
+        {
+            id: 'iphone-6.9',
+            platform: 'ios',
+            simulator: 'iPhone 17 Pro Max',
+            storeAsset: {
+                directory: 'apple/iphone-6.9',
+                height: 2868,
+                maximumUploadCount: 10,
+                minimumUploadCount: 1,
+                store: 'apple',
+                width: 1320,
+            },
+        },
+        {
+            id: 'ipad-13',
+            platform: 'ios',
+            simulator: 'iPad Pro 13-inch (M5)',
+            storeAsset: {
+                directory: 'apple/ipad-13',
+                height: 2752,
+                maximumUploadCount: 10,
+                minimumUploadCount: 1,
+                store: 'apple',
+                width: 2064,
+            },
+        },
+        {
+            // The emulator here carries the development build, while the
+            // simulators carry the production one.
+            appMode: 'development',
+            avd: 'Pixel_9',
+            id: 'pixel',
+            platform: 'android',
+            storeAsset: {
+                directory: 'google-play/phone',
+                height: 1920,
+                maximumFileSizeBytes: 8 * 1024 * 1024,
+                maximumUploadCount: 8,
+                minimumUploadCount: 2,
+                store: 'google-play',
+                width: 1080,
+            },
+            viewport: { density: 420, height: 1920, width: 1080 },
+        },
+    ],
+    // A dedicated port so the harness cannot attach to a Metro server someone
+    // already has running and capture the wrong bundle.
+    metroPort: 8199,
+    outputDirectory: 'artifacts/app-store/screenshots',
+    relaunchSettleMs: 30_000,
+    settleDelayMs: 2_500,
+};
+
+export default config;

--- a/scripts/mobile-showcase/showcase.ts
+++ b/scripts/mobile-showcase/showcase.ts
@@ -1,0 +1,981 @@
+#!/usr/bin/env bun
+// Store screenshot harness. Boots each configured simulator/emulator, puts the
+// app into a known anonymous state, walks the scenes by deep link, and writes
+// upload-ready PNGs validated against the App Store / Play specs.
+//
+// There is no UI automation here. Navigation is deep links, the anonymous device
+// id and the onboarding flag are read and written straight out of the app's
+// AsyncStorage, and subscriptions go through the public API.
+//
+// Derived from the mobile screenshot harness in pingdotgg/t3code (MIT).
+// See LICENSE.upstream in this directory.
+
+import * as NodeChildProcess from 'node:child_process';
+import * as NodeFSP from 'node:fs/promises';
+import * as NodeNet from 'node:net';
+import * as NodeOS from 'node:os';
+import * as NodePath from 'node:path';
+import * as NodeProcess from 'node:process';
+import * as NodeURL from 'node:url';
+import { PNG } from 'pngjs';
+
+import {
+    type AppStorage,
+    DEVICE_ID_KEY,
+    ONBOARDING_KEY,
+    patchAndroidStorage,
+    patchIosStorage,
+    readAndroidStorage,
+    readIosStorage,
+} from './showcase-app-state.ts';
+import {
+    findShowcaseMessage,
+    publishShowcaseContent,
+    SHOWCASE_MEDIA_PORT,
+    startShowcaseMediaServer,
+    subscribeDevice,
+} from './showcase-content.ts';
+import showcaseConfig, {
+    PRE_ONBOARDING_SCENES,
+    SHOWCASE_MESSAGE_TITLE,
+    SHOWCASE_SCENES,
+    SHOWCASE_TOPICS,
+    type ShowcaseAndroidDevice,
+    type ShowcaseConfig,
+    type ShowcaseDevice,
+    type ShowcaseIosDevice,
+    type ShowcaseScene,
+    type ShowcaseStoreAssetSpec,
+} from './showcase.config.ts';
+
+interface CliOptions {
+    readonly deviceIds: ReadonlySet<string>;
+    readonly list: boolean;
+    readonly scenes: ReadonlySet<ShowcaseScene>;
+    readonly skipMetro: boolean;
+}
+
+interface PngMetadata {
+    readonly bitDepth: number;
+    readonly colorType: number;
+    readonly hasAlpha: boolean;
+    readonly height: number;
+    readonly width: number;
+}
+
+interface ShowcaseApp {
+    readonly appId: string;
+    readonly scheme: string;
+}
+
+interface SimctlDevice {
+    readonly isAvailable: boolean;
+    readonly name: string;
+    readonly state: string;
+    readonly udid: string;
+}
+
+const SCRIPT_DIRECTORY = NodePath.dirname(NodeURL.fileURLToPath(import.meta.url));
+const REPO_ROOT = NodePath.resolve(SCRIPT_DIRECTORY, '../..');
+const MOBILE_ROOT = NodePath.join(REPO_ROOT, 'packages/emitsignal-mobile');
+
+const API_URL = (process.env.EMITSIGNAL_API_URL ?? 'http://127.0.0.1:5001').replace(/\/+$/, '');
+
+// Mirrors getProjectConfig() in packages/emitsignal-mobile/app.config.ts. The
+// harness captures whichever variant is installed on the device.
+const APP_VARIANTS = {
+    development: { appId: 'com.emitsignal.development', scheme: 'emitsignal-development' },
+    preview: { appId: 'com.emitsignal.preview', scheme: 'emitsignal-preview' },
+    production: { appId: 'com.emitsignal', scheme: 'emitsignal' },
+} as const;
+
+const APP_MODE = (process.env.APP_MODE ?? 'production') as keyof typeof APP_VARIANTS;
+
+function androidSdkRoot(): string {
+    const configured = process.env.ANDROID_HOME ?? process.env.ANDROID_SDK_ROOT;
+    if (configured) return configured;
+    return NodePath.join(NodeOS.homedir(), 'Library/Android/sdk');
+}
+
+/** The API port, so Android can be given a reverse tunnel for it. */
+function apiPort(): number {
+    const port = Number(new URL(API_URL).port);
+    if (!port) {
+        throw new Error(
+            `EMITSIGNAL_API_URL must include an explicit port for the Android reverse tunnel (got ${API_URL}).`,
+        );
+    }
+    return port;
+}
+
+function appFor(device: ShowcaseDevice): ShowcaseApp {
+    return APP_VARIANTS[device.appMode ?? APP_MODE];
+}
+
+const ADB = NodePath.join(androidSdkRoot(), 'platform-tools/adb');
+const EMULATOR = NodePath.join(androidSdkRoot(), 'emulator/emulator');
+
+export function normalizeStorePng(bytes: Uint8Array): Buffer {
+    const png = PNG.sync.read(Buffer.from(bytes));
+    // Both stores reject alpha; simctl and screencap both emit RGBA.
+    return PNG.sync.write(png, {
+        bitDepth: 8,
+        colorType: 2,
+        inputColorType: 6,
+        inputHasAlpha: true,
+    });
+}
+
+export function parseShowcaseCliArgs(args: ReadonlyArray<string>): CliOptions {
+    const deviceIds = new Set<string>();
+    const scenes = new Set<ShowcaseScene>();
+    let list = false;
+    let skipMetro = false;
+
+    for (let index = 0; index < args.length; index += 1) {
+        const argument = args[index];
+        if (argument === '--device') {
+            deviceIds.add(argumentValue(args, index, argument));
+            index += 1;
+        } else if (argument === '--scene') {
+            const value = argumentValue(args, index, argument);
+            if (!SHOWCASE_SCENES.includes(value as ShowcaseScene)) {
+                throw new Error(`Unknown scene '${value}'. Use ${SHOWCASE_SCENES.join(', ')}.`);
+            }
+            scenes.add(value as ShowcaseScene);
+            index += 1;
+        } else if (argument === '--skip-metro') {
+            skipMetro = true;
+        } else if (argument === '--list' || argument === '--help' || argument === '-h') {
+            list = true;
+        } else {
+            throw new Error(`Unknown option '${argument}'.`);
+        }
+    }
+
+    return { deviceIds, list, scenes, skipMetro };
+}
+
+export function readPngMetadata(bytes: Uint8Array): PngMetadata {
+    const signature = [137, 80, 78, 71, 13, 10, 26, 10];
+    if (bytes.byteLength < 26 || !signature.every((value, index) => bytes[index] === value)) {
+        throw new Error('Captured file is not a valid PNG.');
+    }
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    const colorType = view.getUint8(25);
+    return {
+        bitDepth: view.getUint8(24),
+        colorType,
+        hasAlpha: colorType === 4 || colorType === 6,
+        height: view.getUint32(20),
+        width: view.getUint32(16),
+    };
+}
+
+export function sceneUrl(app: ShowcaseApp, scene: ShowcaseScene, messageId: string): string {
+    // Expo Router omits route groups from URLs, so app/(tabs)/channels.tsx is /channels.
+    const paths: Record<ShowcaseScene, string> = {
+        channels: '/channels',
+        feed: '/',
+        landing: '/auth',
+        message: `/messages/${messageId}`,
+        publish: '/publish',
+        settings: '/settings',
+        'sign-in': '/auth/sign-in',
+    };
+    return `${app.scheme}://${paths[scene]}`;
+}
+
+export function selectDevices(
+    config: ShowcaseConfig,
+    deviceIds: ReadonlySet<string>,
+): ReadonlyArray<ShowcaseDevice> {
+    const known = new Set(config.devices.map((device) => device.id));
+    for (const id of deviceIds) {
+        if (!known.has(id)) {
+            throw new Error(`Unknown device '${id}'. Run with --list to see the matrix.`);
+        }
+    }
+    return config.devices.filter((device) => deviceIds.size === 0 || deviceIds.has(device.id));
+}
+
+export function selectScenes(scenes: ReadonlySet<ShowcaseScene>): ReadonlyArray<ShowcaseScene> {
+    return SHOWCASE_SCENES.filter((scene) => scenes.size === 0 || scenes.has(scene));
+}
+
+export function validateStoreAsset(
+    spec: ShowcaseStoreAssetSpec,
+    bytes: Uint8Array,
+    label: string,
+): PngMetadata {
+    const metadata = readPngMetadata(bytes);
+    if (metadata.width !== spec.width || metadata.height !== spec.height) {
+        throw new Error(
+            `${label} is ${metadata.width}×${metadata.height}; ${spec.store} requires ${spec.width}×${spec.height}.`,
+        );
+    }
+    if (metadata.bitDepth !== 8 || metadata.colorType !== 2 || metadata.hasAlpha) {
+        throw new Error(
+            `${label} must be an 8-bit, 24-bit RGB PNG without alpha (found bit depth ${metadata.bitDepth}, colour type ${metadata.colorType}).`,
+        );
+    }
+    if (spec.maximumFileSizeBytes && bytes.byteLength > spec.maximumFileSizeBytes) {
+        throw new Error(
+            `${label} is ${bytes.byteLength} bytes; ${spec.store} allows at most ${spec.maximumFileSizeBytes}.`,
+        );
+    }
+    if (spec.store === 'google-play') {
+        const shortest = Math.min(metadata.width, metadata.height);
+        const longest = Math.max(metadata.width, metadata.height);
+        if (shortest < 320 || longest > 3_840 || longest > shortest * 2) {
+            throw new Error(
+                `${label} breaks Google Play's 320–3,840 px bounds or its 2:1 maximum aspect ratio.`,
+            );
+        }
+        if (metadata.width * 16 !== metadata.height * 9) {
+            throw new Error(`${label} must use Google Play's portrait 9:16 aspect ratio.`);
+        }
+    }
+    return metadata;
+}
+
+export function validateStoreAssetCount(spec: ShowcaseStoreAssetSpec, count: number): void {
+    if (count > spec.maximumUploadCount) {
+        throw new Error(
+            `${spec.directory} holds ${count} screenshots; ${spec.store} allows at most ${spec.maximumUploadCount}.`,
+        );
+    }
+}
+
+async function adbOutput(serial: string, args: ReadonlyArray<string>): Promise<string> {
+    return await commandOutput(ADB, ['-s', serial, ...args]);
+}
+
+function argumentValue(args: ReadonlyArray<string>, index: number, flag: string): string {
+    const value = args[index + 1];
+    if (!value || value.startsWith('--')) throw new Error(`${flag} requires a value.`);
+    return value;
+}
+
+/**
+ * A bundler left over from an earlier run answers on the port and serves a
+ * stale bundle — including a stale EXPO_PUBLIC_API_URL — so the capture would
+ * quietly show the wrong data rather than fail.
+ */
+async function assertPortFree(port: number): Promise<void> {
+    const inUse = await new Promise<boolean>((resolve) => {
+        const socket = NodeNet.createConnection({ host: '127.0.0.1', port });
+        socket.once('connect', () => {
+            socket.destroy();
+            resolve(true);
+        });
+        socket.once('error', () => resolve(false));
+        socket.setTimeout(500, () => {
+            socket.destroy();
+            resolve(false);
+        });
+    });
+    if (inUse) {
+        throw new Error(
+            `Port ${port} is already in use. Stop whatever is listening (a leftover Metro from an earlier run?) or pass --skip-metro to reuse it deliberately.`,
+        );
+    }
+}
+
+async function captureDevice(
+    device: ShowcaseDevice,
+    scenes: ReadonlyArray<ShowcaseScene>,
+    config: ShowcaseConfig,
+    outputDirectory: string,
+    log: (line: string) => void,
+): Promise<() => Promise<void>> {
+    const app = appFor(device);
+    const directory = NodePath.join(outputDirectory, device.storeAsset.directory);
+    await NodeFSP.mkdir(directory, { recursive: true });
+
+    let target: string;
+    let cleanup: () => Promise<void>;
+
+    if (device.platform === 'ios') {
+        const simulator = await findIosSimulator((device as ShowcaseIosDevice).simulator);
+        target = simulator.udid;
+        process.stdout.write(`  booting ${simulator.name} (${target})\n`);
+        await runCommand('xcrun', ['simctl', 'boot', target]).catch(() => undefined);
+        await runCommand('xcrun', ['simctl', 'bootstatus', target, '-b']);
+        await normalizeIosSimulator(target);
+        await resetIosApp(app.appId, target);
+        await suppressIosDevMenu(app.appId, target);
+        cleanup = async () => {
+            await runCommand('xcrun', ['simctl', 'status_bar', target, 'clear']).catch(
+                () => undefined,
+            );
+        };
+    } else {
+        const androidDevice = device as ShowcaseAndroidDevice;
+        const running = (await runningAndroidAvds()).get(androidDevice.avd);
+        if (!running) {
+            const available = (await commandOutput(EMULATOR, ['-list-avds']))
+                .split('\n')
+                .map((line) => line.trim());
+            if (!available.includes(androidDevice.avd)) {
+                throw new Error(
+                    `Android AVD '${androidDevice.avd}' is not installed. Run '${EMULATOR} -list-avds'.`,
+                );
+            }
+            const emulator = spawnProcess(
+                EMULATOR,
+                ['-avd', androidDevice.avd, '-no-snapshot-load', '-no-boot-anim'],
+                { detached: true, stdio: 'ignore' },
+            );
+            emulator.unref();
+        }
+        target = running ?? (await waitForAndroidSerial(androidDevice.avd));
+        process.stdout.write(`  using ${androidDevice.avd} (${target})\n`);
+        await normalizeAndroidEmulator(androidDevice, target);
+        await runAdb(target, ['shell', 'pm', 'clear', app.appId]);
+        await suppressAndroidDevMenu(app.appId, target);
+        // Metro, the showcase media and the API all live on the host's
+        // loopback, which inside the emulator is the emulator itself.
+        for (const port of [config.metroPort, SHOWCASE_MEDIA_PORT, apiPort()]) {
+            await runAdb(target, ['reverse', `tcp:${port}`, `tcp:${port}`]);
+        }
+        cleanup = async () => {
+            await restoreAndroidEmulator(target);
+        };
+    }
+
+    await launchApp(app, device, target, config, true);
+
+    const preOnboarding = scenes.filter((scene) => PRE_ONBOARDING_SCENES.includes(scene));
+    const postOnboarding = scenes.filter((scene) => !PRE_ONBOARDING_SCENES.includes(scene));
+
+    for (const scene of preOnboarding) {
+        await openScene(app, device, target, sceneUrl(app, scene, ''));
+        await delay(config.settleDelayMs);
+        await captureScene(device, target, scene, NodePath.join(directory, `${scene}.png`));
+    }
+
+    if (postOnboarding.length > 0) {
+        const deviceId = await readDeviceId(app, device, target);
+        log(`  subscribing device ${deviceId} to ${SHOWCASE_TOPICS.length} channels`);
+        for (const topic of SHOWCASE_TOPICS) {
+            await subscribeDevice(API_URL, deviceId, topic);
+        }
+
+        // Published only now, and once per device. The subscriptions above only
+        // surface messages newer than themselves, which is what keeps the feed
+        // to exactly this run's twelve even though the topics are long-lived and
+        // shared with every previous run.
+        log('  publishing the demo feed (paced for the anonymous 10/min limit)…');
+        const published = await publishShowcaseContent(API_URL, log);
+        const messageId = findShowcaseMessage(published, SHOWCASE_MESSAGE_TITLE).messageId;
+
+        // Onboarding is one AsyncStorage flag; the landing page's skip button
+        // sets the same one. Written while the app is stopped, because
+        // AsyncStorage rewrites the whole store when the app next persists.
+        await terminateApp(app, device, target);
+        await patchAppStorage(app, device, target, { [ONBOARDING_KEY]: 'true' });
+        await launchApp(app, device, target, config, false);
+
+        for (const scene of postOnboarding) {
+            await openScene(app, device, target, sceneUrl(app, scene, messageId));
+            await delay(config.settleDelayMs);
+            await captureScene(device, target, scene, NodePath.join(directory, `${scene}.png`));
+        }
+    }
+
+    const written = (await NodeFSP.readdir(directory)).filter((file) => file.endsWith('.png'));
+    validateStoreAssetCount(device.storeAsset, written.length);
+
+    return cleanup;
+}
+
+async function captureScene(
+    device: ShowcaseDevice,
+    target: string,
+    scene: ShowcaseScene,
+    destination: string,
+): Promise<void> {
+    // Grab frames until two in a row match, so a screen still animating in — or
+    // a list that has not painted its rows yet — is never what gets written.
+    let previous: Buffer | null = null;
+    let frame = await grabFrame(device, target);
+    for (let attempt = 0; attempt < 8 && !previous?.equals(frame); attempt += 1) {
+        previous = frame;
+        await delay(1_200);
+        frame = await grabFrame(device, target);
+    }
+    await NodeFSP.writeFile(destination, frame);
+
+    const normalized = normalizeStorePng(await NodeFSP.readFile(destination));
+    await NodeFSP.writeFile(destination, normalized);
+    const metadata = validateStoreAsset(device.storeAsset, normalized, `${device.id}/${scene}.png`);
+    process.stdout.write(
+        `  ✓ ${scene.padEnd(9)} ${metadata.width}×${metadata.height} 24-bit RGB → ${NodePath.relative(REPO_ROOT, destination)}\n`,
+    );
+}
+
+async function commandOutput(
+    command: string,
+    args: ReadonlyArray<string>,
+    options: NodeChildProcess.ExecFileOptions = {},
+): Promise<string> {
+    return await new Promise<string>((resolve, reject) => {
+        NodeChildProcess.execFile(
+            command,
+            [...args],
+            { cwd: REPO_ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, ...options },
+            (error, stdout) => (error ? reject(error) : resolve(String(stdout))),
+        );
+    });
+}
+
+function delay(milliseconds: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function findIosSimulator(name: string): Promise<SimctlDevice> {
+    const parsed = JSON.parse(
+        await commandOutput('xcrun', ['simctl', 'list', 'devices', 'available', '-j']),
+    ) as { readonly devices: Readonly<Record<string, ReadonlyArray<SimctlDevice>>> };
+    const match = Object.entries(parsed.devices)
+        .filter(([runtime]) => runtime.includes('iOS'))
+        .flatMap(([, devices]) => devices)
+        .filter((device) => device.isAvailable && device.name === name)
+        .at(-1);
+    if (!match) {
+        throw new Error(
+            `iOS simulator '${name}' is not installed. Create it in Xcode > Windows > Devices and Simulators.`,
+        );
+    }
+    return match;
+}
+
+async function grabFrame(device: ShowcaseDevice, target: string): Promise<Buffer> {
+    if (device.platform === 'ios') {
+        // simctl only writes to a file, so stage one and read it straight back.
+        const staged = NodePath.join(
+            await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), 'emitsignal-frame-')),
+            'frame.png',
+        );
+        await runCommand('xcrun', ['simctl', 'io', target, 'screenshot', staged]);
+        const bytes = await NodeFSP.readFile(staged);
+        await NodeFSP.rm(NodePath.dirname(staged), { force: true, recursive: true });
+        return bytes;
+    }
+    return await new Promise<Buffer>((resolve, reject) => {
+        NodeChildProcess.execFile(
+            ADB,
+            ['-s', target, 'exec-out', 'screencap', '-p'],
+            { encoding: 'buffer', maxBuffer: 64 * 1024 * 1024 },
+            (error, stdout) => (error ? reject(error) : resolve(stdout)),
+        );
+    });
+}
+
+function killProcessTree(child: NodeChildProcess.ChildProcess, signal: NodeJS.Signals): void {
+    if (child.pid === undefined) return;
+    try {
+        // Negative pid targets the whole group, which is where `expo start`
+        // keeps the bundler that actually holds the port.
+        process.kill(-child.pid, signal);
+    } catch {
+        child.kill(signal);
+    }
+}
+
+/** Points the dev client at the harness's Metro server and waits for the bundle. */
+async function launchApp(
+    app: ShowcaseApp,
+    device: ShowcaseDevice,
+    target: string,
+    config: ShowcaseConfig,
+    awaitFirstRun: boolean,
+): Promise<void> {
+    // Android reaches the host's loopback through the adb reverse tunnels.
+    const metroUrl = encodeURIComponent(`http://127.0.0.1:${config.metroPort}`);
+    await openScene(
+        app,
+        device,
+        target,
+        `${app.scheme}://expo-development-client/?url=${metroUrl}`,
+    );
+
+    if (awaitFirstRun) {
+        // The app writes its device id as soon as React mounts, which makes it a
+        // real readiness signal for the very first launch — far better than
+        // guessing how long a cold bundle takes.
+        await waitForDeviceId(app, device, target, config.bundleLoadTimeoutMs);
+        await delay(config.bundleLoadDelayMs);
+        return;
+    }
+    // On a relaunch the device id is already there, so there is nothing to poll
+    // for and the wait has to be a plain one.
+    await delay(config.relaunchSettleMs);
+}
+
+async function main(): Promise<void> {
+    const options = parseShowcaseCliArgs(process.argv.slice(2));
+    if (options.list) {
+        printUsage(showcaseConfig);
+        return;
+    }
+
+    const devices = selectDevices(showcaseConfig, options.deviceIds);
+    const scenes = selectScenes(options.scenes);
+    const outputDirectory = NodePath.resolve(REPO_ROOT, showcaseConfig.outputDirectory);
+    const log = (line: string) => process.stdout.write(`${line}\n`);
+
+    // Started before anything else and stopped last: the published messages
+    // point at it, and the app loads those images while each scene renders.
+    const media = await startShowcaseMediaServer(log);
+    log(`Serving showcase media on ${media.origin}`);
+
+    let metro: NodeChildProcess.ChildProcess | null = null;
+    const cleanups: Array<() => Promise<void>> = [];
+    try {
+        if (!options.skipMetro) {
+            await assertPortFree(showcaseConfig.metroPort);
+            log(`Starting Metro on :${showcaseConfig.metroPort} against ${API_URL}…`);
+            metro = spawnProcess(
+                'bunx',
+                [
+                    'expo',
+                    'start',
+                    '--dev-client',
+                    '--clear',
+                    '--port',
+                    String(showcaseConfig.metroPort),
+                ],
+                {
+                    cwd: MOBILE_ROOT,
+                    // Metro inlines EXPO_PUBLIC_* at bundle time, and the package's
+                    // .env points at production. Without this the app would read a
+                    // different API than the one the harness just seeded, and every
+                    // signed-in scene would render empty.
+                    // Its own process group: `expo start` spawns a tree, and
+                    // orphaning it leaves a stale bundler squatting on the port
+                    // that the next run would silently capture against.
+                    detached: true,
+                    env: { ...process.env, EXPO_PUBLIC_API_URL: API_URL },
+                    stdio: 'ignore',
+                },
+            );
+            await waitForPort(showcaseConfig.metroPort, 'Metro');
+        }
+
+        for (const device of devices) {
+            log(`\n${device.id}`);
+            cleanups.push(
+                await captureDevice(device, scenes, showcaseConfig, outputDirectory, log),
+            );
+        }
+
+        log(`\nDone. ${NodePath.relative(REPO_ROOT, outputDirectory)}/`);
+    } finally {
+        for (const cleanup of cleanups) await cleanup().catch(() => undefined);
+        if (metro) await stopProcess(metro);
+        media.stop();
+    }
+}
+
+async function normalizeAndroidEmulator(
+    device: ShowcaseAndroidDevice,
+    serial: string,
+): Promise<void> {
+    for (const scale of [
+        'window_animation_scale',
+        'transition_animation_scale',
+        'animator_duration_scale',
+    ]) {
+        await runAdb(serial, ['shell', 'settings', 'put', 'global', scale, '0']);
+    }
+    await runAdb(serial, ['shell', 'cmd', 'uimode', 'night', 'yes']);
+    await runAdb(serial, ['shell', 'settings', 'put', 'global', 'sysui_demo_allowed', '1']);
+    // Demo mode is the only reliable way to get a clean status bar; the
+    // immersive policy_control trick stopped working on Android 14.
+    await runAdb(serial, [
+        'shell',
+        'am',
+        'broadcast',
+        '-a',
+        'com.android.systemui.demo',
+        '-e',
+        'command',
+        'enter',
+    ]);
+    await runAdb(serial, [
+        'shell',
+        'am',
+        'broadcast',
+        '-a',
+        'com.android.systemui.demo',
+        '-e',
+        'command',
+        'clock',
+        '-e',
+        'hhmm',
+        '0941',
+    ]);
+    await runAdb(serial, [
+        'shell',
+        'am',
+        'broadcast',
+        '-a',
+        'com.android.systemui.demo',
+        '-e',
+        'command',
+        'battery',
+        '-e',
+        'level',
+        '100',
+        '-e',
+        'plugged',
+        'false',
+    ]);
+    await runAdb(serial, [
+        'shell',
+        'am',
+        'broadcast',
+        '-a',
+        'com.android.systemui.demo',
+        '-e',
+        'command',
+        'notifications',
+        '-e',
+        'visible',
+        'false',
+    ]);
+    await runAdb(serial, [
+        'shell',
+        'wm',
+        'size',
+        `${device.viewport.width}x${device.viewport.height}`,
+    ]);
+    await runAdb(serial, ['shell', 'wm', 'density', String(device.viewport.density)]);
+}
+
+async function normalizeIosSimulator(udid: string): Promise<void> {
+    await runCommand('xcrun', ['simctl', 'ui', udid, 'appearance', 'dark']);
+    await runCommand('xcrun', [
+        'simctl',
+        'status_bar',
+        udid,
+        'override',
+        '--time',
+        '9:41',
+        '--batteryState',
+        'charged',
+        '--batteryLevel',
+        '100',
+        '--wifiBars',
+        '3',
+        '--cellularBars',
+        '4',
+    ]);
+}
+
+async function openScene(
+    app: ShowcaseApp,
+    device: ShowcaseDevice,
+    target: string,
+    url: string,
+): Promise<void> {
+    if (device.platform === 'ios') {
+        await runCommand('xcrun', ['simctl', 'openurl', target, url]);
+    } else {
+        await runAdb(target, [
+            'shell',
+            'am',
+            'start',
+            '-a',
+            'android.intent.action.VIEW',
+            '-d',
+            url,
+            app.appId,
+        ]);
+    }
+}
+
+async function patchAppStorage(
+    app: ShowcaseApp,
+    device: ShowcaseDevice,
+    target: string,
+    patch: AppStorage,
+): Promise<void> {
+    if (device.platform === 'ios') await patchIosStorage(target, app.appId, patch);
+    else await patchAndroidStorage(ADB, target, app.appId, patch);
+}
+
+function printUsage(config: ShowcaseConfig): void {
+    process.stdout.write(`EmitSignal store screenshot harness
+
+Usage:
+  bun scripts/mobile-showcase/showcase.ts [options]
+
+Options:
+  --device <id>     Capture one configured device (repeatable)
+  --scene <name>    Capture one scene (repeatable)
+  --skip-metro      Reuse an already running showcase Metro server
+  --list            Print this help and the configured matrix
+
+Scenes: ${SHOWCASE_SCENES.join(', ')}
+App:    default APP_MODE=${APP_MODE}, API ${API_URL}
+
+Devices:
+${config.devices
+    .map((device) => {
+        const target = device.platform === 'ios' ? device.simulator : device.avd;
+        return `  ${device.id.padEnd(12)} ${device.platform.padEnd(8)} ${target.padEnd(22)} → ${device.storeAsset.directory} (${device.storeAsset.width}×${device.storeAsset.height})`;
+    })
+    .join('\n')}
+`);
+}
+
+/**
+ * The app mints this UUID on first launch and scopes every anonymous
+ * subscription to it, so the harness has to read it back rather than choose it.
+ */
+async function readDeviceId(
+    app: ShowcaseApp,
+    device: ShowcaseDevice,
+    target: string,
+): Promise<string> {
+    const storage =
+        device.platform === 'ios'
+            ? await readIosStorage(target, app.appId)
+            : await readAndroidStorage(ADB, target, app.appId);
+    const deviceId = storage[DEVICE_ID_KEY];
+    if (!deviceId) {
+        throw new Error(
+            `${app.appId} has not written ${DEVICE_ID_KEY} yet. The bundle probably failed to load — check Metro.`,
+        );
+    }
+    return deviceId;
+}
+
+/**
+ * Reinstalls the app from the copy already on the device. A plain data wipe
+ * leaves the keychain untouched, so a session from manual testing would survive
+ * and the anonymous scenes would render signed in.
+ */
+async function resetIosApp(appId: string, udid: string): Promise<void> {
+    const installed = (
+        await commandOutput('xcrun', ['simctl', 'get_app_container', udid, appId, 'app']).catch(
+            () => '',
+        )
+    ).trim();
+    if (!installed) {
+        throw new Error(
+            `${appId} is not installed on the simulator. Install it once with 'bun run ios' inside packages/emitsignal-mobile.`,
+        );
+    }
+    const staged = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), 'emitsignal-showcase-'));
+    const bundle = NodePath.join(staged, NodePath.basename(installed));
+    await runCommand('cp', ['-R', installed, bundle]);
+    await runCommand('xcrun', ['simctl', 'uninstall', udid, appId]);
+    await runCommand('xcrun', ['simctl', 'install', udid, bundle]);
+    await NodeFSP.rm(staged, { force: true, recursive: true });
+}
+
+async function restoreAndroidEmulator(serial: string): Promise<void> {
+    await runAdb(serial, [
+        'shell',
+        'am',
+        'broadcast',
+        '-a',
+        'com.android.systemui.demo',
+        '-e',
+        'command',
+        'exit',
+    ]).catch(() => undefined);
+    await runAdb(serial, ['shell', 'wm', 'size', 'reset']).catch(() => undefined);
+    await runAdb(serial, ['shell', 'wm', 'density', 'reset']).catch(() => undefined);
+}
+
+async function runAdb(serial: string, args: ReadonlyArray<string>): Promise<void> {
+    await runCommand(ADB, ['-s', serial, ...args]);
+}
+
+async function runCommand(
+    command: string,
+    args: ReadonlyArray<string>,
+    options: NodeChildProcess.SpawnOptions = {},
+): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+        const child = spawnProcess(command, args, {
+            stdio: ['ignore', 'ignore', 'pipe'],
+            ...options,
+        });
+        // Without the tool's own stderr these failures report only an exit code,
+        // which says nothing about which simulator or package was wrong.
+        let stderr = '';
+        child.stderr?.on('data', (chunk: Buffer) => {
+            stderr += chunk.toString();
+        });
+        child.once('error', reject);
+        child.once('exit', (code, signal) => {
+            if (code === 0) resolve();
+            else
+                reject(
+                    new Error(
+                        `${command} ${args.join(' ')} failed ${signal ? `with signal ${signal}` : `with code ${String(code)}`}.${stderr.trim() ? `\n${stderr.trim()}` : ''}`,
+                    ),
+                );
+        });
+    });
+}
+
+async function runningAndroidAvds(): Promise<ReadonlyMap<string, string>> {
+    const serials = (await commandOutput(ADB, ['devices']))
+        .split('\n')
+        .map((line) => line.trim().split(/\s+/u))
+        .filter((parts) => parts[0]?.startsWith('emulator-') && parts[1] === 'device')
+        .map((parts) => parts[0] as string);
+    const result = new Map<string, string>();
+    for (const serial of serials) {
+        const name = (await adbOutput(serial, ['emu', 'avd', 'name'])).split('\n')[0]?.trim();
+        if (name) result.set(name, serial);
+    }
+    return result;
+}
+
+function spawnProcess(
+    command: string,
+    args: ReadonlyArray<string>,
+    options: NodeChildProcess.SpawnOptions = {},
+): NodeChildProcess.ChildProcess {
+    return NodeChildProcess.spawn(command, args, {
+        cwd: REPO_ROOT,
+        env: process.env,
+        stdio: 'inherit',
+        ...options,
+    });
+}
+
+async function stopProcess(child: NodeChildProcess.ChildProcess): Promise<void> {
+    if (child.exitCode !== null || child.signalCode !== null) return;
+    const exited = new Promise<void>((resolve) => child.once('exit', () => resolve()));
+    killProcessTree(child, 'SIGTERM');
+    await Promise.race([exited, delay(5_000)]);
+    if (child.exitCode === null && child.signalCode === null) killProcessTree(child, 'SIGKILL');
+}
+
+async function suppressAndroidDevMenu(appId: string, serial: string): Promise<void> {
+    const preferences = `<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<map>
+  <boolean name="isOnboardingFinished" value="true" />
+  <boolean name="showsAtLaunch" value="false" />
+  <boolean name="showFab" value="false" />
+  <boolean name="motionGestureEnabled" value="false" />
+  <boolean name="touchGestureEnabled" value="false" />
+  <boolean name="keyCommandsEnabled" value="false" />
+</map>`;
+    const encoded = Buffer.from(preferences).toString('base64');
+    await runAdb(serial, [
+        'shell',
+        `run-as ${appId} sh -c 'mkdir -p shared_prefs && printf %s ${encoded} | base64 -d > shared_prefs/expo.modules.devmenu.sharedpreferences.xml'`,
+    ]);
+}
+
+/**
+ * Written straight after install, before the first launch: cfprefsd caches an
+ * app's preferences once it has read them, and a later write needs a reboot to
+ * take effect.
+ */
+async function suppressIosDevMenu(appId: string, udid: string): Promise<void> {
+    for (const [key, value] of [
+        ['EXDevMenuIsOnboardingFinished', 'true'],
+        ['EXDevMenuShowFloatingActionButton', 'false'],
+        ['EXDevMenuShowsAtLaunch', 'false'],
+    ] as const) {
+        await runCommand('xcrun', [
+            'simctl',
+            'spawn',
+            udid,
+            'defaults',
+            'write',
+            appId,
+            key,
+            '-bool',
+            value,
+        ]);
+    }
+}
+
+async function terminateApp(
+    app: ShowcaseApp,
+    device: ShowcaseDevice,
+    target: string,
+): Promise<void> {
+    if (device.platform === 'ios') {
+        await runCommand('xcrun', ['simctl', 'terminate', target, app.appId]).catch(
+            () => undefined,
+        );
+    } else {
+        await runAdb(target, ['shell', 'am', 'force-stop', app.appId]).catch(() => undefined);
+    }
+    await delay(1_500);
+}
+
+async function waitForAndroidSerial(avd: string, timeoutMs = 180_000): Promise<string> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const serial = (await runningAndroidAvds()).get(avd);
+        if (serial) {
+            const booted = (
+                await adbOutput(serial, ['shell', 'getprop', 'sys.boot_completed'])
+            ).trim();
+            if (booted === '1') return serial;
+        }
+        await delay(1_000);
+    }
+    throw new Error(`Android AVD '${avd}' did not finish booting within ${timeoutMs}ms.`);
+}
+
+async function waitForDeviceId(
+    app: ShowcaseApp,
+    device: ShowcaseDevice,
+    target: string,
+    timeoutMs: number,
+): Promise<string> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const deviceId = await readDeviceId(app, device, target).catch(() => '');
+        if (deviceId) return deviceId;
+        await delay(2_000);
+    }
+    throw new Error(
+        `${app.appId} did not start within ${timeoutMs}ms. Check that Metro is serving the bundle.`,
+    );
+}
+
+async function waitForPort(port: number, label: string, timeoutMs = 120_000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const open = await new Promise<boolean>((resolve) => {
+            const socket = NodeNet.createConnection({ host: '127.0.0.1', port });
+            socket.once('connect', () => {
+                socket.destroy();
+                resolve(true);
+            });
+            socket.once('error', () => resolve(false));
+            socket.setTimeout(500, () => {
+                socket.destroy();
+                resolve(false);
+            });
+        });
+        if (open) return;
+        await delay(500);
+    }
+    throw new Error(`${label} did not listen on port ${port} within ${timeoutMs}ms.`);
+}
+
+if (import.meta.main) {
+    main().catch((error: unknown) => {
+        process.stderr.write(
+            `${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`,
+        );
+        NodeProcess.exit(1);
+    });
+}

--- a/scripts/publish-curl.sh
+++ b/scripts/publish-curl.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Hand-runnable curl recipes for POST /topic/:name.
+#
+#   ./scripts/publish-curl.sh list
+#   ./scripts/publish-curl.sh basic
+#   ./scripts/publish-curl.sh all
+#
+# Config via environment:
+#   EMITSIGNAL_API_URL  (default http://localhost:5001)
+#   EMITSIGNAL_TOPIC    (default publish-playground)
+#   EMITSIGNAL_TOKEN    session token or es_ API key (optional; anonymous otherwise)
+
+set -euo pipefail
+
+API_URL="${EMITSIGNAL_API_URL:-http://localhost:5001}"
+TOPIC="${EMITSIGNAL_TOPIC:-publish-playground}"
+TOKEN="${EMITSIGNAL_TOKEN:-}"
+ENDPOINT="${API_URL%/}/topic/${TOPIC}"
+
+BANNER="https://picsum.photos/id/1018/1200/400"
+IMAGE="https://picsum.photos/id/1025/600/400"
+
+auth_args=()
+if [[ -n "$TOKEN" ]]; then
+    auth_args=(-H "Authorization: Bearer ${TOKEN}")
+fi
+
+# post <label> <curl args...>
+post() {
+    local label="$1"
+    shift
+
+    printf '\n\033[35m▸ %s\033[0m\n' "$label"
+    curl -sS -w '\nHTTP %{http_code}\n' -X POST "${auth_args[@]}" "$@" "$ENDPOINT"
+}
+
+json() {
+    local label="$1"
+    local payload="$2"
+
+    post "$label" -H 'Content-Type: application/json' --data "$payload"
+}
+
+basic() {
+    json 'basic — title + body' '{"title":"Deploy finished","body":"web@2.4.1 is live."}'
+}
+
+title_only() {
+    json 'title only' '{"title":"Title only signal"}'
+}
+
+body_only() {
+    json 'body only' '{"body":"Body only signal, no title."}'
+}
+
+priorities() {
+    for priority in 1 2 3 4 5; do
+        json "priority ${priority}" \
+            "{\"title\":\"Priority ${priority}\",\"body\":\"Severity test\",\"priority\":${priority}}"
+    done
+}
+
+tags() {
+    json 'tags' '{"title":"Tagged signal","body":"Routing metadata","tags":["ci","deploy","production"]}'
+}
+
+actions() {
+    json 'actions — view + acknowledge' '{
+        "title": "Incident opened",
+        "body": "Both action kinds (the maximum of 2).",
+        "priority": 5,
+        "actions": [
+            {"type": "view", "label": "View incident", "url": "https://example.com/incident/42"},
+            {"type": "acknowledge", "label": "Acknowledge"}
+        ]
+    }'
+}
+
+media() {
+    json 'media — banner, inline image, attachment' "{
+        \"title\": \"Release 2.0\",
+        \"body\": \"Banner plus one inline image and one attachment.\",
+        \"bannerImage\": {\"href\": \"${BANNER}\", \"title\": \"Release banner\"},
+        \"inlineImages\": [\"${IMAGE}\"],
+        \"inlineAttachments\": [\"https://raw.githubusercontent.com/github/gitignore/main/Node.gitignore\"]
+    }"
+}
+
+scheduled() {
+    local when=$(($(date +%s) + 60))
+
+    json 'scheduled — 60s from now (JSON scheduledAt)' \
+        "{\"title\":\"Scheduled signal\",\"body\":\"Queued, not delivered now.\",\"scheduledAt\":${when}}"
+}
+
+header_basic() {
+    post 'header mode — title/x-priority/x-tags' \
+        -H 'Content-Type: text/plain' \
+        -H 'Title: Header publish' \
+        -H 'X-Priority: urgent' \
+        -H 'X-Tags: ops,pager' \
+        --data 'The raw request body becomes the message body.'
+}
+
+header_aliases() {
+    post 'header mode — short aliases t/m/p/ta' \
+        -H 'Content-Type: text/plain' \
+        -H 'T: Short aliases' \
+        -H 'M: Body from the m header' \
+        -H 'P: 2' \
+        -H 'Ta: cli,shorthand' \
+        --data 'ignored because the m header wins'
+}
+
+header_delay() {
+    post 'header mode — x-delay 5m (relative)' \
+        -H 'Content-Type: text/plain' \
+        -H 'Title: Relative delay' \
+        -H 'X-Delay: 5m' \
+        --data 'Delivered five minutes from now.'
+}
+
+header_media() {
+    post 'header mode — x-banner + x-inline-images' \
+        -H 'Content-Type: text/plain' \
+        -H 'Title: Header media' \
+        -H "X-Banner: ${BANNER}" \
+        -H "X-Inline-Images: ${IMAGE}" \
+        --data 'Media headers accept a URL, a comma-separated list or JSON.'
+}
+
+header_actions() {
+    post 'header mode — x-actions JSON' \
+        -H 'Content-Type: text/plain' \
+        -H 'Title: Header actions' \
+        -H 'X-Actions: [{"type":"view","label":"Open","url":"https://example.com/header-action"}]' \
+        --data 'Actions arrive as a JSON string in x-actions.'
+}
+
+errors() {
+    json 'error — missing content (400 missing_content)' '{"title":"","body":"   "}'
+    json 'error — priority out of range (422)' '{"title":"Priority 6","priority":6}'
+    json 'error — view action without url' '{"title":"No url","actions":[{"type":"view"}]}'
+    json 'error — non-http media (400 invalid_media)' \
+        '{"title":"Bad banner","bannerImage":"ftp://example.com/banner.png"}'
+
+    printf '\n\033[35m▸ error — invalid topic name (400 invalid_topic_name)\033[0m\n'
+    curl -sS -w '\nHTTP %{http_code}\n' -X POST "${auth_args[@]}" \
+        -H 'Content-Type: application/json' \
+        --data '{"title":"Never stored"}' \
+        "${API_URL%/}/topic/Not%20a%20valid%20topic!"
+}
+
+RECIPES=(
+    basic title_only body_only priorities tags actions media scheduled
+    header_basic header_aliases header_delay header_media header_actions errors
+)
+
+list() {
+    printf 'Endpoint: %s\n\nRecipes:\n' "$ENDPOINT"
+    printf '  %s\n' "${RECIPES[@]}"
+    printf '  all  (runs every recipe above)\n'
+}
+
+all() {
+    for recipe in "${RECIPES[@]}"; do
+        "$recipe"
+        # Anonymous publishing is limited to 10/min, authenticated to 60/min.
+        sleep "${EMITSIGNAL_SLEEP:-1}"
+    done
+}
+
+case "${1:-list}" in
+    all) all ;;
+    list | -h | --help) list ;;
+    *)
+        if [[ " ${RECIPES[*]} " == *" ${1} "* ]]; then
+            "$1"
+        else
+            printf 'unknown recipe: %s\n\n' "$1" >&2
+            list >&2
+            exit 1
+        fi
+        ;;
+esac

--- a/scripts/publish-scenarios.ts
+++ b/scripts/publish-scenarios.ts
@@ -1,0 +1,814 @@
+// Scenario catalogue for POST /topic/:name.
+//
+// Every scenario mirrors a branch of packages/emitsignal-server/src/http/topic/publish.ts
+// (and the header parser in src/lib/header-publish.ts). Add a scenario here and the
+// runner in publish.ts picks it up automatically.
+
+export type Outcome = 'error' | 'posted' | 'scheduled';
+
+export interface Scenario {
+    build: (context: ScenarioContext) => ScenarioRequest;
+    description: string;
+    // What the server is expected to answer. Note that a few publish failures
+    // reply with HTTP 200 and an `error` field in the body — the runner treats
+    // both shapes as the `error` outcome.
+    expect: Outcome;
+    group: ScenarioGroup;
+    name: string;
+}
+
+export interface ScenarioContext {
+    now: number;
+    topic: string;
+}
+
+export type ScenarioGroup = 'errors' | 'headers' | 'json' | 'media' | 'schedule' | 'showcase';
+
+export interface ScenarioRequest {
+    body: string;
+    headers: Record<string, string>;
+    topic: string;
+}
+
+// Publicly reachable sample media. Anonymous publishers may attach a single
+// item per array (ANON_INLINE_MAX), so the happy-path media scenarios stay at one.
+const SAMPLE_ATTACHMENT = 'https://raw.githubusercontent.com/github/gitignore/main/Node.gitignore';
+const SAMPLE_BANNER = 'https://picsum.photos/id/1018/1200/400';
+const SAMPLE_IMAGE = 'https://picsum.photos/id/1025/600/400';
+
+const PRIORITY_LABELS: Record<number, string> = {
+    1: 'min — silent, lowest severity',
+    2: 'low',
+    3: 'default',
+    4: 'high',
+    5: 'max — urgent/critical',
+};
+
+// Showcase media lives in the website's public/ folder, which production serves
+// at the root. Point EMITSIGNAL_MEDIA_BASE at a local dev server (usually
+// http://localhost:5002) before the assets have been deployed.
+const MEDIA_BASE = (process.env.EMITSIGNAL_MEDIA_BASE ?? 'https://emitsignal.com').replace(
+    /\/+$/,
+    '',
+);
+
+function showcaseAsset(name: string): string {
+    return `${MEDIA_BASE}/static/showcase/${name}`;
+}
+
+export const scenarios: Scenario[] = [
+    // ---------------------------------------------------------------- json
+    {
+        build: ({ topic }) => jsonRequest(topic, { title: 'Title only signal' }),
+        description: 'Title without a body — the minimum accepted payload',
+        expect: 'posted',
+        group: 'json',
+        name: 'title-only',
+    },
+    {
+        build: ({ topic }) => jsonRequest(topic, { body: 'Body only signal, no title.' }),
+        description: 'Body without a title — the other minimum accepted payload',
+        expect: 'posted',
+        group: 'json',
+        name: 'body-only',
+    },
+    {
+        build: ({ topic }) =>
+            jsonRequest(topic, {
+                body: 'Disk usage crossed 90% on node-3.',
+                title: 'Deploy finished',
+            }),
+        description: 'Standard title + body JSON publish',
+        expect: 'posted',
+        group: 'json',
+        name: 'title-and-body',
+    },
+    ...buildPriorityScenarios(),
+    {
+        build: ({ topic }) =>
+            jsonRequest(topic, {
+                body: 'Tagged for routing and filtering.',
+                tags: ['ci', 'deploy', 'production'],
+                title: 'Tagged signal',
+            }),
+        description: 'tags array (max 20 entries, 64 chars each)',
+        expect: 'posted',
+        group: 'json',
+        name: 'tags',
+    },
+    {
+        build: ({ topic }) =>
+            jsonRequest(topic, {
+                actions: [
+                    { label: 'Open dashboard', type: 'view', url: 'https://example.com/logs' },
+                ],
+                body: 'Tap through to the run that failed.',
+                title: 'Build failed',
+            }),
+        description: 'Single view action with a tap-through URL',
+        expect: 'posted',
+        group: 'json',
+        name: 'action-view',
+    },
+    {
+        build: ({ topic }) =>
+            jsonRequest(topic, {
+                actions: [{ label: 'Got it', type: 'acknowledge' }],
+                body: 'Requires a human to confirm receipt.',
+                title: 'Pager alert',
+            }),
+        description: 'Single acknowledge action',
+        expect: 'posted',
+        group: 'json',
+        name: 'action-acknowledge',
+    },
+    {
+        build: ({ topic }) =>
+            jsonRequest(topic, {
+                actions: [
+                    {
+                        label: 'View incident',
+                        type: 'view',
+                        url: 'https://example.com/incident/42',
+                    },
+                    { label: 'Acknowledge', type: 'acknowledge' },
+                ],
+                body: 'Both action kinds on one message (the maximum of 2).',
+                priority: 5,
+                title: 'Incident opened',
+            }),
+        description: 'Two actions — view + acknowledge, the documented maximum',
+        expect: 'posted',
+        group: 'json',
+        name: 'actions-view-and-acknowledge',
+    },
+    {
+        build: ({ topic }) =>
+            jsonRequest(topic, {
+                body: 'line one\nline two\n\nline four after a blank line',
+                title: 'Multiline body',
+            }),
+        description: 'Newlines survive the JSON body path',
+        expect: 'posted',
+        group: 'json',
+        name: 'multiline-body',
+    },
+    {
+        build: ({ topic }) =>
+            jsonRequest(topic, {
+                body: 'Unicode round-trip: ação, 日本語, emoji 🚀🔥',
+                tags: ['ünïcode', '🚀'],
+                title: '🚀 Unicode & emoji',
+            }),
+        description: 'Non-ASCII title, body and tags',
+        expect: 'posted',
+        group: 'json',
+        name: 'unicode-and-emoji',
+    },
+
+    // --------------------------------------------------------------- media
+    {
+        build: ({ topic }) =>
+            jsonRequest(topic, {
+                bannerImage: SAMPLE_BANNER,
+                title: 'Banner from a bare URL string',
+            }),
+        description: 'bannerImage as a plain URL string',
+        expect: 'posted',
+        group: 'media',
+        name: 'banner-image-url',
+    },
+    {
+        build: ({ topic }) =>
+            jsonRequest(topic, {
+                bannerImage: { href: SAMPLE_BANNER, title: 'Release banner' },
+                title: 'Banner from a {href, title} object',
+            }),
+        description: 'bannerImage as a titled media reference',
+        expect: 'posted',
+        group: 'media',
+        name: 'banner-image-object',
+    },
+    {
+        build: ({ topic }) =>
+            jsonRequest(topic, {
+                body: 'One inline image (the anonymous per-array limit).',
+                inlineImages: [SAMPLE_IMAGE],
+                title: 'Inline image',
+            }),
+        description: 'inlineImages array with a single entry',
+        expect: 'posted',
+        group: 'media',
+        name: 'inline-image',
+    },
+    {
+        build: ({ topic }) =>
+            jsonRequest(topic, {
+                body: 'One inline attachment.',
+                inlineAttachments: [{ href: SAMPLE_ATTACHMENT, title: 'Node.gitignore' }],
+                title: 'Inline attachment',
+            }),
+        description: 'inlineAttachments array with a titled entry',
+        expect: 'posted',
+        group: 'media',
+        name: 'inline-attachment',
+    },
+    {
+        build: ({ topic }) =>
+            jsonRequest(topic, {
+                actions: [{ label: 'Release notes', type: 'view', url: 'https://example.com/v2' }],
+                bannerImage: SAMPLE_BANNER,
+                body: 'Banner, inline image, attachment, action, tags and priority in one payload.',
+                inlineAttachments: [SAMPLE_ATTACHMENT],
+                inlineImages: [SAMPLE_IMAGE],
+                priority: 4,
+                tags: ['release', 'v2'],
+                title: 'Everything at once',
+            }),
+        description: 'Every optional field populated in a single publish',
+        expect: 'posted',
+        group: 'media',
+        name: 'full-payload',
+    },
+
+    // ------------------------------------------------------------ schedule
+    {
+        build: ({ now, topic }) =>
+            jsonRequest(topic, {
+                body: 'Skips the SSE bus and goes to the schedule queue.',
+                scheduledAt: now + 60,
+                title: 'Scheduled in 60s',
+            }),
+        description: 'scheduledAt in the future — queued, not delivered now',
+        expect: 'scheduled',
+        group: 'schedule',
+        name: 'scheduled-in-60-seconds',
+    },
+    {
+        build: ({ now, topic }) =>
+            jsonRequest(topic, {
+                body: 'A past timestamp is not a schedule — this delivers immediately.',
+                scheduledAt: now - 60,
+                title: 'Scheduled in the past',
+            }),
+        description: 'scheduledAt <= now falls back to immediate delivery',
+        expect: 'posted',
+        group: 'schedule',
+        name: 'scheduled-in-the-past',
+    },
+    {
+        build: ({ topic }) =>
+            headerRequest(
+                topic,
+                { title: 'Relative delay via header', 'x-delay': '5m' },
+                'Delivered five minutes from now.',
+            ),
+        description: 'x-delay with a relative duration (s/m/h/d/w)',
+        expect: 'scheduled',
+        group: 'schedule',
+        name: 'header-delay-relative',
+    },
+    {
+        build: ({ now, topic }) =>
+            headerRequest(
+                topic,
+                { title: 'Absolute delay via header', 'x-delay': String(now + 3600) },
+                'Delivered at an absolute unix timestamp.',
+            ),
+        description: 'x-delay with an absolute unix timestamp',
+        expect: 'scheduled',
+        group: 'schedule',
+        name: 'header-delay-unix',
+    },
+
+    // ------------------------------------------------------------- headers
+    {
+        build: ({ topic }) =>
+            headerRequest(
+                topic,
+                { title: 'Header publish', 'x-priority': 'urgent', 'x-tags': 'ops,pager' },
+                'The raw request body becomes the message body.',
+            ),
+        description: 'Header-based publish — title, x-priority word, x-tags',
+        expect: 'posted',
+        group: 'headers',
+        name: 'header-basic',
+    },
+    {
+        build: ({ topic }) =>
+            headerRequest(
+                topic,
+                { m: 'Body from the m header', p: '2', t: 'Short aliases', ta: 'cli,shorthand' },
+                'ignored because the m header wins',
+            ),
+        description: 'Short header aliases — t, m, p, ta',
+        expect: 'posted',
+        group: 'headers',
+        name: 'header-short-aliases',
+    },
+    {
+        build: ({ topic }) =>
+            headerRequest(
+                topic,
+                { title: 'Low priority word', 'x-priority': 'low' },
+                'Priority words map to 1–5: min, low, default/none, high, max/urgent.',
+            ),
+        description: 'x-priority accepts words as well as digits',
+        expect: 'posted',
+        group: 'headers',
+        name: 'header-priority-word',
+    },
+    {
+        build: ({ topic }) =>
+            headerRequest(
+                topic,
+                {
+                    title: 'Header actions',
+                    'x-actions': JSON.stringify([
+                        { label: 'Open', type: 'view', url: 'https://example.com/header-action' },
+                    ]),
+                },
+                'Actions arrive as a JSON string in x-actions.',
+            ),
+        description: 'x-actions carrying a JSON array',
+        expect: 'posted',
+        group: 'headers',
+        name: 'header-actions-json',
+    },
+    {
+        build: ({ topic }) =>
+            headerRequest(
+                topic,
+                {
+                    title: 'Header media',
+                    'x-banner': SAMPLE_BANNER,
+                    'x-inline-images': SAMPLE_IMAGE,
+                },
+                'Media headers accept a bare URL, a comma-separated list or JSON.',
+            ),
+        description: 'x-banner and x-inline-images as plain URLs',
+        expect: 'posted',
+        group: 'headers',
+        name: 'header-media',
+    },
+    {
+        build: ({ topic }) =>
+            headerRequest(
+                topic,
+                { title: 'Message override', 'x-message': 'This header replaces the raw body.' },
+                'raw body that gets discarded',
+            ),
+        description: 'x-message takes precedence over the raw request body',
+        expect: 'posted',
+        group: 'headers',
+        name: 'header-message-override',
+    },
+
+    // -------------------------------------------------------------- errors
+    {
+        build: ({ topic }) => jsonRequest(topic, { body: '   ', title: '' }),
+        description: '400 missing_content — title and body both blank after trim',
+        expect: 'error',
+        group: 'errors',
+        name: 'error-missing-content',
+    },
+    {
+        build: () => jsonRequest('Not a valid topic!', { title: 'Never stored' }),
+        description: '400 invalid_topic_name — topic must match [a-z0-9][a-z0-9/_-]*[a-z0-9]',
+        expect: 'error',
+        group: 'errors',
+        name: 'error-invalid-topic-name',
+    },
+    {
+        build: ({ topic }) => jsonRequest(topic, { priority: 6, title: 'Priority 6' }),
+        description: '422 validation — priority is constrained to 1–5',
+        expect: 'error',
+        group: 'errors',
+        name: 'error-priority-out-of-range',
+    },
+    {
+        build: ({ topic }) =>
+            jsonRequest(topic, {
+                actions: [
+                    { type: 'view', url: 'https://example.com/one' },
+                    { type: 'view', url: 'https://example.com/two' },
+                    { type: 'acknowledge' },
+                ],
+                title: 'Three actions',
+            }),
+        description: '422 validation — actions is capped at 2 entries',
+        expect: 'error',
+        group: 'errors',
+        name: 'error-too-many-actions',
+    },
+    {
+        build: ({ topic }) =>
+            jsonRequest(topic, {
+                actions: [{ label: 'Nowhere', type: 'view' }],
+                title: 'View without url',
+            }),
+        description: 'actions error — a view action requires a url',
+        expect: 'error',
+        group: 'errors',
+        name: 'error-view-action-without-url',
+    },
+    {
+        build: ({ topic }) =>
+            jsonRequest(topic, {
+                actions: [
+                    { type: 'view', url: 'https://example.com/same' },
+                    { type: 'view', url: 'https://example.com/same' },
+                ],
+                title: 'Duplicate view urls',
+            }),
+        description: 'actions error — duplicate view urls are rejected',
+        expect: 'error',
+        group: 'errors',
+        name: 'error-duplicate-view-url',
+    },
+    {
+        build: ({ topic }) =>
+            jsonRequest(topic, {
+                actions: [{ type: 'snooze' }],
+                title: 'Unknown action type',
+            }),
+        description: '422 validation — only view and acknowledge exist',
+        expect: 'error',
+        group: 'errors',
+        name: 'error-unknown-action-type',
+    },
+    {
+        build: ({ topic }) =>
+            jsonRequest(topic, {
+                bannerImage: 'ftp://example.com/banner.png',
+                title: 'Non-http banner',
+            }),
+        description: '400 invalid_media — media hrefs must be http(s)',
+        expect: 'error',
+        group: 'errors',
+        name: 'error-invalid-media-url',
+    },
+    {
+        build: ({ topic }) =>
+            jsonRequest(topic, {
+                inlineImages: Array.from(
+                    { length: 20 },
+                    (_value, index) => `${SAMPLE_IMAGE}?n=${index}`,
+                ),
+                title: 'Twenty inline images',
+            }),
+        description: '400 invalid_media — exceeds the per-array inline limit of every plan',
+        expect: 'error',
+        group: 'errors',
+        name: 'error-too-many-inline-images',
+    },
+    {
+        build: ({ now, topic }) =>
+            jsonRequest(topic, {
+                scheduledAt: now + 2 * 365 * 24 * 60 * 60,
+                title: 'Two years out',
+            }),
+        description: 'scheduling error — scheduledAt may not exceed one year',
+        expect: 'error',
+        group: 'errors',
+        name: 'error-schedule-too-far-ahead',
+    },
+    {
+        build: ({ topic }) =>
+            jsonRequest(topic, { body: 'x'.repeat(32_769), title: 'Oversized body' }),
+        description: '422 validation — body is capped at 32768 characters',
+        expect: 'error',
+        group: 'errors',
+        name: 'error-body-too-long',
+    },
+    {
+        build: ({ topic }) => jsonRequest(topic, { title: 'T'.repeat(257) }),
+        description: '422 validation — title is capped at 256 characters',
+        expect: 'error',
+        group: 'errors',
+        name: 'error-title-too-long',
+    },
+
+    // ------------------------------------------------------------ showcase
+    // Demo content for screenshots and walkthroughs: what a real cron/CI/alerting
+    // stack would actually emit. These ignore --topic and publish to the seeded
+    // topics instead, so the inbox groups the way a team's would. Priorities track
+    // severity — 5 is reserved for the two that should wake someone.
+    {
+        build: () =>
+            jsonRequest('alerts/prod', {
+                actions: [
+                    {
+                        label: 'Open trace',
+                        type: 'view',
+                        url: 'https://status.emitsignal.com/traces/9f4c1ab',
+                    },
+                ],
+                bannerImage: {
+                    href: showcaseAsset('latency-p99.png'),
+                    title: 'p99 response time, last 30 minutes',
+                },
+                body: [
+                    '/api/events is averaging 2.8s, with p99 at 6.4s. The error budget for',
+                    'this month is 61% consumed.',
+                    '',
+                    'Environment: production',
+                    'Service:     api-gateway',
+                    'Version:     v2.14.3',
+                    'Region:      us-east-1',
+                    'Instance:    4× c7g.large',
+                    'Status:      degraded',
+                    'Started:     2 minutes ago',
+                ].join('\n'),
+                priority: 4,
+                tags: ['latency', 'sev2', 'api-gateway'],
+                title: 'Production API latency spike',
+            }),
+        description: 'Latency regression with a p99 chart and a tap-through to the trace',
+        expect: 'posted',
+        group: 'showcase',
+        name: 'showcase-latency-spike',
+    },
+    {
+        build: () =>
+            jsonRequest('alerts/prod', {
+                actions: [{ label: 'Acknowledge', type: 'acknowledge' }],
+                bannerImage: {
+                    href: showcaseAsset('pool-saturation.webp'),
+                    title: 'Connection pool saturation',
+                },
+                body: [
+                    'orders-primary has been at max_connections for 4 minutes. New checkouts',
+                    'are failing with 503 while the pool drains.',
+                    '',
+                    'Database:  postgres 16.3',
+                    'Host:      orders-primary',
+                    'In use:    100 / 100',
+                    'Waiting:   38 clients',
+                    'Longest:   query running 94s (reporting/daily_rollup)',
+                ].join('\n'),
+                priority: 5,
+                tags: ['database', 'sev1', 'paging'],
+                title: 'Database connection pool exhausted',
+            }),
+        description: 'Page-worthy database saturation with an acknowledge action',
+        expect: 'posted',
+        group: 'showcase',
+        name: 'showcase-pool-exhausted',
+    },
+    {
+        build: () =>
+            jsonRequest('alerts/prod', {
+                actions: [
+                    {
+                        label: 'View certificate',
+                        type: 'view',
+                        url: 'https://status.emitsignal.com/certs/cdn',
+                    },
+                ],
+                body: [
+                    'The certificate for cdn.acme.io expires in 7 days and auto-renewal has',
+                    'not run. Last successful renewal was 83 days ago.',
+                    '',
+                    'Domain:   cdn.acme.io',
+                    'Issuer:   ISRG Root X1',
+                    'Expires:  2026-08-15T04:12:00Z',
+                    'Renewal:  certbot timer inactive on edge-02',
+                ].join('\n'),
+                priority: 4,
+                tags: ['tls', 'renewal'],
+                title: 'TLS certificate expires in 7 days',
+            }),
+        description: 'Scheduled-risk warning that needs action before a deadline',
+        expect: 'posted',
+        group: 'showcase',
+        name: 'showcase-cert-expiring',
+    },
+    {
+        build: () =>
+            jsonRequest('deploy/prod', {
+                actions: [
+                    {
+                        label: 'Release notes',
+                        type: 'view',
+                        url: 'https://github.com/kevenleone/emitsignal/releases',
+                    },
+                ],
+                body: [
+                    'api-gateway v2.14.3 is live on all four instances. Health checks green',
+                    'for 3 minutes.',
+                    '',
+                    'Commit:   9f4c1ab',
+                    'Duration: 2m 41s',
+                    'Migrated: 2 migrations',
+                    'Rollout:  100%',
+                ].join('\n'),
+                priority: 3,
+                tags: ['release', 'v2.14.3'],
+                title: 'Deploy succeeded · api-gateway v2.14.3',
+            }),
+        description: 'Routine successful deploy — informational, not urgent',
+        expect: 'posted',
+        group: 'showcase',
+        name: 'showcase-deploy-succeeded',
+    },
+    {
+        build: () =>
+            jsonRequest('deploy/prod', {
+                bannerImage: {
+                    href: showcaseAsset('error-rate.webp'),
+                    title: 'Error rate during the canary window',
+                },
+                body: [
+                    '5xx rate crossed the 5% guardrail at 10% traffic. The canary was pulled',
+                    'automatically and traffic is back on v2.14.2.',
+                    '',
+                    'Candidate:  v2.14.4',
+                    'Peak error: 7.4% (guardrail 5%)',
+                    'Exposure:   10% for 6m 20s',
+                    'Action:     rolled back automatically',
+                ].join('\n'),
+                priority: 4,
+                tags: ['canary', 'rollback'],
+                title: 'Canary rolled back automatically',
+            }),
+        description: 'Automatic rollback with the error-rate chart that triggered it',
+        expect: 'posted',
+        group: 'showcase',
+        name: 'showcase-canary-rollback',
+    },
+    {
+        build: () =>
+            jsonRequest('ci/web', {
+                actions: [
+                    {
+                        label: 'View run',
+                        type: 'view',
+                        url: 'https://github.com/kevenleone/emitsignal/actions/runs/4821',
+                    },
+                ],
+                body: [
+                    'Two tests failed in the OAuth callback suite. The PKCE verifier is not',
+                    'matching the stored challenge.',
+                    '',
+                    'Branch:   feat/oauth-pkce',
+                    'Commit:   9f4c1ab',
+                    'Failed:   2 of 249',
+                    'Duration: 41.2s',
+                ].join('\n'),
+                inlineAttachments: [
+                    { href: showcaseAsset('build-4821.log'), title: 'build-4821.log' },
+                ],
+                priority: 4,
+                tags: ['ci', 'failed'],
+                title: 'Build failed · feat/oauth-pkce',
+            }),
+        description: 'Failing CI run with the build log attached',
+        expect: 'posted',
+        group: 'showcase',
+        name: 'showcase-build-failed',
+    },
+    {
+        build: () =>
+            jsonRequest('ci/web', {
+                body: 'main · 312 tests · 41s · no lint or type errors.',
+                priority: 2,
+                tags: ['ci', 'passed'],
+                title: 'Build passed · main',
+            }),
+        description: 'Routine green build — low priority so it stays out of the way',
+        expect: 'posted',
+        group: 'showcase',
+        name: 'showcase-build-passed',
+    },
+    {
+        build: () =>
+            jsonRequest('cron/backup', {
+                body: [
+                    'orders-primary dumped and uploaded. Restore smoke test passed on staging.',
+                    '',
+                    'Size:      14.2 GB compressed (51.8 GB raw)',
+                    'Duration:  6m 12s',
+                    'Target:    s3://acme-backups/postgres/2026-08-08/',
+                    'Retention: 35 daily · 12 monthly',
+                ].join('\n'),
+                inlineAttachments: [
+                    { href: showcaseAsset('backup-manifest.txt'), title: 'backup-manifest.txt' },
+                ],
+                priority: 2,
+                tags: ['cron', 'success'],
+                title: 'Nightly backup completed · 14.2 GB → s3',
+            }),
+        description: 'Successful cron job with its manifest attached',
+        expect: 'posted',
+        group: 'showcase',
+        name: 'showcase-backup-done',
+    },
+    {
+        build: () =>
+            jsonRequest('cron/backup', {
+                body: [
+                    'The 03:00 run exited early because a snapshot lock from yesterday was',
+                    'still held. No backup was written for 2026-08-07.',
+                    '',
+                    'Lock:     /var/lib/backup/.snapshot.lock',
+                    'Held by:  pid 21884 (since 2026-08-07T03:00:11Z)',
+                    'Skipped:  1 run',
+                    'Next:     2026-08-09T03:00:00Z',
+                ].join('\n'),
+                priority: 4,
+                tags: ['cron', 'skipped'],
+                title: 'Backup skipped — snapshot lock held',
+            }),
+        description: 'Silent-failure case: the job that did not run is the interesting one',
+        expect: 'posted',
+        group: 'showcase',
+        name: 'showcase-backup-skipped',
+    },
+    {
+        build: () =>
+            jsonRequest('alerts/prod', {
+                actions: [{ label: 'This was me', type: 'acknowledge' }],
+                body: [
+                    'Public-key login for deploy@edge-02 from an address outside the office',
+                    'and VPN ranges. Session is still open.',
+                    '',
+                    'User:     deploy',
+                    'Host:     edge-02',
+                    'Source:   203.0.113.44 (AS64512, Frankfurt)',
+                    'Key:      SHA256:7hQ2…d1Ac',
+                    'Opened:   1 minute ago',
+                ].join('\n'),
+                priority: 5,
+                tags: ['security', 'ssh', 'paging'],
+                title: 'SSH login from an unrecognised address',
+            }),
+        description: 'Security event that needs a human to confirm it was expected',
+        expect: 'posted',
+        group: 'showcase',
+        name: 'showcase-ssh-login',
+    },
+    {
+        build: () =>
+            jsonRequest('billing/stripe', {
+                body: 'Acme Corp · invoice INV-2026-0812 · $4,820.00 · card ending 4242.',
+                priority: 1,
+                tags: ['stripe', 'billing'],
+                title: 'invoice.paid · $4,820.00',
+            }),
+        description: 'Informational receipt at the minimum priority — silent by design',
+        expect: 'posted',
+        group: 'showcase',
+        name: 'showcase-invoice-paid',
+    },
+    {
+        build: () =>
+            jsonRequest('home/sensors', {
+                body: 'Garage door has been open for 12 minutes. Nobody is home according to presence.',
+                priority: 3,
+                tags: ['home', 'sensor'],
+                title: 'Garage door open for 12m',
+            }),
+        description: 'Personal automation — topics are free-form, so this sits beside prod',
+        expect: 'posted',
+        group: 'showcase',
+        name: 'showcase-garage-door',
+    },
+];
+
+function buildPriorityScenarios(): Scenario[] {
+    return [1, 2, 3, 4, 5].map((priority) => ({
+        build: ({ topic }: ScenarioContext) =>
+            jsonRequest(topic, {
+                body: `Priority ${priority}: ${PRIORITY_LABELS[priority]}.`,
+                priority,
+                title: `Priority ${priority}`,
+            }),
+        description: `priority ${priority} (${PRIORITY_LABELS[priority]})`,
+        expect: 'posted' as const,
+        group: 'json' as const,
+        name: `priority-${priority}`,
+    }));
+}
+
+// Anything whose content-type is not application/json goes through
+// parsePublishHeaders, with the raw request body used as the message body.
+function headerRequest(
+    topic: string,
+    headers: Record<string, string>,
+    rawBody: string,
+): ScenarioRequest {
+    return {
+        body: rawBody,
+        headers: { 'content-type': 'text/plain; charset=utf-8', ...headers },
+        topic,
+    };
+}
+
+function jsonRequest(topic: string, payload: Record<string, unknown>): ScenarioRequest {
+    return {
+        body: JSON.stringify(payload),
+        headers: { 'content-type': 'application/json' },
+        topic,
+    };
+}

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -1,0 +1,435 @@
+#!/usr/bin/env bun
+// Exercises POST /topic/:name against a running EmitSignal server.
+//
+//   bun scripts/publish.ts --list
+//   bun scripts/publish.ts --topic my-topic
+//   bun scripts/publish.ts --group errors
+//   bun scripts/publish.ts --only action-view,header-basic --dry-run
+//
+// See scripts/README.md for the full option list.
+
+import type { Outcome, Scenario, ScenarioGroup, ScenarioRequest } from './publish-scenarios.ts';
+
+import { scenarios } from './publish-scenarios.ts';
+
+interface RunnerOptions {
+    baseUrl: string;
+    delayMilliseconds: number;
+    dryRun: boolean;
+    groups: string[];
+    names: string[];
+    retryOnRateLimit: boolean;
+    token: string;
+    topic: string;
+}
+
+interface ScenarioResult {
+    actual: 'unknown' | Outcome;
+    detail: string;
+    passed: boolean;
+    scenario: Scenario;
+    status: number;
+}
+
+const ANONYMOUS_RATE_LIMIT_PER_MINUTE = 10;
+const AUTHENTICATED_RATE_LIMIT_PER_MINUTE = 60;
+const MAX_RETRY_WAIT_SECONDS = 90;
+
+const color = {
+    bold: (value: string) => `[1m${value}[0m`,
+    dim: (value: string) => `[2m${value}[0m`,
+    green: (value: string) => `[32m${value}[0m`,
+    red: (value: string) => `[31m${value}[0m`,
+    violet: (value: string) => `[35m${value}[0m`,
+    yellow: (value: string) => `[33m${value}[0m`,
+};
+
+await main();
+
+function authHeaders(token: string): Record<string, string> {
+    if (!token) {
+        return {};
+    }
+
+    // The server resolves both Bearer session tokens and es_ API keys from the
+    // Authorization header; x-api-key is the documented secondary header.
+    const headers: Record<string, string> = { authorization: `Bearer ${token}` };
+
+    if (token.startsWith('es_')) {
+        headers['x-api-key'] = token;
+    }
+
+    return headers;
+}
+
+// Publish failures come back two ways: a real 4xx, or HTTP 200 carrying an
+// `error` field. Both count as the `error` outcome.
+function classify(status: number, payload: unknown): 'unknown' | Outcome {
+    if (status >= 400) {
+        return 'error';
+    }
+
+    if (isRecord(payload)) {
+        if ('error' in payload) {
+            return 'error';
+        }
+
+        if (payload.message === 'scheduled') {
+            return 'scheduled';
+        }
+
+        if (payload.message === 'posted') {
+            return 'posted';
+        }
+    }
+
+    return 'unknown';
+}
+
+function describePayload(status: number, payload: unknown): string {
+    if (isRecord(payload)) {
+        if (typeof payload.messageId === 'string') {
+            const scheduledAt =
+                typeof payload.scheduledAt === 'number'
+                    ? ` at ${new Date(payload.scheduledAt * 1000).toISOString()}`
+                    : '';
+
+            return `${payload.messageId}${scheduledAt}`;
+        }
+
+        if (typeof payload.error === 'string') {
+            const message = typeof payload.message === 'string' ? `: ${payload.message}` : '';
+
+            return `${payload.error}${message}`;
+        }
+
+        if (payload.type === 'validation') {
+            return typeof payload.summary === 'string' ? payload.summary : 'validation failed';
+        }
+    }
+
+    return typeof payload === 'string' ? payload.slice(0, 120) : `HTTP ${status}`;
+}
+
+function groupNames(): string[] {
+    return [...new Set(scenarios.map((scenario) => scenario.group))].sort();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+async function main(): Promise<void> {
+    const argv = process.argv.slice(2);
+
+    if (argv.includes('--help') || argv.includes('-h')) {
+        printHelp();
+
+        return;
+    }
+
+    const options = parseArguments(argv);
+    const selected = selectScenarios(options);
+
+    if (argv.includes('--list')) {
+        printList(selected);
+
+        return;
+    }
+
+    if (selected.length === 0) {
+        console.error(color.red('no scenarios matched the given --group/--only filters'));
+
+        process.exit(1);
+    }
+
+    console.log(
+        `${color.bold('EmitSignal publish suite')} ${color.dim(
+            `· ${selected.length} scenario(s) · ${options.baseUrl} · topic ${options.topic}`,
+        )}`,
+    );
+    console.log(
+        color.dim(
+            options.token
+                ? `authenticated · limit ${AUTHENTICATED_RATE_LIMIT_PER_MINUTE} publishes/min`
+                : `anonymous · limit ${ANONYMOUS_RATE_LIMIT_PER_MINUTE} publishes/min — pass --token for a faster run`,
+        ),
+    );
+    console.log('');
+
+    const results: ScenarioResult[] = [];
+    const context = { now: Math.floor(Date.now() / 1000), topic: options.topic };
+
+    for (const [index, scenario] of selected.entries()) {
+        const request = scenario.build({ ...context, now: Math.floor(Date.now() / 1000) });
+
+        if (options.dryRun) {
+            console.log(`${color.violet(scenario.name)} ${color.dim(scenario.description)}`);
+            console.log(`${toCurl(options, request)}\n`);
+
+            continue;
+        }
+
+        const result = await runScenario(options, scenario, request);
+
+        results.push(result);
+        printResult(result);
+
+        const isLast = index === selected.length - 1;
+
+        if (!isLast && options.delayMilliseconds > 0) {
+            await sleep(options.delayMilliseconds);
+        }
+    }
+
+    if (options.dryRun) {
+        return;
+    }
+
+    printSummary(results);
+}
+
+function parseArguments(argv: string[]): RunnerOptions {
+    const options: RunnerOptions = {
+        baseUrl: (process.env.EMITSIGNAL_API_URL ?? 'http://localhost:5001').replace(/\/+$/, ''),
+        delayMilliseconds: Number(process.env.EMITSIGNAL_DELAY_MS ?? '0'),
+        dryRun: false,
+        groups: [],
+        names: [],
+        retryOnRateLimit: true,
+        token: process.env.EMITSIGNAL_TOKEN ?? '',
+        topic: process.env.EMITSIGNAL_TOPIC ?? 'publish-playground',
+    };
+
+    let delayWasSet = options.delayMilliseconds > 0;
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const argument = argv[index];
+        const next = (): string => {
+            const value = argv[index + 1];
+
+            if (value === undefined) {
+                console.error(color.red(`missing value for ${argument}`));
+
+                process.exit(1);
+            }
+
+            index += 1;
+
+            return value;
+        };
+
+        switch (argument) {
+            case '--delay':
+                options.delayMilliseconds = Number(next());
+                delayWasSet = true;
+                break;
+            case '--dry-run':
+                options.dryRun = true;
+                break;
+            case '--group':
+                options.groups.push(...splitList(next()));
+                break;
+            case '--list':
+                break;
+            case '--no-retry':
+                options.retryOnRateLimit = false;
+                break;
+            case '--only':
+                options.names.push(...splitList(next()));
+                break;
+            case '--token':
+                options.token = next();
+                break;
+            case '--topic':
+                options.topic = next();
+                break;
+            case '--url':
+                options.baseUrl = next().replace(/\/+$/, '');
+                break;
+            default:
+                console.error(color.red(`unknown option: ${argument}`));
+
+                process.exit(1);
+        }
+    }
+
+    if (!delayWasSet) {
+        // Stay just under the server-side publish limiter so a full run does
+        // not spend most of its time waiting out 429s.
+        const perMinute = options.token
+            ? AUTHENTICATED_RATE_LIMIT_PER_MINUTE
+            : ANONYMOUS_RATE_LIMIT_PER_MINUTE;
+
+        options.delayMilliseconds = Math.ceil(60_000 / perMinute) + 100;
+    }
+
+    return options;
+}
+
+function printHelp(): void {
+    console.log(`${color.bold('bun scripts/publish.ts')} — exercise POST /topic/:name
+
+Options
+  --url <base>      API base URL              (env EMITSIGNAL_API_URL, default http://localhost:5001)
+  --topic <name>    Topic to publish to       (env EMITSIGNAL_TOPIC, default publish-playground)
+  --token <token>   Session token or es_ API key (env EMITSIGNAL_TOKEN)
+  --group <names>   Comma-separated groups: ${groupNames().join(', ')}
+  --only <names>    Comma-separated scenario names or substrings
+  --delay <ms>      Pause between publishes   (default: derived from the server rate limit)
+  --no-retry        Fail fast on 429 instead of waiting out the limiter
+  --dry-run         Print the equivalent curl command instead of publishing
+  --list            List the matching scenarios and exit
+  -h, --help        Show this help
+
+Exit code is 1 when any scenario's outcome differs from what the route should return.`);
+}
+
+function printList(selected: Scenario[]): void {
+    let currentGroup = '';
+
+    for (const scenario of selected) {
+        if (scenario.group !== currentGroup) {
+            currentGroup = scenario.group;
+
+            console.log(`\n${color.bold(currentGroup)}`);
+        }
+
+        console.log(
+            `  ${color.violet(scenario.name.padEnd(30))} ${color.dim(`[${scenario.expect}]`)} ${
+                scenario.description
+            }`,
+        );
+    }
+
+    console.log('');
+}
+
+function printResult(result: ScenarioResult): void {
+    const badge = result.passed ? color.green('PASS') : color.red('FAIL');
+    const outcome = result.passed
+        ? result.actual
+        : `${result.actual}, expected ${result.scenario.expect}`;
+
+    console.log(
+        `${badge} ${result.scenario.name.padEnd(30)} ${color.dim(
+            `${result.status} ${outcome}`,
+        )} · ${result.detail}`,
+    );
+}
+
+function printSummary(results: ScenarioResult[]): void {
+    const failed = results.filter((result) => !result.passed);
+
+    console.log('');
+    console.log(
+        `${color.bold('summary')} ${color.green(`${results.length - failed.length} passed`)}${
+            failed.length > 0 ? ` · ${color.red(`${failed.length} failed`)}` : ''
+        }`,
+    );
+
+    if (failed.length > 0) {
+        for (const result of failed) {
+            console.log(
+                `  ${color.red(result.scenario.name)} — ${result.scenario.description} (${result.detail})`,
+            );
+        }
+
+        process.exit(1);
+    }
+}
+
+function publishUrl(baseUrl: string, topic: string): string {
+    return `${baseUrl}/topic/${encodeURIComponent(topic)}`;
+}
+
+async function readPayload(response: Response): Promise<unknown> {
+    const text = await response.text();
+
+    try {
+        return JSON.parse(text);
+    } catch {
+        return text;
+    }
+}
+
+async function runScenario(
+    options: RunnerOptions,
+    scenario: Scenario,
+    request: ScenarioRequest,
+): Promise<ScenarioResult> {
+    let response = await send(options, request);
+
+    if (response.status === 429 && options.retryOnRateLimit) {
+        const waitSeconds = Math.min(
+            MAX_RETRY_WAIT_SECONDS,
+            Number(response.headers.get('retry-after')) || 60,
+        );
+
+        console.log(color.yellow(`  rate limited — waiting ${waitSeconds}s before retrying`));
+
+        await sleep(waitSeconds * 1000);
+
+        response = await send(options, request);
+    }
+
+    const payload = await readPayload(response);
+    const actual = classify(response.status, payload);
+
+    return {
+        actual,
+        detail: describePayload(response.status, payload),
+        passed: actual === scenario.expect,
+        scenario,
+        status: response.status,
+    };
+}
+
+function selectScenarios(options: RunnerOptions): Scenario[] {
+    return scenarios.filter((scenario) => {
+        const matchesGroup =
+            options.groups.length === 0 || options.groups.includes(scenario.group as ScenarioGroup);
+        const matchesName =
+            options.names.length === 0 ||
+            options.names.some((name) => scenario.name.includes(name));
+
+        return matchesGroup && matchesName;
+    });
+}
+
+function send(options: RunnerOptions, request: ScenarioRequest): Promise<Response> {
+    return fetch(publishUrl(options.baseUrl, request.topic), {
+        body: request.body,
+        headers: { ...request.headers, ...authHeaders(options.token) },
+        method: 'POST',
+    });
+}
+
+function shellQuote(value: string): string {
+    return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function sleep(milliseconds: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function splitList(value: string): string[] {
+    return value
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+}
+
+function toCurl(options: RunnerOptions, request: ScenarioRequest): string {
+    const headers = { ...request.headers, ...authHeaders(options.token) };
+    const parts = ['curl -sS -X POST'];
+
+    for (const [key, value] of Object.entries(headers)) {
+        parts.push(`  -H ${shellQuote(`${key}: ${value}`)}`);
+    }
+
+    parts.push(`  --data ${shellQuote(request.body)}`);
+    parts.push(`  ${shellQuote(publishUrl(options.baseUrl, request.topic))}`);
+
+    return parts.join(' \\\n');
+}


### PR DESCRIPTION
One command regenerates every App Store and Play screenshot:

```bash
bun run showcase                      # all devices, all scenes
bun run showcase --device iphone-6.9  # one device
```

Captures 7 scenes on iPhone 6.9", iPad 13" and a Play phone, then converts each
PNG to 24-bit RGB and validates it against the store's spec before the run is
allowed to pass.

No UI automation. Navigation is deep links; the anonymous device id and the
onboarding flag are read and written straight out of the app's AsyncStorage, and
subscriptions go through the public API. No app or server changes.

Derived from the screenshot harness in
[pingdotgg/t3code](https://github.com/pingdotgg/t3code) (MIT) — see
`scripts/mobile-showcase/LICENSE.upstream`.

Two things to know:

- Settings renders the signed-out state, since the harness never signs in.
- `packages/emitsignal-website/public/static/showcase` is gitignored, so a fresh
  clone has no banner images until those files are restored.