### PR TITLE
feat: apex publish URL and shared publish example builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ No SDK required to send — if it can make an HTTP request, it can emit a signal
 **Publish a message** — header-based, no body parsing required:
 
 ```bash
-curl -X POST https://api.emitsignal.com/publish/alerts \
+curl -X POST https://emitsignal.com/publish/alerts \
   -H "X-Title: Deploy finished" \
   -H "X-Priority: high" \
   -H "X-Tags: ci,prod" \
@@ -39,7 +39,7 @@ curl -X POST https://api.emitsignal.com/publish/alerts \
 **Or send JSON, authenticated with an API key:**
 
 ```bash
-curl -X POST https://api.emitsignal.com/publish/alerts \
+curl -X POST https://emitsignal.com/publish/alerts \
   -H "Authorization: Bearer es_your_api_key" \
   -H "Content-Type: application/json" \
   -d '{ "title": "Latency alert", "body": "p99 over 800ms", "priority": 5, "tags": ["prod"] }'
@@ -58,7 +58,7 @@ curl -N "https://api.emitsignal.com/listen?topics=alerts,ci,deploys&since=$(($(d
 **Schedule for later** — relative durations (`30m`, `2h`, `1d`) or a unix timestamp:
 
 ```bash
-curl -X POST https://api.emitsignal.com/publish/reminders \
+curl -X POST https://emitsignal.com/publish/reminders \
   -H "X-Title: Stand-up in 30 minutes" \
   -H "X-Delay: 30m" \
   -d "Don't forget the daily"

--- a/packages/emitsignal-docker/docker-compose.yml
+++ b/packages/emitsignal-docker/docker-compose.yml
@@ -245,6 +245,7 @@ services:
             dockerfile: packages/emitsignal-docker/website/Dockerfile
             args:
                 VITE_API_URL: '${API_URL:-http://localhost:5100}'
+                VITE_PUBLISH_BASE_URL: '${PUBLISH_BASE_URL:-}'
                 VITE_SENTRY_DSN: '${VITE_SENTRY_DSN:-}'
                 VITE_SENTRY_ENABLED: '${VITE_SENTRY_ENABLED:-false}'
         environment:

--- a/packages/emitsignal-docker/website/Dockerfile
+++ b/packages/emitsignal-docker/website/Dockerfile
@@ -42,6 +42,10 @@ WORKDIR /app/packages/emitsignal-website
 ARG VITE_API_URL=http://localhost:3333
 ENV VITE_API_URL=${VITE_API_URL}
 
+# Host shown in the curl snippets only; empty falls back to VITE_API_URL at runtime.
+ARG VITE_PUBLISH_BASE_URL=
+ENV VITE_PUBLISH_BASE_URL=${VITE_PUBLISH_BASE_URL}
+
 # VITE_SENTRY_DSN/VITE_SENTRY_ENABLED are read via import.meta.env and baked
 # into the client bundle at build time, so they must be build args (unlike the
 # server-side SENTRY_DSN/SENTRY_ENABLED, which are read from process.env at

--- a/packages/emitsignal-docs/api/index.mdx
+++ b/packages/emitsignal-docs/api/index.mdx
@@ -27,6 +27,10 @@ and every language works.
 https://api.emitsignal.com
 ```
 
+Publishing also accepts the shorter `https://emitsignal.com/publish/<topic>`, which is what the
+examples below use. That alias covers `POST /publish/*` only — listening, webhooks, auth and every
+other endpoint require the API host above.
+
 Self-hosting? Point the CLI at your own instance with `emitsignal config set-url`, or
 set `ES_BASE_URL`. Auth routes live under `/api/auth/*`; everything else is at the
 root.
@@ -37,11 +41,11 @@ root.
 
 ```bash No auth — public publish
 # Publish to any topic. The topic is created on first publish.
-curl -d "hello from curl" https://api.emitsignal.com/publish/welcome
+curl -d "hello from curl" https://emitsignal.com/publish/welcome
 ```
 
 ```bash Authenticated publish
-curl https://api.emitsignal.com/publish/deploy/prod \
+curl https://emitsignal.com/publish/deploy/prod \
   -H "Authorization: Bearer es_xxxxxxxxxxxx" \
   -H "Content-Type: application/json" \
   -d '{"title": "v2.14.3 shipped", "body": "api-gateway deployed", "priority": 4}'

--- a/packages/emitsignal-docs/api/publish.mdx
+++ b/packages/emitsignal-docs/api/publish.mdx
@@ -13,6 +13,12 @@ authenticated publish applies your plan's daily message quota and attributes the
 sender.
 
 <Note>
+    Publishing answers on two hosts: `https://emitsignal.com/publish/<topic>` (shorter, used in the
+    examples here) and `https://api.emitsignal.com/publish/<topic>`. They hit the same endpoint with the
+    same limits. Only publishing is aliased — every other endpoint requires the API host.
+</Note>
+
+<Note>
     `POST /topic/<topic>` is the former path for this endpoint. It still works and behaves
     identically, but it is deprecated: responses carry a `Deprecation` header and a `Link` header
     pointing at `/publish/`. Move publishers to `/publish/` when convenient.
@@ -61,7 +67,7 @@ Send `Content-Type: application/json` with any of these fields. At least one of
 </ParamField>
 
 ```bash
-curl https://api.emitsignal.com/publish/deploy/prod \
+curl https://emitsignal.com/publish/deploy/prod \
   -H "Authorization: Bearer es_xxx" \
   -H "Content-Type: application/json" \
   -d '{
@@ -78,7 +84,7 @@ If the request `Content-Type` is **not** `application/json`, the raw body become
 message and metadata is read from headers. This is what `curl -d` uses by default.
 
 ```bash
