### PR TITLE
Show the scheme in landing curl examples

### DIFF
--- a/packages/emitsignal-website/src/components/landing/mock-publish.tsx
+++ b/packages/emitsignal-website/src/components/landing/mock-publish.tsx
@@ -3,9 +3,9 @@ import { Bell } from 'lucide-react';
 
 import { CopyButton } from '#/components/ui/copy-button';
 import { Dot } from '#/components/ui/dot';
-import { PUBLISH_BASE_URL_CLEAN } from '#/lib/api';
+import { PUBLISH_BASE_URL } from '#/lib/api';
 
-const ENDPOINT = publishUrl(PUBLISH_BASE_URL_CLEAN, 'alerts/prod');
+const ENDPOINT = publishUrl(PUBLISH_BASE_URL, 'alerts/prod');
 const COMMAND = `curl -d "Production API latency spike" -H "x-priority: 5" ${ENDPOINT}`;
 
 export function MockPublish() {

--- a/packages/emitsignal-website/src/components/mobile/feature-tabs.tsx
+++ b/packages/emitsignal-website/src/components/mobile/feature-tabs.tsx
@@ -2,7 +2,7 @@ import { publishUrl } from '@emitsignal/shared/topic';
 import { Bell, Inbox, Radio, Send } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
-import { PUBLISH_BASE_URL_CLEAN } from '#/lib/api';
+import { PUBLISH_BASE_URL } from '#/lib/api';
 import { cn } from '#/lib/cn';
 
 /** How long a tab holds before the strip advances on its own. */
@@ -200,7 +200,7 @@ function QuickstartCard() {
                     <span className="text-dim"> \</span>
                     {'\n  '}
                     <span className="text-accent">
-                        {publishUrl(PUBLISH_BASE_URL_CLEAN, 'deploy/prod')}
+                        {publishUrl(PUBLISH_BASE_URL, 'deploy/prod')}
                     </span>
                 </code>
             </div>

--- a/packages/emitsignal-website/src/lib/api.ts
+++ b/packages/emitsignal-website/src/lib/api.ts
@@ -6,9 +6,7 @@ export * from '@emitsignal/shared/api';
 export * from '@emitsignal/shared/message-filters';
 
 export const API_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:5001';
-export const API_URL_CLEAN = new URL(API_URL).host;
 
 export const PUBLISH_BASE_URL = import.meta.env.VITE_PUBLISH_BASE_URL ?? API_URL;
-export const PUBLISH_BASE_URL_CLEAN = new URL(PUBLISH_BASE_URL).host;
 
 export const { api, setAuthToken, sseMultiUrl, sseUrl } = createApiClient(API_URL);


### PR DESCRIPTION
The curl snippets on the landing page rendered the endpoint through `PUBLISH_BASE_URL_CLEAN`, which is `new URL(...).host` — the scheme was stripped. A copied command therefore read:

```
curl -d "Production API latency spike" -H "x-priority: 5" emitsignal.com/publish/alerts/prod
```

curl defaults that to `http://`, which returns `404 page not found`. With `https://` it posts fine.

Both snippets (`mock-publish` and the mobile `feature-tabs` quickstart) now use `PUBLISH_BASE_URL`, which keeps the scheme. `PUBLISH_BASE_URL_CLEAN` and `API_URL_CLEAN` had no remaining consumers, so they're removed rather than left as a footgun.

Other curl examples were already correct: everything going through `buildCurlExample` (publish preview, inbox, API keys, mobile) passes the scheme-qualified `PUBLISH_BASE_URL`, and the README snippets already spell out `https://`.