### PR TITLE
Add a permanent lifetime counter of published messages

### DIFF
--- a/packages/emitsignal-server/prisma/migrations/20260819120000_counter/migration.sql
+++ b/packages/emitsignal-server/prisma/migrations/20260819120000_counter/migration.sql
@@ -1,0 +1,8 @@
+-- CreateTable
+CREATE TABLE "Counter" (
+    "key" TEXT NOT NULL,
+    "total" BIGINT NOT NULL DEFAULT 0,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Counter_pkey" PRIMARY KEY ("key")
+);

--- a/packages/emitsignal-server/prisma/schema.prisma
+++ b/packages/emitsignal-server/prisma/schema.prisma
@@ -206,6 +206,13 @@ model Acknowledgment {
     @@index([userId])
 }
 
+model Counter {
+    key       String   @id
+
+    total     BigInt   @default(0)
+    updatedAt DateTime @updatedAt
+}
+
 model Message {
     id        String   @id @default(cuid())
 

--- a/packages/emitsignal-server/src/__tests__/mocks.ts
+++ b/packages/emitsignal-server/src/__tests__/mocks.ts
@@ -1,6 +1,7 @@
 import { mock } from 'bun:test';
 
 export const prismaMock = {
+    $executeRaw: mock<() => Promise<number>>(() => Promise.resolve(1)),
     $queryRaw: mock<() => Promise<unknown[]>>(() => Promise.resolve([])),
     acknowledgment: {
         count: mock<() => Promise<number>>(() => Promise.resolve(0)),
@@ -17,6 +18,9 @@ export const prismaMock = {
         findMany: mock<(args?: Record<string, unknown>) => Promise<object[]>>(() =>
             Promise.resolve([]),
         ),
+    },
+    counter: {
+        findUnique: mock<() => Promise<{ total: bigint } | null>>(() => Promise.resolve(null)),
     },
     message: {
         create: mock<() => Promise<object>>(() =>

--- a/packages/emitsignal-server/src/http/stats/get.ts
+++ b/packages/emitsignal-server/src/http/stats/get.ts
@@ -1,0 +1,7 @@
+import Elysia from 'elysia';
+
+import { readMessageTotal } from '#/services/stats/message-counter';
+
+export const stats = new Elysia().get('/stats', async () => ({
+    messages: await readMessageTotal(),
+}));

--- a/packages/emitsignal-server/src/http/topic/__tests__/publish.spec.ts
+++ b/packages/emitsignal-server/src/http/topic/__tests__/publish.spec.ts
@@ -16,6 +16,7 @@ mock.module('#/lib/queue', () => ({
 mock.module('#/lib/storage', () => ({ FileStorageService: fileStorageMock }));
 
 import { publish } from '#/http/topic/publish';
+import { readMessageTotal, resetMessageCounterForTests } from '#/services/stats/message-counter';
 
 describe('POST /publish/:name', () => {
     const app = new Elysia().use(publish);
@@ -55,6 +56,15 @@ describe('POST /publish/:name', () => {
 
         expect(lastCall[0]).toBe('push-message');
         expect(lastCall[1]).toHaveProperty('messageId', 'msg-1');
+    });
+
+    it('counts the message against the lifetime total', async () => {
+        resetMessageCounterForTests();
+
+        await app.handle(request('test-topic', validBody));
+        await app.handle(request('test-topic', validBody));
+
+        expect(await readMessageTotal()).toBe(2);
     });
 
     it('publishes to event bus', async () => {

--- a/packages/emitsignal-server/src/http/topic/publish.ts
+++ b/packages/emitsignal-server/src/http/topic/publish.ts
@@ -12,6 +12,7 @@ import { getUserLimits, getUserPlan } from '#/services/billing/get-user-plan';
 import { messageExpiresAt, messageRetentionDays } from '#/services/billing/retention';
 import { consumeDailyQuota, quotaExceededHeaders } from '#/services/billing/usage';
 import { serializeMessage } from '#/services/message';
+import { incrementMessageCounter } from '#/services/stats/message-counter';
 import { getOrCreateTopic, TopicNameError } from '#/services/topic';
 import { resolveTopicCapabilities } from '#/services/topic-access';
 import { validateActions } from '#/utils/actions';
@@ -184,6 +185,8 @@ function publishRoute(path: string, deprecated: boolean) {
                     topicId: topic.id,
                 },
             });
+
+            void incrementMessageCounter();
 
             if (isScheduled) {
                 scheduleQueue.add(

--- a/packages/emitsignal-server/src/http/webhooks/receive.ts
+++ b/packages/emitsignal-server/src/http/webhooks/receive.ts
@@ -20,6 +20,7 @@ import {
     webhookRetentionDays,
 } from '#/services/billing/retention';
 import { serializeMessage } from '#/services/message';
+import { incrementMessageCounter } from '#/services/stats/message-counter';
 import { getOrCreateTopic } from '#/services/topic';
 import { canPublishToTopicName } from '#/services/topic-access';
 import { validateActions } from '#/utils/actions';
@@ -144,6 +145,8 @@ export const receiveWebhook = new Elysia().post(
                 topicId: topic.id,
             },
         });
+
+        void incrementMessageCounter();
 
         const event = await serializeMessage({ ...message, topicId: topic.id }, 0, false);
 

--- a/packages/emitsignal-server/src/index.ts
+++ b/packages/emitsignal-server/src/index.ts
@@ -17,6 +17,7 @@ import { deletePushToken } from '#/http/push-tokens/delete';
 import { listPushTokens } from '#/http/push-tokens/list';
 import { registerPushToken } from '#/http/push-tokens/register';
 import { updatePushToken } from '#/http/push-tokens/update';
+import { stats } from '#/http/stats/get';
 import { claimSubscriptions } from '#/http/subscriptions/claim';
 import { listSubscriptions } from '#/http/subscriptions/list';
 import { listSubscriptionMessages } from '#/http/subscriptions/messages';
@@ -109,6 +110,7 @@ const app = new Elysia({
     .use(receiveWebhook)
     .use(registerPushToken)
     .use(serveUpload)
+    .use(stats)
     .use(streamWebhookDeliveries)
     .use(subscribe)
     .use(subscriptionMetrics)

--- a/packages/emitsignal-server/src/index.ts
+++ b/packages/emitsignal-server/src/index.ts
@@ -50,7 +50,7 @@ import { EmailService } from '#/lib/email-service';
 import { shutdownTelemetry } from '#/lib/instrumentation';
 import { flushLogs, logger } from '#/lib/logger';
 import { emailQueue, purgeQueue, pushQueue, redisConnection, scheduleQueue } from '#/lib/queue';
-import { rateLimitRedis } from '#/lib/rate-limit';
+import { redis } from '#/lib/redis';
 import { FileStorageService } from '#/lib/storage';
 import { environment, isProduction } from '#/schema/environment';
 import { isUnobservedPath } from '#/utils/observability';
@@ -158,7 +158,7 @@ async function shutdown() {
     await pushQueue.close();
     await scheduleQueue.close();
 
-    await rateLimitRedis.quit();
+    await redis.quit();
     await redisConnection.quit();
 
     server.stop();

--- a/packages/emitsignal-server/src/lib/queue/connection.ts
+++ b/packages/emitsignal-server/src/lib/queue/connection.ts
@@ -3,6 +3,9 @@ import Redis from 'ioredis';
 import { logger } from '#/lib/logger';
 import { environment } from '#/schema/environment';
 
+// maxRetriesPerRequest: null because workers park on blocking commands (BZPOPMIN
+// for up to 10s); failing those fast would break job fetching. Request paths want
+// the opposite and use `#/lib/redis`.
 export const redisConnection = new Redis(environment.REDIS_URL, {
     enableReadyCheck: false,
     maxRetriesPerRequest: null,

--- a/packages/emitsignal-server/src/lib/queue/index.ts
+++ b/packages/emitsignal-server/src/lib/queue/index.ts
@@ -1,7 +1,11 @@
 export { redisConnection } from './connection';
 export { emailQueue } from '#/lib/queue/email/email-queue';
 export { createEmailWorker } from '#/lib/queue/email/email-worker';
-export { purgeQueue, scheduleRetentionSweep } from '#/lib/queue/purge/purge-queue';
+export {
+    purgeQueue,
+    scheduleCounterFlush,
+    scheduleRetentionSweep,
+} from '#/lib/queue/purge/purge-queue';
 export { createPurgeWorker } from '#/lib/queue/purge/purge-worker';
 export { pushQueue } from '#/lib/queue/push/push-queue';
 export { createPushWorker } from '#/lib/queue/push/push-worker';

--- a/packages/emitsignal-server/src/lib/queue/purge/purge-queue.ts
+++ b/packages/emitsignal-server/src/lib/queue/purge/purge-queue.ts
@@ -9,7 +9,7 @@ import type { PurgeJob } from './types';
 export const purgeQueue = new Queue<
     Traced<PurgeJob>,
     void,
-    'purge-expired' | 'purge-signals' | 'purge-storage'
+    'flush-counters' | 'purge-expired' | 'purge-signals' | 'purge-storage'
 >('purge', {
     connection: redisConnection as ConnectionOptions,
     defaultJobOptions: {
@@ -19,6 +19,14 @@ export const purgeQueue = new Queue<
         removeOnFail: { age: duration.hours(24).as('seconds'), count: 1000 },
     },
 });
+
+export async function scheduleCounterFlush(): Promise<void> {
+    await purgeQueue.upsertJobScheduler(
+        'flush-counters',
+        { every: duration.minutes(5).as('ms') },
+        { data: { kind: 'counters' }, name: 'flush-counters' },
+    );
+}
 
 // Registers the hourly retention sweep. Idempotent — safe to call from every
 // worker replica at boot; BullMQ dedupes by the scheduler id.

--- a/packages/emitsignal-server/src/lib/queue/purge/purge-worker.ts
+++ b/packages/emitsignal-server/src/lib/queue/purge/purge-worker.ts
@@ -6,6 +6,7 @@ import { prisma } from '#/lib/prisma';
 import { redisConnection } from '#/lib/queue/connection';
 import { FileStorageService } from '#/lib/storage';
 import { traceContextFrom, Traced } from '#/lib/trace-context';
+import { flushMessageCounter } from '#/services/stats/message-counter';
 
 import type { PurgeJob } from './types';
 
@@ -37,7 +38,9 @@ export function createPurgeWorker(): Worker<Traced<PurgeJob>> {
                     try {
                         logger.info({ jobId: job.id, kind: job.data.kind }, 'processing purge job');
 
-                        if (job.data.kind === 'expired') {
+                        if (job.data.kind === 'counters') {
+                            await flushMessageCounter();
+                        } else if (job.data.kind === 'expired') {
                             await purgeExpired();
                         } else if (job.data.kind === 'signals') {
                             await purgeSignals(job.data.userId);

--- a/packages/emitsignal-server/src/lib/queue/purge/types.ts
+++ b/packages/emitsignal-server/src/lib/queue/purge/types.ts
@@ -3,9 +3,13 @@
 // `signals` runs while the user still exists: it deletes every message the user
 // owns (in their topics) or sent into others' topics, keeping the topics intact.
 //
+// `counters` flushes the lifetime message counter into its durable row; it
+// deletes nothing, and rides this queue only to reuse the worker.
+//
 // `storage` runs after an account has been deleted: the DB rows are already gone
 // via cascade, so the job only removes the orphaned files from object storage.
 export type PurgeJob =
     | { avatarKey?: string; kind: 'storage'; storageKeys: string[] }
+    | { kind: 'counters' }
     | { kind: 'expired' }
     | { kind: 'signals'; userId: string };

--- a/packages/emitsignal-server/src/lib/rate-limit/limiters.ts
+++ b/packages/emitsignal-server/src/lib/rate-limit/limiters.ts
@@ -1,18 +1,7 @@
-import Redis from 'ioredis';
 import { RateLimiterMemory, RateLimiterRedis } from 'rate-limiter-flexible';
 
-import { logger } from '#/lib/logger';
-import { environment } from '#/schema/environment';
+import { redis } from '#/lib/redis';
 import { duration } from '#/utils/duration';
-
-export const rateLimitRedis = new Redis(environment.REDIS_URL, {
-    enableReadyCheck: false,
-    maxRetriesPerRequest: 0,
-});
-
-rateLimitRedis.on('error', (error: Error) => {
-    logger.error({ error }, 'rate limit redis connection error');
-});
 
 function makeLimiter(keyPrefix: string, points: number, windowSeconds: number) {
     if (Bun.env.NODE_ENV === 'test') {
@@ -23,7 +12,7 @@ function makeLimiter(keyPrefix: string, points: number, windowSeconds: number) {
         duration: windowSeconds,
         keyPrefix,
         points,
-        storeClient: rateLimitRedis,
+        storeClient: redis,
     });
 }
 

--- a/packages/emitsignal-server/src/lib/rate-limit/sse-slot.ts
+++ b/packages/emitsignal-server/src/lib/rate-limit/sse-slot.ts
@@ -1,6 +1,5 @@
+import { redis } from '#/lib/redis';
 import { duration } from '#/utils/duration';
-
-import { rateLimitRedis } from './limiters';
 
 const SLOT_TTL_SECONDS = duration.minutes(2).as('seconds');
 
@@ -25,11 +24,11 @@ export async function acquireSseSlot(key: string, max: number): Promise<null | S
     }
 
     try {
-        const current = await rateLimitRedis.incr(key);
-        await rateLimitRedis.expire(key, SLOT_TTL_SECONDS);
+        const current = await redis.incr(key);
+        await redis.expire(key, SLOT_TTL_SECONDS);
 
         if (current > max) {
-            await rateLimitRedis.decr(key);
+            await redis.decr(key);
 
             return null;
         }
@@ -39,7 +38,7 @@ export async function acquireSseSlot(key: string, max: number): Promise<null | S
         return {
             refresh: async () => {
                 try {
-                    await rateLimitRedis.expire(key, SLOT_TTL_SECONDS);
+                    await redis.expire(key, SLOT_TTL_SECONDS);
                 } catch {
                     // non-fatal — a missed refresh only shortens the TTL window
                 }
@@ -52,7 +51,7 @@ export async function acquireSseSlot(key: string, max: number): Promise<null | S
                 released = true;
 
                 try {
-                    await rateLimitRedis.decr(key);
+                    await redis.decr(key);
                 } catch {
                     // non-fatal — key will expire via TTL
                 }

--- a/packages/emitsignal-server/src/lib/redis.ts
+++ b/packages/emitsignal-server/src/lib/redis.ts
@@ -1,0 +1,16 @@
+import Redis from 'ioredis';
+
+import { logger } from '#/lib/logger';
+import { environment } from '#/schema/environment';
+
+// maxRetriesPerRequest: 0 is what lets callers fail open instead of stalling a
+// request behind a retrying command. BullMQ needs the opposite and keeps its own
+// connection in `#/lib/queue/connection`.
+export const redis = new Redis(environment.REDIS_URL, {
+    enableReadyCheck: false,
+    maxRetriesPerRequest: 0,
+});
+
+redis.on('error', (error: Error) => {
+    logger.error({ error }, 'redis connection error');
+});

--- a/packages/emitsignal-server/src/services/billing/get-user-plan.ts
+++ b/packages/emitsignal-server/src/services/billing/get-user-plan.ts
@@ -3,7 +3,7 @@ import type { PlanLimits, PlanName } from '@emitsignal/shared';
 import { isPlanName, PLANS } from '@emitsignal/shared';
 
 import { prisma } from '#/lib/prisma';
-import { rateLimitRedis } from '#/lib/rate-limit';
+import { redis } from '#/lib/redis';
 import { duration } from '#/utils/duration';
 
 const PLAN_CACHE_TTL_SECONDS = 60;
@@ -36,7 +36,7 @@ export async function getUserPlan(userId: string): Promise<PlanName> {
     }
 
     try {
-        const cached = await rateLimitRedis.get(cacheKey(userId));
+        const cached = await redis.get(cacheKey(userId));
 
         if (cached && isPlanName(cached)) {
             return cached;
@@ -48,7 +48,7 @@ export async function getUserPlan(userId: string): Promise<PlanName> {
     const plan = await resolvePlanFromDatabase(userId);
 
     try {
-        await rateLimitRedis.setex(cacheKey(userId), PLAN_CACHE_TTL_SECONDS, plan);
+        await redis.setex(cacheKey(userId), PLAN_CACHE_TTL_SECONDS, plan);
     } catch {
         // Redis unavailable — skip caching
     }
@@ -64,7 +64,7 @@ export async function invalidateUserPlanCache(userId: string): Promise<void> {
     }
 
     try {
-        await rateLimitRedis.del(cacheKey(userId));
+        await redis.del(cacheKey(userId));
     } catch {
         // non-fatal — the key expires via TTL
     }

--- a/packages/emitsignal-server/src/services/billing/usage.ts
+++ b/packages/emitsignal-server/src/services/billing/usage.ts
@@ -1,5 +1,5 @@
 import { logger } from '#/lib/logger';
-import { rateLimitRedis } from '#/lib/rate-limit';
+import { redis } from '#/lib/redis';
 import { duration } from '#/utils/duration';
 
 export interface QuotaResult {
@@ -36,10 +36,10 @@ export async function consumeDailyQuota(
 
     try {
         const key = usageKey(userId, metric);
-        const used = await rateLimitRedis.incr(key);
+        const used = await redis.incr(key);
 
         if (used === 1) {
-            await rateLimitRedis.expire(key, KEY_TTL_SECONDS);
+            await redis.expire(key, KEY_TTL_SECONDS);
         }
 
         return { allowed: used <= limit, limit, remaining: Math.max(0, limit - used), resetAt };
@@ -56,7 +56,7 @@ export async function getDailyUsage(userId: string, metric: UsageMetric): Promis
     }
 
     try {
-        const raw = await rateLimitRedis.get(usageKey(userId, metric));
+        const raw = await redis.get(usageKey(userId, metric));
 
         return raw ? Math.max(0, Number.parseInt(raw, 10)) : 0;
     } catch {

--- a/packages/emitsignal-server/src/services/stats/__tests__/message-counter.spec.ts
+++ b/packages/emitsignal-server/src/services/stats/__tests__/message-counter.spec.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+import { prismaMock } from '#/__tests__/mocks';
+
+mock.module('#/lib/prisma', () => ({ prisma: prismaMock }));
+
+import {
+    flushMessageCounter,
+    incrementMessageCounter,
+    readMessageTotal,
+    resetMessageCounterForTests,
+} from '#/services/stats/message-counter';
+
+function storedTotal(total: null | number): void {
+    prismaMock.counter.findUnique = mock(() =>
+        Promise.resolve(total === null ? null : { total: BigInt(total) }),
+    );
+}
+
+beforeEach(() => {
+    resetMessageCounterForTests();
+    storedTotal(null);
+    prismaMock.$executeRaw = mock(() => Promise.resolve(1));
+});
+
+describe('incrementMessageCounter', () => {
+    it('counts each published message', async () => {
+        await incrementMessageCounter();
+        await incrementMessageCounter();
+        await incrementMessageCounter();
+
+        expect(await readMessageTotal()).toBe(3);
+    });
+
+    it('resumes from the stored total when the live counter is missing', async () => {
+        storedTotal(500);
+
+        await incrementMessageCounter();
+
+        expect(await readMessageTotal()).toBe(501);
+    });
+
+    it('only folds the stored total in once', async () => {
+        storedTotal(500);
+
+        await incrementMessageCounter();
+        await incrementMessageCounter();
+
+        expect(await readMessageTotal()).toBe(502);
+    });
+
+    it('does not throw when the counter backend fails', async () => {
+        storedTotal(10);
+        prismaMock.counter.findUnique = mock(() => Promise.reject(new Error('redis down')));
+
+        await expect(incrementMessageCounter()).resolves.toBeUndefined();
+        expect(await readMessageTotal()).toBe(1);
+    });
+});
+
+describe('readMessageTotal', () => {
+    it('falls back to the stored total before anything is published', async () => {
+        storedTotal(42);
+
+        expect(await readMessageTotal()).toBe(42);
+    });
+
+    it('reports zero when neither the live nor the stored counter exists', async () => {
+        expect(await readMessageTotal()).toBe(0);
+    });
+});
+
+describe('flushMessageCounter', () => {
+    it('writes nothing when the live counter is absent', async () => {
+        await flushMessageCounter();
+
+        expect(prismaMock.$executeRaw).not.toHaveBeenCalled();
+    });
+
+    it('persists the live total', async () => {
+        await incrementMessageCounter();
+        await flushMessageCounter();
+
+        expect(prismaMock.$executeRaw).toHaveBeenCalledTimes(1);
+    });
+
+    it('is idempotent', async () => {
+        await incrementMessageCounter();
+
+        await flushMessageCounter();
+        await flushMessageCounter();
+
+        expect(await readMessageTotal()).toBe(1);
+    });
+});

--- a/packages/emitsignal-server/src/services/stats/message-counter.ts
+++ b/packages/emitsignal-server/src/services/stats/message-counter.ts
@@ -1,0 +1,88 @@
+import { logger } from '#/lib/logger';
+import { prisma } from '#/lib/prisma';
+import { redis } from '#/lib/redis';
+
+const COUNTER_KEY = 'messages';
+const REDIS_KEY = `counter:${COUNTER_KEY}`;
+
+const testCounters = new Map<string, number>();
+
+export async function flushMessageCounter(): Promise<void> {
+    const live = await readLiveTotal();
+
+    if (live === null) {
+        return;
+    }
+
+    // GREATEST, not assignment: a flush landing between a reseeding INCR and its
+    // INCRBY must not write the momentarily small live value over the total.
+    await prisma.$executeRaw`
+        INSERT INTO "Counter" ("key", "total", "updatedAt")
+        VALUES (${COUNTER_KEY}, ${BigInt(live)}, NOW())
+        ON CONFLICT ("key") DO UPDATE
+            SET "total" = GREATEST("Counter"."total", EXCLUDED."total"),
+                "updatedAt" = EXCLUDED."updatedAt"
+    `;
+}
+
+export async function incrementMessageCounter(): Promise<void> {
+    try {
+        const total = await addToLiveTotal(1);
+
+        // 1 means the key was absent, so Redis lost the total; fold it back in.
+        // Additive, so publishes racing with the reseed are still counted.
+        if (total === 1) {
+            const stored = await readStoredTotal();
+
+            if (stored > 0) {
+                await addToLiveTotal(stored);
+            }
+        }
+    } catch (error) {
+        logger.error({ error }, 'message counter increment failed');
+    }
+}
+
+export async function readMessageTotal(): Promise<number> {
+    try {
+        const live = await readLiveTotal();
+
+        return live === null ? await readStoredTotal() : live;
+    } catch (error) {
+        logger.error({ error }, 'message counter read failed');
+
+        return 0;
+    }
+}
+
+export function resetMessageCounterForTests(): void {
+    testCounters.clear();
+}
+
+async function addToLiveTotal(amount: number): Promise<number> {
+    if (Bun.env.NODE_ENV === 'test') {
+        const total = (testCounters.get(REDIS_KEY) ?? 0) + amount;
+
+        testCounters.set(REDIS_KEY, total);
+
+        return total;
+    }
+
+    return redis.incrby(REDIS_KEY, amount);
+}
+
+async function readLiveTotal(): Promise<null | number> {
+    if (Bun.env.NODE_ENV === 'test') {
+        return testCounters.get(REDIS_KEY) ?? null;
+    }
+
+    const raw = await redis.get(REDIS_KEY);
+
+    return raw === null ? null : Math.max(0, Number.parseInt(raw, 10));
+}
+
+async function readStoredTotal(): Promise<number> {
+    const counter = await prisma.counter.findUnique({ where: { key: COUNTER_KEY } });
+
+    return counter ? Number(counter.total) : 0;
+}

--- a/packages/emitsignal-server/src/workers/all.ts
+++ b/packages/emitsignal-server/src/workers/all.ts
@@ -5,6 +5,7 @@ import {
     createPurgeWorker,
     createPushWorker,
     createScheduleWorker,
+    scheduleCounterFlush,
     scheduleRetentionSweep,
 } from '#/lib/queue';
 import { runWorkers } from '#/lib/run-workers';
@@ -17,5 +18,6 @@ FileStorageService.init(environment);
 runWorkers([createEmailWorker(), createPushWorker(), createScheduleWorker(), createPurgeWorker()]);
 
 await scheduleRetentionSweep();
+await scheduleCounterFlush();
 
 logger.info('📧 email, 🔔 push, ⏱️ schedule, 🗑️ purge workers started');

--- a/packages/emitsignal-server/src/workers/purge.ts
+++ b/packages/emitsignal-server/src/workers/purge.ts
@@ -1,5 +1,5 @@
 import { logger } from '#/lib/logger';
-import { scheduleRetentionSweep } from '#/lib/queue';
+import { scheduleCounterFlush, scheduleRetentionSweep } from '#/lib/queue';
 import { createPurgeWorker } from '#/lib/queue/purge/purge-worker';
 import { runWorkers } from '#/lib/run-workers';
 import { FileStorageService } from '#/lib/storage';
@@ -10,5 +10,6 @@ FileStorageService.init(environment);
 runWorkers([createPurgeWorker()]);
 
 await scheduleRetentionSweep();
+await scheduleCounterFlush();
 
 logger.info('🗑️ purge worker started');


### PR DESCRIPTION
Messages are transient — the hourly retention sweep deletes them once `expiresAt` passes (7d anonymous through 365d on pulse), and `DELETE /me/signals` purges them outright. Every count we show is derived live from the `Message` table, so those numbers silently shrink as messages are retired and a true "messages published" figure can't be reconstructed.

This adds a lifetime total that only ever goes up, following the same two-tier pattern ntfy.sh uses, with Redis standing in for its in-process counter since we run the API and workers as separate processes:

- **Publish path** costs one Redis `INCR` — no added database write.
- **A `Counter` table** holds the durable copy, written every 5 minutes with the absolute Redis value (idempotent, no delta bookkeeping). Because that row isn't derived from `Message`, nothing in the purge path can decrement it.
- **`GET /stats`** returns `{ "messages": N }`, served straight from Redis.

The flush reuses the existing purge queue as a new `counters` job kind, so no new queue or worker process is involved.

Two details that keep it honest: an `INCR` returning `1` means Redis lost the key, so the stored total is folded back in — the counter self-heals after an eviction or flush; and the upsert uses `GREATEST`, which keeps the durable value monotonic if a flush lands mid-reseed.

The first commit is a standalone refactor: the shared Redis client was named `rateLimitRedis` but three of its five consumers (daily quotas, plan cache, and now this) aren't rate limiting. It moves to `lib/redis.ts` as `redis`. No behavior change — BullMQ keeps its own connection, which it needs for blocking commands.

## Verifying

Beyond the unit tests, I ran the service against a real Postgres and Redis:

```
after 5 publishes  live= 5
after flush        stored= 5
redis wiped        read= 5 (from DB row)
publish after wipe live= 6      # reseed, not a reset to 1
stored ahead       stored= 9999 # GREATEST guard holds
big value          stored= 5000000000  # BigInt round-trips
GET /stats -> 200 { messages: 5000000000 }
```

## Note for review

The counter starts at zero and does not backfill, so on an instance with existing messages it will read far below the visible message count. Seeding it once from `SELECT count(*) FROM "Message"` in the migration is a one-line change if we'd rather it launch closer to a true lifetime figure — happy to add it.