-curl https://api.emitsignal.com/publish/alerts/prod \
+curl https://emitsignal.com/publish/alerts/prod \
   -H "Authorization: Bearer es_xxx" \
   -H "title: High memory on api-02" \
   -H "x-priority: urgent" \

--- a/packages/emitsignal-mobile/.env.example
+++ b/packages/emitsignal-mobile/.env.example
@@ -1,5 +1,6 @@
 # API base URL
 EXPO_PUBLIC_API_URL=http://127.0.0.1:5001
+EXPO_PUBLIC_PUBLISH_BASE_URL=
 
 # Sentry error tracking (optional)
 EXPO_PUBLIC_SENTRY_DSN=

--- a/packages/emitsignal-mobile/app/(tabs)/publish.tsx
+++ b/packages/emitsignal-mobile/app/(tabs)/publish.tsx
@@ -1,4 +1,4 @@
-import { TOPIC_NAME_MAX_LENGTH } from '@emitsignal/shared/topic';
+import { publishUrl, TOPIC_NAME_MAX_LENGTH } from '@emitsignal/shared/topic';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { router } from 'expo-router';
 import { useState } from 'react';
@@ -20,7 +20,7 @@ import { IconSymbol } from '@/components/ui/icon-symbol';
 import { Fonts, type Palette } from '@/constants/theme';
 import { useTabBarInset } from '@/hooks/use-tab-bar-inset';
 import { useThemedStyles } from '@/hooks/use-themed-styles';
-import { api } from '@/lib/api';
+import { api, PUBLISH_BASE_URL } from '@/lib/api';
 import { queryKeys } from '@/lib/query-client';
 
 const TOPIC_PLACEHOLDER = 'deploy/prod';
@@ -72,7 +72,7 @@ export default function PublishScreen() {
 
     const curl = `curl -d "${body}" \\
   -H "Content-Type: application/json" \\
-  ${api.baseUrl}/publish/${curlTopic}`;
+  ${publishUrl(PUBLISH_BASE_URL, curlTopic)}`;
 
     return (
         <SafeAreaView edges={['top']} style={styles.root}>

--- a/packages/emitsignal-mobile/app/(tabs)/publish.tsx
+++ b/packages/emitsignal-mobile/app/(tabs)/publish.tsx
@@ -1,4 +1,5 @@
-import { publishUrl, TOPIC_NAME_MAX_LENGTH } from '@emitsignal/shared/topic';
+import { buildCurlExample } from '@emitsignal/shared/publish-example';
+import { TOPIC_NAME_MAX_LENGTH } from '@emitsignal/shared/topic';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { router } from 'expo-router';
 import { useState } from 'react';
@@ -70,9 +71,19 @@ export default function PublishScreen() {
 
     const curlTopic = topic.trim() || TOPIC_PLACEHOLDER;
 
-    const curl = `curl -d "${body}" \\
-  -H "Content-Type: application/json" \\
-  ${publishUrl(PUBLISH_BASE_URL, curlTopic)}`;
+    const curl = buildCurlExample({
+        baseUrl: PUBLISH_BASE_URL,
+        message: {
+            body,
+            priority,
+            tags: tags
+                .split(',')
+                .map((tag) => tag.trim())
+                .filter(Boolean),
+            title,
+        },
+        topicName: curlTopic,
+    });
 
     return (
         <SafeAreaView edges={['top']} style={styles.root}>

--- a/packages/emitsignal-mobile/app/messages/[id].tsx
+++ b/packages/emitsignal-mobile/app/messages/[id].tsx
@@ -1,4 +1,4 @@
-import { publishUrl } from '@emitsignal/shared/topic';
+import { buildCurlExample } from '@emitsignal/shared/publish-example';
 import { useQuery } from '@tanstack/react-query';
 import { router, useLocalSearchParams } from 'expo-router';
 import { useState } from 'react';
@@ -74,6 +74,18 @@ export default function MessageDetailScreen() {
 
     const priorityLabel =
         priority >= 5 ? 'max' : priority === 4 ? 'high' : priority === 3 ? 'default' : 'low';
+
+    const curlCommand = buildCurlExample({
+        baseUrl: PUBLISH_BASE_URL,
+        message: {
+            actions: message.actions,
+            body: message.body,
+            priority: message.priority,
+            tags: message.tags,
+            title: message.title,
+        },
+        topicName: message.topicName ?? message.topicId,
+    });
 
     return (
         <SafeAreaView edges={['top']} style={styles.root}>
@@ -211,17 +223,7 @@ export default function MessageDetailScreen() {
                     <>
                         <SectionHead>reproduce · curl</SectionHead>
                         <View style={styles.codeWrap}>
-                            <WCode language="BASH">
-                                {`curl -X POST ${publishUrl(PUBLISH_BASE_URL, message.topicName ?? message.topicId)} \\
-  -H "Content-Type: application/json" \\
-  -d '${JSON.stringify({
-      actions: message.actions.length ? message.actions : undefined,
-      body: message.body,
-      priority: message.priority,
-      tags: message.tags,
-      title: message.title,
-  })}'`}
-                            </WCode>
+                            <WCode language="BASH">{curlCommand}</WCode>
                         </View>
                     </>
                 ) : null}

