### PR TITLE
Keep the lifetime message counter in memory instead of Redis

### DIFF
--- a/packages/emitsignal-server/src/http/topic/__tests__/publish.spec.ts
+++ b/packages/emitsignal-server/src/http/topic/__tests__/publish.spec.ts
@@ -64,7 +64,7 @@ describe('POST /publish/:name', () => {
         await app.handle(request('test-topic', validBody));
         await app.handle(request('test-topic', validBody));
 
-        expect(await readMessageTotal()).toBe(2);
+        expect(readMessageTotal()).toBe(2);
     });
 
     it('publishes to event bus', async () => {

--- a/packages/emitsignal-server/src/http/topic/publish.ts
+++ b/packages/emitsignal-server/src/http/topic/publish.ts
@@ -186,7 +186,7 @@ function publishRoute(path: string, deprecated: boolean) {
                 },
             });
 
-            void incrementMessageCounter();
+            incrementMessageCounter();
 
             if (isScheduled) {
                 scheduleQueue.add(

--- a/packages/emitsignal-server/src/http/webhooks/receive.ts
+++ b/packages/emitsignal-server/src/http/webhooks/receive.ts
@@ -146,7 +146,7 @@ export const receiveWebhook = new Elysia().post(
             },
         });
 
-        void incrementMessageCounter();
+        incrementMessageCounter();
 
         const event = await serializeMessage({ ...message, topicId: topic.id }, 0, false);
 

--- a/packages/emitsignal-server/src/index.ts
+++ b/packages/emitsignal-server/src/index.ts
@@ -54,6 +54,8 @@ import { emailQueue, purgeQueue, pushQueue, redisConnection, scheduleQueue } fro
 import { redis } from '#/lib/redis';
 import { FileStorageService } from '#/lib/storage';
 import { environment, isProduction } from '#/schema/environment';
+import { flushMessageCounter, loadMessageCounter } from '#/services/stats/message-counter';
+import { duration } from '#/utils/duration';
 import { isUnobservedPath } from '#/utils/observability';
 
 Email.init(environment);
