### PR TITLE
chore(docker): upgrade base image to oven/bun:1.4.0-slim

### DIFF
--- a/packages/emitsignal-docker/server/Dockerfile
+++ b/packages/emitsignal-docker/server/Dockerfile
@@ -4,7 +4,7 @@
 # ── Stage 1: Install the server's production dependencies only ─────────────────
 # Pinned + slim: a rolling `oven/bun:1` tag changes digest on every upstream 1.x
 # release, busting the whole build cache; pin to a known-good version.
-FROM oven/bun:1.3.14-slim AS deps
+FROM oven/bun:1.4.0-slim AS deps
 
 WORKDIR /app
 
@@ -33,7 +33,7 @@ RUN bun pm pkg delete devDependencies patchedDependencies \
 RUN rm -f bun.lock && bun install --production
 
 # ── Stage 2: Production image ─────────────────────────────────────────────────
-FROM oven/bun:1.3.14-slim
+FROM oven/bun:1.4.0-slim
 
 WORKDIR /app
 

--- a/packages/emitsignal-docker/website/Dockerfile
+++ b/packages/emitsignal-docker/website/Dockerfile
@@ -3,7 +3,7 @@
 
 # ── Stage 1: Build the TanStack Start / Nitro SSR bundle ──────────────────────
 # Pinned + slim: avoids cache-busting digest changes on rolling `oven/bun:1`.
-FROM oven/bun:1.3.14-slim AS build
+FROM oven/bun:1.4.0-slim AS build
 
 WORKDIR /app
 
@@ -59,7 +59,7 @@ ENV VITE_SENTRY_ENABLED=${VITE_SENTRY_ENABLED}
 RUN bun run build
 
 # ── Stage 2: Run the Nitro SSR server ────────────────────────────────────────
-FROM oven/bun:1.3.14-slim
+FROM oven/bun:1.4.0-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
Bumps the pinned Bun base image from `oven/bun:1.3.14-slim` to `oven/bun:1.4.0-slim` in the server and website Dockerfiles.

## Why

Bun 1.4 is out: https://bun.sh/blog/bun-v1.4

## Changes

- `packages/emitsignal-docker/server/Dockerfile` — both stages (deps + production)
- `packages/emitsignal-docker/website/Dockerfile` — both stages (build + Nitro SSR runtime)

Pins stay explicit so the build cache is not busted by rolling `oven/bun:1` digests.