--- a/packages/emitsignal-mobile/app/messages/[id].tsx
+++ b/packages/emitsignal-mobile/app/messages/[id].tsx
@@ -1,3 +1,4 @@
+import { publishUrl } from '@emitsignal/shared/topic';
 import { useQuery } from '@tanstack/react-query';
 import { router, useLocalSearchParams } from 'expo-router';
 import { useState } from 'react';
@@ -14,7 +15,7 @@ import { Fonts, type Palette, PriorityColors } from '@/constants/theme';
 import { useDebugSections } from '@/ctx/debug-sections';
 import { useDevice } from '@/ctx/device';
 import { useThemedStyles } from '@/hooks/use-themed-styles';
-import { api } from '@/lib/api';
+import { api, PUBLISH_BASE_URL } from '@/lib/api';
 import { relativeTime } from '@/lib/format';
 import { openExternalUrl } from '@/lib/open-external';
 import { queryKeys } from '@/lib/query-client';
@@ -211,7 +212,7 @@ export default function MessageDetailScreen() {
                         <SectionHead>reproduce · curl</SectionHead>
                         <View style={styles.codeWrap}>
                             <WCode language="BASH">
-                                {`curl -X POST ${api.baseUrl}/publish/${message.topicName} \\
+                                {`curl -X POST ${publishUrl(PUBLISH_BASE_URL, message.topicName ?? message.topicId)} \\
   -H "Content-Type: application/json" \\
   -d '${JSON.stringify({
       actions: message.actions.length ? message.actions : undefined,

--- a/packages/emitsignal-mobile/app/modal.tsx
+++ b/packages/emitsignal-mobile/app/modal.tsx
@@ -1,4 +1,5 @@
-import { publishUrl, TOPIC_NAME_MAX_LENGTH } from '@emitsignal/shared/topic';
+import { buildCliExample, buildCurlExample } from '@emitsignal/shared/publish-example';
+import { TOPIC_NAME_MAX_LENGTH } from '@emitsignal/shared/topic';
 import { router, Stack } from 'expo-router';
 import { useState } from 'react';
 import {
@@ -56,6 +57,17 @@ export default function SubscribeModal() {
             setBusy(false);
         }
     };
+
+    const publishSnippet = `# from your shell
+${buildCurlExample({
+    baseUrl: PUBLISH_BASE_URL,
+    message: { body: 'hello' },
+    style: 'headers',
+    topicName: topic,
+})}
+
+# from EmitSignal cli
+${buildCliExample({ message: { body: 'deploy ok' }, topicName: topic })}`;
 
     return (
         <>
@@ -150,13 +162,7 @@ export default function SubscribeModal() {
                         {topic && (
                             <View style={styles.section}>
                                 <Text style={styles.sectionLabel}>PUBLISH FROM</Text>
-                                <WCode language="BASH">
-                                    {`# from your shell
-curl -d "hello" ${publishUrl(PUBLISH_BASE_URL, topic)}
-
-# from EmitSignal cli
-emitsignal publish ${topic} "deploy ok"`}
-                                </WCode>
+                                <WCode language="BASH">{publishSnippet}</WCode>
                             </View>
                         )}
                     </ScrollView>

--- a/packages/emitsignal-mobile/app/modal.tsx
+++ b/packages/emitsignal-mobile/app/modal.tsx
@@ -1,4 +1,4 @@
-import { TOPIC_NAME_MAX_LENGTH } from '@emitsignal/shared/topic';
+import { publishUrl, TOPIC_NAME_MAX_LENGTH } from '@emitsignal/shared/topic';
 import { router, Stack } from 'expo-router';
 import { useState } from 'react';
 import {
@@ -21,7 +21,7 @@ import { useDevice } from '@/ctx/device';
 import { useSubscriptions } from '@/hooks/use-subscriptions';
 import { useThemedStyles } from '@/hooks/use-themed-styles';
 import { useTopicSuggestions } from '@/hooks/use-topic-suggestions';
-import { api, type ListenSince } from '@/lib/api';
+import { api, type ListenSince, PUBLISH_BASE_URL } from '@/lib/api';
 import { apiErrorMessage } from '@/lib/api-error';
 
 export default function SubscribeModal() {
@@ -152,7 +152,7 @@ export default function SubscribeModal() {
                                 <Text style={styles.sectionLabel}>PUBLISH FROM</Text>
                                 <WCode language="BASH">
                                     {`# from your shell
-curl -d "hello" ${api.baseUrl}/publish/${topic}
+curl -d "hello" ${publishUrl(PUBLISH_BASE_URL, topic)}
 
 # from EmitSignal cli
 emitsignal publish ${topic} "deploy ok"`}

--- a/packages/emitsignal-mobile/lib/api.ts
+++ b/packages/emitsignal-mobile/lib/api.ts
@@ -7,4 +7,7 @@ export * from '@emitsignal/shared/api';
 export const API_URL =
     process.env.EXPO_PUBLIC_API_URL?.replace(/\/$/, '') ?? 'http://127.0.0.1:5001';
 
+export const PUBLISH_BASE_URL =
+    process.env.EXPO_PUBLIC_PUBLISH_BASE_URL?.replace(/\/$/, '') ?? API_URL;
+
 export const { api, getAuthToken, setAuthToken, sseMultiUrl, sseUrl } = createApiClient(API_URL);

--- a/packages/emitsignal-shared/package.json
+++ b/packages/emitsignal-shared/package.json
@@ -6,6 +6,7 @@
         "./format": "./src/format.ts",
         "./message-filters": "./src/message-filters.ts",
         "./priority": "./src/priority.ts",
+        "./publish-example": "./src/publish-example.ts",
         "./topic": "./src/topic.ts",
         "./url": "./src/url.ts",
         "./webhook-template": "./src/webhook-template.ts",

--- a/packages/emitsignal-shared/src/index.ts
+++ b/packages/emitsignal-shared/src/index.ts
@@ -3,6 +3,7 @@ export * from './billing.ts';
 export * from './format.ts';
 export * from './message-filters.ts';
 export * from './priority.ts';
+export * from './publish-example.ts';
 export * from './topic.ts';
 export * from './url.ts';
 export * from './webhook-template.ts';

--- a/packages/emitsignal-shared/src/publish-example.test.ts
+++ b/packages/emitsignal-shared/src/publish-example.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from 'bun:test';
+
+import { buildCliExample, buildCurlExample } from './publish-example.ts';
+
+const BASE_URL = 'https://emitsignal.com';
+
+describe('buildCurlExample · json', () => {
+    test('builds a JSON publish command', () => {
+        expect(
+            buildCurlExample({
+                baseUrl: BASE_URL,
+                message: { body: 'shipped v2', priority: 4, tags: ['deploy'], title: 'Deploy' },
+                topicName: 'deploy/prod',
+            }),
+        ).toBe(
+            `curl -X POST https://emitsignal.com/publish/deploy/prod \\
+  -H "Content-Type: application/json" \\
+  -d '{"title":"Deploy","body":"shipped v2","priority":4,"tags":["deploy"]}'`,
+        );
+    });
+
+    test('adds an Authorization header when an API key is given', () => {
+        expect(
+            buildCurlExample({
+                apiKey: 'es_secret',
+                baseUrl: BASE_URL,
+                message: { body: 'hello' },
+                topicName: 'alerts',
+            }),
+        ).toBe(
+            `curl -X POST https://emitsignal.com/publish/alerts \\
+  -H "Authorization: Bearer es_secret" \\
+  -H "Content-Type: application/json" \\
+  -d '{"body":"hello"}'`,
+        );
+    });
+
+    test('omits empty fields from the payload', () => {
+        expect(
+            buildCurlExample({
+                baseUrl: BASE_URL,
+                message: { actions: [], body: 'hello', tags: [] },
+                topicName: 'alerts',
+            }),
+        ).toContain(`-d '{"body":"hello"}'`);
+    });
+
+    test('includes actions when present', () => {
+        expect(
+            buildCurlExample({
+                baseUrl: BASE_URL,
+                message: { actions: [{ type: 'acknowledge' }], body: 'hello' },
+                topicName: 'alerts',
+            }),
+        ).toContain(`"actions":[{"type":"acknowledge"}]`);
+    });
+
+    test('drops the body flags when the message is empty', () => {
+        expect(buildCurlExample({ baseUrl: BASE_URL, topicName: 'alerts' })).toBe(
+            'curl -X POST https://emitsignal.com/publish/alerts',
+        );
+    });
+
+    test('keeps a body containing a single quote pasteable', () => {
+        const command = buildCurlExample({
+            baseUrl: BASE_URL,
+            message: { body: "deploy didn't finish" },
+            topicName: 'alerts',
+        });
+
+        expect(command).toContain(`-d '{"body":"deploy didn'\\''t finish"}'`);
+    });
+});
+
+describe('buildCurlExample · headers', () => {
+    test('builds a single-line command when only a body is given', () => {
+        expect(
+            buildCurlExample({
+                baseUrl: BASE_URL,
+                message: { body: 'hello' },
+                style: 'headers',
+                topicName: 'alerts/prod',
+            }),
+        ).toBe('curl -d "hello" https://emitsignal.com/publish/alerts/prod');
+    });
+
+    test('emits title, priority and tag headers with the url last', () => {
+        expect(
+            buildCurlExample({
+                apiKey: 'es_secret',
+                baseUrl: BASE_URL,
+                message: { body: 'hello', priority: 5, tags: ['deploy', 'prod'], title: 'Hello' },
+                style: 'headers',
+                topicName: 'alerts',
+            }),
+        ).toBe(
+            `curl -d "hello" \\
+  -H "Authorization: Bearer es_secret" \\
+  -H "title: Hello" \\
+  -H "x-priority: 5" \\
+  -H "x-tags: deploy,prod" \\
+  https://emitsignal.com/publish/alerts`,
+        );
+    });
+
+    test('escapes double quotes in the body', () => {
+        expect(
+            buildCurlExample({
+                baseUrl: BASE_URL,
+                message: { body: 'say "hi"' },
+                style: 'headers',
+                topicName: 'alerts',
+            }),
+        ).toContain('curl -d "say \\"hi\\""');
+    });
+});
+
+describe('buildCliExample', () => {
+    test('publishes a body with no flags at the default priority', () => {
+        expect(
+            buildCliExample({ message: { body: 'deploy ok', priority: 3 }, topicName: 'alerts' }),
+        ).toBe('emitsignal publish alerts "deploy ok"');
+    });
+
+    test('adds priority, title and tag flags', () => {
+        expect(
+            buildCliExample({
+                message: {
+                    body: 'shipped v2',
+                    priority: 4,
+                    tags: ['deploy', 'prod'],
+                    title: 'Deploy',
+                },
+                topicName: 'deploy/prod',
+            }),
+        ).toBe('emitsignal publish deploy/prod "shipped v2" -p4 -T "Deploy" -t "deploy,prod"');
+    });
+
+    test('skips the title flag when it repeats the body', () => {
+        expect(
+            buildCliExample({ message: { body: 'hello', title: 'hello' }, topicName: 'a' }),
+        ).toBe('emitsignal publish a "hello"');
+    });
+});

--- a/packages/emitsignal-shared/src/publish-example.ts
+++ b/packages/emitsignal-shared/src/publish-example.ts
@@ -1,0 +1,164 @@
+import type { Action } from './api.ts';
+
+import { publishUrl } from './topic.ts';
+
+export interface CliExampleOptions {
+    message?: PublishExampleMessage;
+    topicName: string;
+}
+
+export interface CurlExampleOptions {
+    apiKey?: string;
+    baseUrl: string;
+    message?: PublishExampleMessage;
+    style?: PublishExampleStyle;
+    topicName: string;
+}
+
+export interface PublishExampleMessage {
+    actions?: Action[];
+    body?: string;
+    priority?: number;
+    tags?: string[];
+    title?: string;
+}
+
+export type PublishExampleStyle = 'headers' | 'json';
+
+const DEFAULT_PRIORITY = 3;
+
+const CONTINUATION = ' \\\n  ';
+
+export function buildCliExample({ message = {}, topicName }: CliExampleOptions): string {
+    const parts = [`emitsignal publish ${topicName}`];
+
+    if (message.body) {
+        parts.push(doubleQuote(message.body));
+    }
+
+    if (message.priority && message.priority !== DEFAULT_PRIORITY) {
+        parts.push(`-p${message.priority}`);
+    }
+
+    if (message.title && message.title !== message.body) {
+        parts.push(`-T ${doubleQuote(message.title)}`);
+    }
+
+    if (message.tags?.length) {
+        parts.push(`-t ${doubleQuote(message.tags.join(','))}`);
+    }
+
+    return parts.join(' ');
+}
+
+export function buildCurlExample({
+    apiKey,
+    baseUrl,
+    message = {},
+    style = 'json',
+    topicName,
+}: CurlExampleOptions): string {
+    const url = publishUrl(baseUrl, topicName);
+
+    if (style === 'headers') {
+        return buildHeaderStyleCurl(url, apiKey, message);
+    }
+
+    return buildJsonStyleCurl(url, apiKey, message);
+}
+
+function authorizationHeader(apiKey: string | undefined): string[] {
+    if (!apiKey) {
+        return [];
+    }
+
+    return [`-H ${doubleQuote(`Authorization: Bearer ${apiKey}`)}`];
+}
+
+function buildHeaderStyleCurl(
+    url: string,
+    apiKey: string | undefined,
+    message: PublishExampleMessage,
+): string {
+    const headers = authorizationHeader(apiKey);
+
+    if (message.title) {
+        headers.push(`-H ${doubleQuote(`title: ${message.title}`)}`);
+    }
+
+    if (message.priority) {
+        headers.push(`-H ${doubleQuote(`x-priority: ${message.priority}`)}`);
+    }
+
+    if (message.tags?.length) {
+        headers.push(`-H ${doubleQuote(`x-tags: ${message.tags.join(',')}`)}`);
+    }
+
+    const command = `curl -d ${doubleQuote(message.body ?? '')}`;
+
+    if (headers.length === 0) {
+        return `${command} ${url}`;
+    }
+
+    return [command, ...headers, url].join(CONTINUATION);
+}
+
+function buildJsonStyleCurl(
+    url: string,
+    apiKey: string | undefined,
+    message: PublishExampleMessage,
+): string {
+    const payload = jsonPayload(message);
+    const lines = [`curl -X POST ${url}`, ...authorizationHeader(apiKey)];
+
+    if (payload) {
+        lines.push(
+            `-H ${doubleQuote('Content-Type: application/json')}`,
+            `-d ${singleQuote(payload)}`,
+        );
+    }
+
+    return lines.join(CONTINUATION);
+}
+
+// Shell-safe double quoting: the interpolated title/body come from user content,
+// so a bare `"` or `$` would otherwise break the command the user pastes.
+function doubleQuote(value: string): string {
+    return `"${value.replace(/(["$\\`])/g, '\\$1')}"`;
+}
+
+function jsonPayload(message: PublishExampleMessage): null | string {
+    const payload: Record<string, unknown> = {};
+
+    if (message.title) {
+        payload.title = message.title;
+    }
+
+    if (message.body) {
+        payload.body = message.body;
+    }
+
+    if (message.priority) {
+        payload.priority = message.priority;
+    }
+
+    if (message.tags?.length) {
+        payload.tags = message.tags;
+    }
+
+    if (message.actions?.length) {
+        payload.actions = message.actions;
+    }
+
+    if (Object.keys(payload).length === 0) {
+        return null;
+    }
+
+    return JSON.stringify(payload);
+}
+
+// A single-quoted shell word cannot contain an escaped quote; it has to be
+// closed, given a literal quote, and reopened.
+function singleQuote(value: string): string {
+    return `'${value.replace(/'/g, `'\\''`)}'`;
+}

--- a/packages/emitsignal-shared/src/topic.test.ts
+++ b/packages/emitsignal-shared/src/topic.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+
+import { publishUrl } from './topic.ts';
+
+describe('publishUrl', () => {
+    test('appends the publish path to the base URL', () => {
+        expect(publishUrl('https://api.emitsignal.com', 'alerts')).toBe(
+            'https://api.emitsignal.com/publish/alerts',
+        );
+    });
+
+    test('formats the apex alias the same way', () => {
+        expect(publishUrl('https://emitsignal.com', 'alerts')).toBe(
+            'https://emitsignal.com/publish/alerts',
+        );
+    });
+
+    test('keeps the separator in a nested topic literal', () => {
+        expect(publishUrl('https://emitsignal.com', 'alerts/prod')).toBe(
+            'https://emitsignal.com/publish/alerts/prod',
+        );
+    });
+
+    test('strips a trailing slash from the base URL', () => {
+        expect(publishUrl('https://emitsignal.com/', 'alerts')).toBe(
+            'https://emitsignal.com/publish/alerts',
+        );
+    });
+
+    test('supports a base URL with a port', () => {
+        expect(publishUrl('http://localhost:5001', 'deploy/prod')).toBe(
+            'http://localhost:5001/publish/deploy/prod',
+        );
+    });
+});

--- a/packages/emitsignal-shared/src/topic.ts
+++ b/packages/emitsignal-shared/src/topic.ts
@@ -4,3 +4,7 @@ export const TOPIC_NAME_REGEX = /^[a-z0-9][a-z0-9/_-]*[a-z0-9]$/i;
 export function isValidTopicName(name: string): boolean {
     return name.length <= TOPIC_NAME_MAX_LENGTH && TOPIC_NAME_REGEX.test(name);
 }
+
+export function publishUrl(baseUrl: string, topicName: string): string {
+    return `${baseUrl.replace(/\/$/, '')}/publish/${topicName}`;
+}

--- a/packages/emitsignal-website/.env.example
+++ b/packages/emitsignal-website/.env.example
@@ -1,13 +1,12 @@
-# API base URL
-VITE_API_URL=http://localhost:5001
+# Sentry error tracking — SSR server (optional, read at runtime)
+SENTRY_DSN=
+SENTRY_ENABLED=false
 
-# Site URL (used for absolute links in blog/RSS/OG tags)
-VITE_SITE_URL=https://emitsignal.com
+VITE_API_URL=http://localhost:5001
+VITE_PUBLISH_BASE_URL=
 
 # Sentry error tracking — client bundle (optional, baked in at build time)
 VITE_SENTRY_DSN=
 VITE_SENTRY_ENABLED=false
 
-# Sentry error tracking — SSR server (optional, read at runtime)
-SENTRY_DSN=
-SENTRY_ENABLED=false
+VITE_SITE_URL=https://emitsignal.com

--- a/packages/emitsignal-website/src/components/app/channels/routing-rail.tsx
+++ b/packages/emitsignal-website/src/components/app/channels/routing-rail.tsx
@@ -1,8 +1,9 @@
+import { publishUrl } from '@emitsignal/shared/topic';
 import { Plus } from 'lucide-react';
 
 import { Code } from '#/components/ui/code';
 import { SubHeading } from '#/components/ui/sub-head';
-import { API_URL, type Subscription } from '#/lib/api';
+import { PUBLISH_BASE_URL, type Subscription } from '#/lib/api';
 
 interface RoutingRule {
     color: string;
@@ -59,7 +60,9 @@ export function RoutingRail({ subscription }: Props) {
             <SubHeading>PUBLISH A MESSAGE</SubHeading>
 
             <Code language="POST">
-                {topicName ? `${API_URL}/publish/${topicName}` : 'subscribe to a channel first'}
+                {topicName
+                    ? publishUrl(PUBLISH_BASE_URL, topicName)
+                    : 'subscribe to a channel first'}
             </Code>
         </aside>
     );

--- a/packages/emitsignal-website/src/components/app/inbox/preview.tsx
+++ b/packages/emitsignal-website/src/components/app/inbox/preview.tsx
@@ -1,4 +1,4 @@
-import { publishUrl } from '@emitsignal/shared/topic';
+import { buildCurlExample } from '@emitsignal/shared/publish-example';
 import { safeExternalUrl } from '@emitsignal/shared/url';
 import { ExternalLink } from 'lucide-react';
 import { useState } from 'react';
@@ -66,15 +66,17 @@ export function InboxPreview({ message }: { message: Message | null }) {
         2,
     );
 
-    const curlCommand = `curl -X POST ${publishUrl(PUBLISH_BASE_URL, channel)} \\
-  -H "Content-Type: application/json" \\
-  -d '${JSON.stringify({
-      actions: message.actions.length ? message.actions : undefined,
-      body: message.body,
-      priority: message.priority,
-      tags: message.tags,
-      title: message.title,
-  })}'`;
+    const curlCommand = buildCurlExample({
+        baseUrl: PUBLISH_BASE_URL,
+        message: {
+            actions: message.actions,
+            body: message.body,
+            priority: message.priority,
+            tags: message.tags,
+            title: message.title,
+        },
+        topicName: channel,
+    });
 
     return (
         <div className="min-w-0 flex-1 overflow-auto p-7">

--- a/packages/emitsignal-website/src/components/app/inbox/preview.tsx
+++ b/packages/emitsignal-website/src/components/app/inbox/preview.tsx
@@ -1,3 +1,4 @@
+import { publishUrl } from '@emitsignal/shared/topic';
 import { safeExternalUrl } from '@emitsignal/shared/url';
 import { ExternalLink } from 'lucide-react';
 import { useState } from 'react';
@@ -11,7 +12,7 @@ import { LinkWarningDialog } from '#/components/ui/link-warning-dialog';
 import { Pill } from '#/components/ui/pill';
 import { SubHeading } from '#/components/ui/sub-head';
 import { useDebugSections } from '#/ctx/debug-sections';
-import { API_URL } from '#/lib/api';
+import { PUBLISH_BASE_URL } from '#/lib/api';
 import { relativeTime } from '#/lib/format';
 import { priorityHex } from '#/lib/priority';
 
@@ -65,7 +66,7 @@ export function InboxPreview({ message }: { message: Message | null }) {
         2,
     );
 
-    const curlCommand = `curl -X POST ${API_URL}/publish/${encodeURIComponent(channel)} \\
+    const curlCommand = `curl -X POST ${publishUrl(PUBLISH_BASE_URL, channel)} \\
   -H "Content-Type: application/json" \\
   -d '${JSON.stringify({
       actions: message.actions.length ? message.actions : undefined,

--- a/packages/emitsignal-website/src/components/app/keys/create-key-dialog.tsx
+++ b/packages/emitsignal-website/src/components/app/keys/create-key-dialog.tsx
@@ -1,6 +1,8 @@
+import { publishUrl } from '@emitsignal/shared/topic';
 import { AlertTriangle, Check, Key, Plus } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
+import { PUBLISH_BASE_URL } from '#/lib/api';
 import { authClient } from '#/lib/auth-client';
 
 const EXPIRY_OPTIONS = [
@@ -90,7 +92,7 @@ export function CreateKeyDialog({ onClose, onCreated, open, revealData }: Create
     };
 
     const curlExample = reveal
-        ? `curl emitsignal.sh/publish \\\n  -H "Authorization: Bearer ${reveal.secret}" \\\n  -d topic=my-topic -d "msg=hello"`
+        ? `curl -X POST ${publishUrl(PUBLISH_BASE_URL, 'my-topic')} \\\n  -H "Authorization: Bearer ${reveal.secret}" \\\n  -H "title: Hello" \\\n  -d "hello from my new key"`
         : '';
 
     if (!open) {

--- a/packages/emitsignal-website/src/components/app/keys/create-key-dialog.tsx
+++ b/packages/emitsignal-website/src/components/app/keys/create-key-dialog.tsx
@@ -1,4 +1,4 @@
-import { publishUrl } from '@emitsignal/shared/topic';
+import { buildCurlExample } from '@emitsignal/shared/publish-example';
 import { AlertTriangle, Check, Key, Plus } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
@@ -92,7 +92,13 @@ export function CreateKeyDialog({ onClose, onCreated, open, revealData }: Create
     };
 
     const curlExample = reveal
-        ? `curl -X POST ${publishUrl(PUBLISH_BASE_URL, 'my-topic')} \\\n  -H "Authorization: Bearer ${reveal.secret}" \\\n  -H "title: Hello" \\\n  -d "hello from my new key"`
+        ? buildCurlExample({
+              apiKey: reveal.secret,
+              baseUrl: PUBLISH_BASE_URL,
+              message: { body: 'hello from my new key', title: 'Hello' },
+              style: 'headers',
+              topicName: 'my-topic',
+          })
         : '';
 
     if (!open) {

--- a/packages/emitsignal-website/src/components/app/publish/preview-column.tsx
+++ b/packages/emitsignal-website/src/components/app/publish/preview-column.tsx
@@ -1,7 +1,9 @@
+import { publishUrl } from '@emitsignal/shared/topic';
+
 import { Code } from '#/components/ui/code';
 import { Dot } from '#/components/ui/dot';
 import { SubHeading } from '#/components/ui/sub-head';
-import { api } from '#/lib/api';
+import { PUBLISH_BASE_URL } from '#/lib/api';
 import { DELIVERY_FLAG_ENABLED } from '#/lib/feature-flags';
 
 interface Props {
@@ -14,7 +16,7 @@ interface Props {
 
 export function PreviewColumn({ body, priority, tags, title, topicName }: Props) {
     const curlCmd = topicName
-        ? `curl -X POST ${api.baseUrl}/publish/${topicName} \\
+        ? `curl -X POST ${publishUrl(PUBLISH_BASE_URL, topicName)} \\
   -H "Authorization: Bearer es_••••" \\
   -H "Priority: ${priority}" \\
   -H "Content-Type: application/json" \\

--- a/packages/emitsignal-website/src/components/app/publish/preview-column.tsx
+++ b/packages/emitsignal-website/src/components/app/publish/preview-column.tsx
@@ -1,4 +1,4 @@
-import { publishUrl } from '@emitsignal/shared/topic';
+import { buildCurlExample } from '@emitsignal/shared/publish-example';
 
 import { Code } from '#/components/ui/code';
 import { Dot } from '#/components/ui/dot';
@@ -16,11 +16,12 @@ interface Props {
 
 export function PreviewColumn({ body, priority, tags, title, topicName }: Props) {
     const curlCmd = topicName
-        ? `curl -X POST ${publishUrl(PUBLISH_BASE_URL, topicName)} \\
-  -H "Authorization: Bearer es_••••" \\
-  -H "Priority: ${priority}" \\
-  -H "Content-Type: application/json" \\
-  -d '${JSON.stringify({ body: body || '...', priority, tags, title: title || '...' })}'`
+        ? buildCurlExample({
+              apiKey: 'es_••••',
+              baseUrl: PUBLISH_BASE_URL,
+              message: { body: body || '...', priority, tags, title: title || '...' },
+              topicName,
+          })
         : 'fill in topic to see curl example';
 
     return (

--- a/packages/emitsignal-website/src/components/landing/mock-publish.tsx
+++ b/packages/emitsignal-website/src/components/landing/mock-publish.tsx
@@ -1,10 +1,12 @@
+import { publishUrl } from '@emitsignal/shared/topic';
 import { Bell } from 'lucide-react';
 
 import { CopyButton } from '#/components/ui/copy-button';
 import { Dot } from '#/components/ui/dot';
-import { API_URL_CLEAN } from '#/lib/api';
+import { PUBLISH_BASE_URL_CLEAN } from '#/lib/api';
 
-const COMMAND = `curl -d "Production API latency spike" -H "x-priority: 5" ${API_URL_CLEAN}/alerts/prod`;
+const ENDPOINT = publishUrl(PUBLISH_BASE_URL_CLEAN, 'alerts/prod');
+const COMMAND = `curl -d "Production API latency spike" -H "x-priority: 5" ${ENDPOINT}`;
 
 export function MockPublish() {
     return (
@@ -16,7 +18,7 @@ export function MockPublish() {
                     <span className="text-warn">"Production API latency spike"</span>{' '}
                     <span className="text-dim">-H</span>{' '}
                     <span className="text-warn">"x-priority: 5"</span>{' '}
-                    <span className="text-accent">{API_URL_CLEAN}/alerts/prod</span>
+                    <span className="text-accent">{ENDPOINT}</span>
                 </code>
 
                 <CopyButton className="shrink-0" value={COMMAND} />

--- a/packages/emitsignal-website/src/components/mobile/feature-tabs.tsx
+++ b/packages/emitsignal-website/src/components/mobile/feature-tabs.tsx
@@ -1,7 +1,8 @@
+import { publishUrl } from '@emitsignal/shared/topic';
 import { Bell, Inbox, Radio, Send } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
-import { API_URL_CLEAN } from '#/lib/api';
+import { PUBLISH_BASE_URL_CLEAN } from '#/lib/api';
 import { cn } from '#/lib/cn';
 
 /** How long a tab holds before the strip advances on its own. */
@@ -198,7 +199,9 @@ function QuickstartCard() {
                     <span className="text-warn">&quot;Content-Type: application/json&quot;</span>
                     <span className="text-dim"> \</span>
                     {'\n  '}
-                    <span className="text-accent">{API_URL_CLEAN}/publish/deploy/prod</span>
+                    <span className="text-accent">
+                        {publishUrl(PUBLISH_BASE_URL_CLEAN, 'deploy/prod')}
+                    </span>
                 </code>
             </div>
 

--- a/packages/emitsignal-website/src/lib/api.ts
+++ b/packages/emitsignal-website/src/lib/api.ts
@@ -8,4 +8,7 @@ export * from '@emitsignal/shared/message-filters';
 export const API_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:5001';
 export const API_URL_CLEAN = new URL(API_URL).host;
 
+export const PUBLISH_BASE_URL = import.meta.env.VITE_PUBLISH_BASE_URL ?? API_URL;
+export const PUBLISH_BASE_URL_CLEAN = new URL(PUBLISH_BASE_URL).host;
+
 export const { api, setAuthToken, sseMultiUrl, sseUrl } = createApiClient(API_URL);


### PR DESCRIPTION
## Summary

Adds a short publish alias (`POST /publish/<topic>` on the apex domain) and makes every surface build its publish examples from one shared place.

## Apex publish URL

- `PUBLISH_BASE_URL` is configurable in Docker and in the mobile/web env, with Traefik routing for the `/publish` endpoint.
- `publishUrl(baseUrl, topicName)` lands in `@emitsignal/shared/topic` and replaces the hand-built endpoint strings across mobile and web.
- README and docs point at the shorter alias.

## Shared publish examples

`packages/emitsignal-shared/src/publish-example.ts` exposes two builders:

- `buildCurlExample({ apiKey?, baseUrl, message?, style?, topicName })` — `style: 'json'` (default) emits `curl -X POST … -H "Content-Type: application/json" -d '<json>'`; `style: 'headers'` emits the header form (`title`, `x-priority`, `x-tags`) and collapses to a single line when no headers are set.
- `buildCliExample({ message?, topicName })` — `emitsignal publish <topic> "<body>" -p4 -T "…" -t "…"`, matching the real flags in `emitsignal-cli/src/commands/publish.ts`.

Six hand-rolled snippets now call these instead. Along the way this fixes:

1. The mobile publish tab advertised `Content-Type: application/json` while sending a raw string body — the quickstart curl now matches what the form posts.
2. Every JSON snippet interpolated `JSON.stringify(...)` inside single quotes, so a title or body containing `'` produced a command that could not be pasted. Shell quoting is now handled once.
3. `Priority:` vs `x-priority:` disagreed between the publish preview and the landing page; `x-priority` is now canonical.

`landing/mock-publish.tsx` is deliberately left alone — its hand-colored single-line markup does not fit the multi-line builder output.

## Test plan

- `bun test` in `emitsignal-shared` — 38 pass, including 12 new tests for the builders.
- `vitest run` in `emitsignal-website` — 22 pass.
- `tsc --noEmit` clean for website and mobile.
- `bun lint` clean, `bun format` a no-op.

Note: running `bun test` from the repo root surfaces 22 pre-existing failures in website `.test.tsx` files (`document is not defined` — jsdom specs picked up by the Bun runner). Same count on `main`; unrelated to this branch.