@@ -123,7 +125,11 @@ const app = new Elysia({
     .use(updateWebhook)
     .use(userAvatar);
 
+await loadMessageCounter();
+
 export const server = app.listen(environment.EMIT_SIGNAL_HTTP_PORT);
+
+const counterFlush = setInterval(flushMessageCounter, duration.minutes(5).as('ms'));
 
 logger.info(
     `🟣 Server started at ${environment.EMIT_SIGNAL_HTTP_PORT} ` +
@@ -154,6 +160,10 @@ async function shutdown() {
     isShuttingDown = true;
 
     logger.info('shutting down server');
+
+    clearInterval(counterFlush);
+
+    await flushMessageCounter();
 
     await emailQueue.close();
     await purgeQueue.close();

--- a/packages/emitsignal-server/src/lib/queue/email/email-worker.ts
+++ b/packages/emitsignal-server/src/lib/queue/email/email-worker.ts
@@ -28,7 +28,7 @@ export function createEmailWorker(): Worker<Traced<EmailOptions>> {
                 traceContextFrom(job.data.traceContext),
                 async (span) => {
                     try {
-                        logger.info({ jobId: job.id, to: job.data.to }, 'processing email job');
+                        logger.debug({ jobId: job.id, to: job.data.to }, 'processing email job');
 
                         await Email.provider.send(job.data);
 

--- a/packages/emitsignal-server/src/lib/queue/index.ts
+++ b/packages/emitsignal-server/src/lib/queue/index.ts
@@ -1,11 +1,7 @@
 export { redisConnection } from './connection';
 export { emailQueue } from '#/lib/queue/email/email-queue';
 export { createEmailWorker } from '#/lib/queue/email/email-worker';
-export {
-    purgeQueue,
-    scheduleCounterFlush,
-    scheduleRetentionSweep,
-} from '#/lib/queue/purge/purge-queue';
+export { purgeQueue, scheduleRetentionSweep } from '#/lib/queue/purge/purge-queue';
 export { createPurgeWorker } from '#/lib/queue/purge/purge-worker';
 export { pushQueue } from '#/lib/queue/push/push-queue';
 export { createPushWorker } from '#/lib/queue/push/push-worker';

--- a/packages/emitsignal-server/src/lib/queue/purge/purge-queue.ts
+++ b/packages/emitsignal-server/src/lib/queue/purge/purge-queue.ts
@@ -9,7 +9,7 @@ import type { PurgeJob } from './types';
 export const purgeQueue = new Queue<
     Traced<PurgeJob>,
     void,
-    'flush-counters' | 'purge-expired' | 'purge-signals' | 'purge-storage'
+    'purge-expired' | 'purge-signals' | 'purge-storage'
 >('purge', {
     connection: redisConnection as ConnectionOptions,
     defaultJobOptions: {
@@ -19,14 +19,6 @@ export const purgeQueue = new Queue<
         removeOnFail: { age: duration.hours(24).as('seconds'), count: 1000 },
     },
 });
-
-export async function scheduleCounterFlush(): Promise<void> {
-    await purgeQueue.upsertJobScheduler(
-        'flush-counters',
-        { every: duration.minutes(5).as('ms') },
-        { data: { kind: 'counters' }, name: 'flush-counters' },
-    );
-}
 
 // Registers the hourly retention sweep. Idempotent — safe to call from every
 // worker replica at boot; BullMQ dedupes by the scheduler id.

--- a/packages/emitsignal-server/src/lib/queue/purge/purge-worker.ts
+++ b/packages/emitsignal-server/src/lib/queue/purge/purge-worker.ts
@@ -35,7 +35,10 @@ export function createPurgeWorker(): Worker<Traced<PurgeJob>> {
                 traceContextFrom(job.data.traceContext),
                 async (span) => {
                     try {
-                        logger.info({ jobId: job.id, kind: job.data.kind }, 'processing purge job');
+                        logger.debug(
+                            { jobId: job.id, kind: job.data.kind },
+                            'processing purge job',
+                        );
 
                         if (job.data.kind === 'expired') {
                             await purgeExpired();

--- a/packages/emitsignal-server/src/lib/queue/purge/purge-worker.ts
+++ b/packages/emitsignal-server/src/lib/queue/purge/purge-worker.ts
@@ -6,7 +6,6 @@ import { prisma } from '#/lib/prisma';
 import { redisConnection } from '#/lib/queue/connection';
 import { FileStorageService } from '#/lib/storage';
 import { traceContextFrom, Traced } from '#/lib/trace-context';
-import { flushMessageCounter } from '#/services/stats/message-counter';
 
 import type { PurgeJob } from './types';
 
@@ -38,9 +37,7 @@ export function createPurgeWorker(): Worker<Traced<PurgeJob>> {
                     try {
                         logger.info({ jobId: job.id, kind: job.data.kind }, 'processing purge job');
 
-                        if (job.data.kind === 'counters') {
-                            await flushMessageCounter();
-                        } else if (job.data.kind === 'expired') {
+                        if (job.data.kind === 'expired') {
                             await purgeExpired();
                         } else if (job.data.kind === 'signals') {
                             await purgeSignals(job.data.userId);

--- a/packages/emitsignal-server/src/lib/queue/purge/types.ts
+++ b/packages/emitsignal-server/src/lib/queue/purge/types.ts
@@ -3,13 +3,9 @@
 // `signals` runs while the user still exists: it deletes every message the user
 // owns (in their topics) or sent into others' topics, keeping the topics intact.
 //
-// `counters` flushes the lifetime message counter into its durable row; it
-// deletes nothing, and rides this queue only to reuse the worker.
-//
 // `storage` runs after an account has been deleted: the DB rows are already gone
 // via cascade, so the job only removes the orphaned files from object storage.
 export type PurgeJob =
     | { avatarKey?: string; kind: 'storage'; storageKeys: string[] }
-    | { kind: 'counters' }
     | { kind: 'expired' }
     | { kind: 'signals'; userId: string };

--- a/packages/emitsignal-server/src/lib/queue/push/push-worker.ts
+++ b/packages/emitsignal-server/src/lib/queue/push/push-worker.ts
@@ -29,7 +29,7 @@ export function createPushWorker(): Worker<Traced<PushJob>> {
                 traceContextFrom(job.data.traceContext),
                 async (span) => {
                     try {
-                        logger.info(
+                        logger.debug(
                             { jobId: job.id, topicName: job.data.topicName },
                             'processing push job',
                         );

--- a/packages/emitsignal-server/src/services/stats/__tests__/message-counter.spec.ts
+++ b/packages/emitsignal-server/src/services/stats/__tests__/message-counter.spec.ts
@@ -91,6 +91,30 @@ describe('flushMessageCounter', () => {
         expect(readMessageTotal()).toBe(1);
     });
 
+    it('re-writes a message that arrived while the previous flush was in flight', async () => {
+        let release!: () => void;
+        const inFlightWrite = new Promise<void>((resolve) => {
+            release = resolve;
+        });
+
+        prismaMock.$executeRaw = mock(() => inFlightWrite.then(() => 1));
+
+        incrementMessageCounter();
+
+        const flushing = flushMessageCounter();
+
+        incrementMessageCounter();
+
+        release();
+        await flushing;
+
+        prismaMock.$executeRaw = mock(() => Promise.resolve(1));
+
+        await flushMessageCounter();
+
+        expect(prismaMock.$executeRaw).toHaveBeenCalledTimes(1);
+    });
+
     it('keeps the total pending when the write fails', async () => {
         incrementMessageCounter();
         prismaMock.$executeRaw = mock(() => Promise.reject(new Error('database down')));

--- a/packages/emitsignal-server/src/services/stats/__tests__/message-counter.spec.ts
+++ b/packages/emitsignal-server/src/services/stats/__tests__/message-counter.spec.ts
@@ -7,6 +7,7 @@ mock.module('#/lib/prisma', () => ({ prisma: prismaMock }));
 import {
     flushMessageCounter,
     incrementMessageCounter,
+    loadMessageCounter,
     readMessageTotal,
     resetMessageCounterForTests,
 } from '#/services/stats/message-counter';
@@ -23,73 +24,83 @@ beforeEach(() => {
     prismaMock.$executeRaw = mock(() => Promise.resolve(1));
 });
 
-describe('incrementMessageCounter', () => {
-    it('counts each published message', async () => {
-        await incrementMessageCounter();
-        await incrementMessageCounter();
-        await incrementMessageCounter();
-
-        expect(await readMessageTotal()).toBe(3);
-    });
-
-    it('resumes from the stored total when the live counter is missing', async () => {
+describe('loadMessageCounter', () => {
+    it('seeds the total from the stored row', async () => {
         storedTotal(500);
 
-        await incrementMessageCounter();
+        await loadMessageCounter();
 
-        expect(await readMessageTotal()).toBe(501);
+        expect(readMessageTotal()).toBe(500);
     });
 
-    it('only folds the stored total in once', async () => {
-        storedTotal(500);
+    it('starts at zero when no row exists yet', async () => {
+        await loadMessageCounter();
 
-        await incrementMessageCounter();
-        await incrementMessageCounter();
-
-        expect(await readMessageTotal()).toBe(502);
+        expect(readMessageTotal()).toBe(0);
     });
 
-    it('does not throw when the counter backend fails', async () => {
-        storedTotal(10);
-        prismaMock.counter.findUnique = mock(() => Promise.reject(new Error('redis down')));
+    it('does not throw when the stored total cannot be read', async () => {
+        prismaMock.counter.findUnique = mock(() => Promise.reject(new Error('database down')));
 
-        await expect(incrementMessageCounter()).resolves.toBeUndefined();
-        expect(await readMessageTotal()).toBe(1);
+        await expect(loadMessageCounter()).resolves.toBeUndefined();
+        expect(readMessageTotal()).toBe(0);
     });
 });
 
-describe('readMessageTotal', () => {
-    it('falls back to the stored total before anything is published', async () => {
-        storedTotal(42);
+describe('incrementMessageCounter', () => {
+    it('counts each published message', () => {
+        incrementMessageCounter();
+        incrementMessageCounter();
+        incrementMessageCounter();
 
-        expect(await readMessageTotal()).toBe(42);
+        expect(readMessageTotal()).toBe(3);
     });
 
-    it('reports zero when neither the live nor the stored counter exists', async () => {
-        expect(await readMessageTotal()).toBe(0);
+    it('continues from the seeded total', async () => {
+        storedTotal(500);
+
+        await loadMessageCounter();
+        incrementMessageCounter();
+
+        expect(readMessageTotal()).toBe(501);
     });
 });
 
 describe('flushMessageCounter', () => {
-    it('writes nothing when the live counter is absent', async () => {
+    it('writes nothing when nothing was counted', async () => {
         await flushMessageCounter();
 
         expect(prismaMock.$executeRaw).not.toHaveBeenCalled();
     });
 
-    it('persists the live total', async () => {
-        await incrementMessageCounter();
+    it('persists the total after an increment', async () => {
+        incrementMessageCounter();
+
         await flushMessageCounter();
 
         expect(prismaMock.$executeRaw).toHaveBeenCalledTimes(1);
     });
 
-    it('is idempotent', async () => {
-        await incrementMessageCounter();
+    it('skips the write when no message arrived since the last flush', async () => {
+        incrementMessageCounter();
 
         await flushMessageCounter();
         await flushMessageCounter();
 
-        expect(await readMessageTotal()).toBe(1);
+        expect(prismaMock.$executeRaw).toHaveBeenCalledTimes(1);
+        expect(readMessageTotal()).toBe(1);
+    });
+
+    it('keeps the total pending when the write fails', async () => {
+        incrementMessageCounter();
+        prismaMock.$executeRaw = mock(() => Promise.reject(new Error('database down')));
+
+        await expect(flushMessageCounter()).resolves.toBeUndefined();
+
+        prismaMock.$executeRaw = mock(() => Promise.resolve(1));
+
+        await flushMessageCounter();
+
+        expect(prismaMock.$executeRaw).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/emitsignal-server/src/services/stats/message-counter.ts
+++ b/packages/emitsignal-server/src/services/stats/message-counter.ts
@@ -1,88 +1,54 @@
 import { logger } from '#/lib/logger';
 import { prisma } from '#/lib/prisma';
-import { redis } from '#/lib/redis';
 
 const COUNTER_KEY = 'messages';
-const REDIS_KEY = `counter:${COUNTER_KEY}`;
 
-const testCounters = new Map<string, number>();
+let total = 0;
+let dirty = false;
 
 export async function flushMessageCounter(): Promise<void> {
-    const live = await readLiveTotal();
-
-    if (live === null) {
+    if (!dirty) {
         return;
     }
 
-    // GREATEST, not assignment: a flush landing between a reseeding INCR and its
-    // INCRBY must not write the momentarily small live value over the total.
-    await prisma.$executeRaw`
-        INSERT INTO "Counter" ("key", "total", "updatedAt")
-        VALUES (${COUNTER_KEY}, ${BigInt(live)}, NOW())
-        ON CONFLICT ("key") DO UPDATE
-            SET "total" = GREATEST("Counter"."total", EXCLUDED."total"),
-                "updatedAt" = EXCLUDED."updatedAt"
-    `;
-}
-
-export async function incrementMessageCounter(): Promise<void> {
     try {
-        const total = await addToLiveTotal(1);
+        // GREATEST, not assignment: during a rolling restart the outgoing process can
+        // flush after the incoming one has seeded, and must not write the older total
+        // back over it.
+        await prisma.$executeRaw`
+            INSERT INTO "Counter" ("key", "total", "updatedAt")
+            VALUES (${COUNTER_KEY}, ${BigInt(total)}, NOW())
+            ON CONFLICT ("key") DO UPDATE
+                SET "total" = GREATEST("Counter"."total", EXCLUDED."total"),
+                    "updatedAt" = EXCLUDED."updatedAt"
+        `;
 
-        // 1 means the key was absent, so Redis lost the total; fold it back in.
-        // Additive, so publishes racing with the reseed are still counted.
-        if (total === 1) {
-            const stored = await readStoredTotal();
-
-            if (stored > 0) {
-                await addToLiveTotal(stored);
-            }
-        }
+        dirty = false;
     } catch (error) {
-        logger.error({ error }, 'message counter increment failed');
+        logger.error({ error }, 'message counter flush failed');
     }
 }
 
-export async function readMessageTotal(): Promise<number> {
+export function incrementMessageCounter(): void {
+    total += 1;
+    dirty = true;
+}
+
+export async function loadMessageCounter(): Promise<void> {
     try {
-        const live = await readLiveTotal();
+        const counter = await prisma.counter.findUnique({ where: { key: COUNTER_KEY } });
 
-        return live === null ? await readStoredTotal() : live;
+        total = counter ? Number(counter.total) : 0;
     } catch (error) {
-        logger.error({ error }, 'message counter read failed');
-
-        return 0;
+        logger.error({ error }, 'message counter load failed');
     }
+}
+
+export function readMessageTotal(): number {
+    return total;
 }
 
 export function resetMessageCounterForTests(): void {
-    testCounters.clear();
-}
-
-async function addToLiveTotal(amount: number): Promise<number> {
-    if (Bun.env.NODE_ENV === 'test') {
-        const total = (testCounters.get(REDIS_KEY) ?? 0) + amount;
-
-        testCounters.set(REDIS_KEY, total);
-
-        return total;
-    }
-
-    return redis.incrby(REDIS_KEY, amount);
-}
-
-async function readLiveTotal(): Promise<null | number> {
-    if (Bun.env.NODE_ENV === 'test') {
-        return testCounters.get(REDIS_KEY) ?? null;
-    }
-
-    const raw = await redis.get(REDIS_KEY);
-
-    return raw === null ? null : Math.max(0, Number.parseInt(raw, 10));
-}
-
-async function readStoredTotal(): Promise<number> {
-    const counter = await prisma.counter.findUnique({ where: { key: COUNTER_KEY } });
-
-    return counter ? Number(counter.total) : 0;
+    total = 0;
+    dirty = false;
 }

--- a/packages/emitsignal-server/src/services/stats/message-counter.ts
+++ b/packages/emitsignal-server/src/services/stats/message-counter.ts
@@ -4,10 +4,14 @@ import { prisma } from '#/lib/prisma';
 const COUNTER_KEY = 'messages';
 
 let total = 0;
-let dirty = false;
+let flushed = 0;
 
 export async function flushMessageCounter(): Promise<void> {
-    if (!dirty) {
+    // Read once up front: an increment landing mid-write must not be recorded as
+    // persisted, or it would be lost until the next message arrived.
+    const pending = total;
+
+    if (pending === flushed) {
         return;
     }
 
@@ -17,21 +21,21 @@ export async function flushMessageCounter(): Promise<void> {
         // back over it.
         await prisma.$executeRaw`
             INSERT INTO "Counter" ("key", "total", "updatedAt")
-            VALUES (${COUNTER_KEY}, ${BigInt(total)}, NOW())
+            VALUES (${COUNTER_KEY}, ${BigInt(pending)}, NOW())
             ON CONFLICT ("key") DO UPDATE
                 SET "total" = GREATEST("Counter"."total", EXCLUDED."total"),
                     "updatedAt" = EXCLUDED."updatedAt"
         `;
 
-        dirty = false;
+        flushed = pending;
     } catch (error) {
+        // flushed stays behind, so the next tick retries this total.
         logger.error({ error }, 'message counter flush failed');
     }
 }
 
 export function incrementMessageCounter(): void {
     total += 1;
-    dirty = true;
 }
 
 export async function loadMessageCounter(): Promise<void> {
@@ -39,6 +43,7 @@ export async function loadMessageCounter(): Promise<void> {
         const counter = await prisma.counter.findUnique({ where: { key: COUNTER_KEY } });
 
         total = counter ? Number(counter.total) : 0;
+        flushed = total;
     } catch (error) {
         logger.error({ error }, 'message counter load failed');
     }
@@ -50,5 +55,5 @@ export function readMessageTotal(): number {
 
 export function resetMessageCounterForTests(): void {
     total = 0;
-    dirty = false;
+    flushed = 0;
 }

--- a/packages/emitsignal-server/src/workers/all.ts
+++ b/packages/emitsignal-server/src/workers/all.ts
@@ -5,7 +5,6 @@ import {
     createPurgeWorker,
     createPushWorker,
     createScheduleWorker,
-    scheduleCounterFlush,
     scheduleRetentionSweep,
 } from '#/lib/queue';
 import { runWorkers } from '#/lib/run-workers';
@@ -18,6 +17,5 @@ FileStorageService.init(environment);
 runWorkers([createEmailWorker(), createPushWorker(), createScheduleWorker(), createPurgeWorker()]);
 
 await scheduleRetentionSweep();
-await scheduleCounterFlush();
 
 logger.info('📧 email, 🔔 push, ⏱️ schedule, 🗑️ purge workers started');

--- a/packages/emitsignal-server/src/workers/purge.ts
+++ b/packages/emitsignal-server/src/workers/purge.ts
@@ -1,5 +1,5 @@
 import { logger } from '#/lib/logger';
-import { scheduleCounterFlush, scheduleRetentionSweep } from '#/lib/queue';
+import { scheduleRetentionSweep } from '#/lib/queue';
 import { createPurgeWorker } from '#/lib/queue/purge/purge-worker';
 import { runWorkers } from '#/lib/run-workers';
 import { FileStorageService } from '#/lib/storage';
@@ -10,6 +10,5 @@ FileStorageService.init(environment);
 runWorkers([createPurgeWorker()]);
 
 await scheduleRetentionSweep();
-await scheduleCounterFlush();
 
 logger.info('🗑️ purge worker started');


### PR DESCRIPTION
Follow-up to #63. The counter worked, but it carried complexity it did not need.

`incrementMessageCounter()` is only called from HTTP handlers, and `GET /stats` is served by the same process — but the flush was put on the `purge` BullMQ queue, so it ran in the *worker* process. Redis existed purely to bridge that split, and everything awkward in `message-counter.ts` followed from it: the reseed-on-key-loss path, and a `NODE_ENV === 'test'` branch with a `Map` living in production code.

ntfy does the simple thing instead — seed from the DB at boot, increment in memory, write on a tick. That works here because `lib/event-bus.ts` already hard-requires single-node for the SSE fanout, so an in-memory counter adds no constraint we don't already have.

## What changed

- The counter is a module-level number, seeded once by `loadMessageCounter()` at boot. Increment and read are now synchronous.
- The flush runs on a 5-minute interval in the API process, plus once in the existing `shutdown()` so a graceful deploy loses nothing.
- `counters` is off the `purge` queue entirely — job kind, scheduler, worker branch, and both worker bootstraps. The queue is purge-only again.
- The per-job "processing X job" log drops to `debug` in the purge, email, and push workers. The surrounding OTel span already carries the job id and kind, and "job completed" stays at `info`. This was the log flooding: `counters` was the only every-5-minutes job on a queue whose other jobs are hourly. The push worker fires on every publish, so its pair was noisier still.

`lib/redis.ts` stays — rate limiting and billing still use it.

## One fix worth reading

`540a0cb` fixes a bug introduced in the first commit here, not one inherited from #63. The dirty flag was cleared *after* the await, so a message counted while a flush was in flight got marked persisted without ever being written. It now tracks the last flushed total and compares exactly, which also lets a failed write retry on the next tick instead of being swallowed. Covered by a regression test.

## Required after deploy

The `flush-counters` job scheduler is already persisted in Redis from #63. Removing the code stops it being re-upserted, but the existing entry keeps firing jobs that now fall through every branch as no-ops. Clear it once:

```ts
await purgeQueue.removeJobScheduler('flush-counters');
```

No breaking changes to the API — `GET /stats` is unchanged.

## Verification

494 tests pass, `bun lint` and `bun format:check` clean. Not yet exercised end-to-end against a live Docker stack; the restart-resumes-from-row path is the one worth a manual look.