### PR TITLE
fix(website): serve every SSE consumer from one shell-level connection

### DIFF
--- a/packages/emitsignal-website/src/ctx/realtime.test.tsx
+++ b/packages/emitsignal-website/src/ctx/realtime.test.tsx
@@ -1,0 +1,199 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, render, renderHook } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { RealtimeMessage } from '#/lib/realtime';
+
+import { REALTIME_SETTLE_DELAY_MS } from '#/lib/realtime';
+
+import { RealtimeProvider, useRealtimeTopics } from './realtime';
+
+const mockFetchEventSource = vi.fn();
+
+vi.mock('@microsoft/fetch-event-source', () => ({
+    fetchEventSource: (...args: unknown[]) => mockFetchEventSource(...args),
+}));
+
+const subscriptionsState = { loading: false, topicNames: ['alerts', 'deploys'] };
+
+vi.mock('#/ctx/session', () => ({
+    useSession: () => ({ loading: false, user: { id: 'user-1' } }),
+}));
+
+vi.mock('#/ctx/subscriptions', () => ({
+    useSubscriptions: () => ({
+        loading: subscriptionsState.loading,
+        subscriptions: subscriptionsState.topicNames.map((name) => ({ topic: { name } })),
+    }),
+}));
+
+function connectedUrls(): string[] {
+    return mockFetchEventSource.mock.calls.map((call) => call[0] as string);
+}
+
+function emit(message: Partial<RealtimeMessage>, event = 'message') {
+    const options = mockFetchEventSource.mock.lastCall?.[1] as {
+        onmessage: (frame: { data: string; event: string }) => void;
+    };
+
+    act(() => {
+        options.onmessage({ data: JSON.stringify(message), event });
+    });
+}
+
+function makeMessage(overrides: Partial<RealtimeMessage>): Partial<RealtimeMessage> {
+    return { createdAt: Date.now(), id: 'message-1', topicName: 'alerts', ...overrides };
+}
+
+function settle() {
+    act(() => {
+        vi.advanceTimersByTime(REALTIME_SETTLE_DELAY_MS);
+    });
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    return (
+        <QueryClientProvider client={queryClient}>
+            <RealtimeProvider>{children}</RealtimeProvider>
+        </QueryClientProvider>
+    );
+}
+
+describe('RealtimeProvider', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        mockFetchEventSource.mockReset();
+        mockFetchEventSource.mockResolvedValue(undefined);
+        subscriptionsState.loading = false;
+        subscriptionsState.topicNames = ['alerts', 'deploys'];
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('opens a single connection covering every registered topic', () => {
+        renderHook(
+            () => {
+                useRealtimeTopics({ onMessage: vi.fn(), topicNames: ['deploys'] });
+                useRealtimeTopics({ onMessage: vi.fn(), topicNames: ['builds', 'alerts'] });
+            },
+            { wrapper },
+        );
+
+        settle();
+
+        expect(mockFetchEventSource).toHaveBeenCalledOnce();
+        expect(connectedUrls()[0]).toContain('/listen?topics=alerts,builds,deploys');
+    });
+
+    it('does not reconnect when a subscriber remounts with the same topics', () => {
+        function Consumer() {
+            useRealtimeTopics({ onMessage: vi.fn(), topicNames: ['alerts'] });
+
+            return null;
+        }
+
+        const { rerender } = render(<Consumer />, { wrapper });
+
+        settle();
+        expect(mockFetchEventSource).toHaveBeenCalledOnce();
+
+        // Sibling-route navigation: unmount then remount inside the settle window.
+        rerender(<div />);
+        rerender(<Consumer />);
+        settle();
+
+        expect(mockFetchEventSource).toHaveBeenCalledOnce();
+    });
+
+    it('reconnects once with a since window when a new topic joins', () => {
+        const { rerender } = renderHook(
+            ({ topicName }: { topicName: string }) => {
+                useRealtimeTopics({ onMessage: vi.fn(), topicNames: [topicName] });
+            },
+            { initialProps: { topicName: 'alerts' }, wrapper },
+        );
+
+        settle();
+
+        expect(connectedUrls()[0]).not.toContain('since=');
+
+        rerender({ topicName: 'ad-hoc' });
+        settle();
+
+        expect(mockFetchEventSource).toHaveBeenCalledTimes(2);
+        expect(connectedUrls()[1]).toContain('topics=ad-hoc,alerts,deploys');
+        expect(connectedUrls()[1]).toContain('since=');
+    });
+
+    it('dispatches a message only to subscribers of its topic', () => {
+        const onAlerts = vi.fn();
+        const onDeploys = vi.fn();
+
+        renderHook(
+            () => {
+                useRealtimeTopics({ onMessage: onAlerts, topicNames: ['alerts'] });
+                useRealtimeTopics({ onMessage: onDeploys, topicNames: ['deploys'] });
+            },
+            { wrapper },
+        );
+
+        settle();
+        emit(makeMessage({ topicName: 'deploys' }));
+
+        expect(onAlerts).not.toHaveBeenCalled();
+        expect(onDeploys).toHaveBeenCalledOnce();
+    });
+
+    it('ignores malformed payloads and non-message events', () => {
+        const onMessage = vi.fn();
+
+        renderHook(() => useRealtimeTopics({ onMessage, topicNames: ['alerts'] }), { wrapper });
+
+        settle();
+        emit({ id: 'no-topic' });
+        emit(makeMessage({}), 'ping');
+
+        expect(onMessage).not.toHaveBeenCalled();
+    });
+
+    it('excludes disabled subscribers from the topic union', () => {
+        renderHook(
+            () => {
+                useRealtimeTopics({ enabled: false, onMessage: vi.fn(), topicNames: ['disabled'] });
+            },
+            { wrapper },
+        );
+
+        settle();
+
+        expect(connectedUrls()[0]).not.toContain('disabled');
+    });
+
+    it('does not dispatch replayed messages older than the subscriber', () => {
+        const onMessage = vi.fn();
+
+        renderHook(() => useRealtimeTopics({ onMessage, topicNames: ['alerts'] }), { wrapper });
+
+        settle();
+        emit(makeMessage({ createdAt: Date.now() - 60_000 }));
+
+        expect(onMessage).not.toHaveBeenCalled();
+    });
+
+    it('stays closed until subscriptions have loaded', () => {
+        subscriptionsState.loading = true;
+
+        renderHook(() => useRealtimeTopics({ onMessage: vi.fn(), topicNames: ['alerts'] }), {
+            wrapper,
+        });
+
+        settle();
+
+        expect(mockFetchEventSource).not.toHaveBeenCalled();
+    });
+});

--- a/packages/emitsignal-website/src/ctx/realtime.tsx
+++ b/packages/emitsignal-website/src/ctx/realtime.tsx
@@ -1,0 +1,231 @@
+import {
+    createContext,
+    type ReactElement,
+    type ReactNode,
+    type RefObject,
+    useCallback,
+    useContext,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
+
+import type { RealtimeMessage, RealtimeStatus } from '#/lib/realtime';
+
+import { useSession } from '#/ctx/session';
+import { useSubscriptions } from '#/ctx/subscriptions';
+import { useSSE } from '#/hooks/use-sse';
+import { sseMultiUrl } from '#/lib/api';
+import {
+    isRealtimeMessage,
+    REALTIME_MAX_REPLAY_WINDOW_MS,
+    REALTIME_SETTLE_DELAY_MS,
+    topicUnionKey,
+} from '#/lib/realtime';
+
+interface RealtimeContextValue {
+    connectedTopicNames: readonly string[];
+    status: RealtimeStatus;
+    subscribe: (subscriber: RealtimeSubscriber) => () => void;
+}
+
+interface RealtimeSubscriber {
+    handlerRef: RefObject<(message: RealtimeMessage) => void>;
+    registeredAt: number;
+    topicNames: readonly string[];
+}
+
+interface UseRealtimeTopicsOptions {
+    enabled?: boolean;
+    onMessage: (message: RealtimeMessage) => void;
+    topicNames: readonly string[];
+}
+
+const RealtimeContext = createContext<RealtimeContextValue | undefined>(undefined);
+
+export function RealtimeProvider({ children }: { children: ReactNode }): ReactElement {
+    const [connection, setConnection] = useState<{ topicKey: string; url: null | string }>({
+        topicKey: '',
+        url: null,
+    });
+    const [status, setStatus] = useState<RealtimeStatus>('closed');
+
+    const { loading: authLoading } = useSession();
+    const { loading: subscriptionsLoading, subscriptions } = useSubscriptions();
+
+    const subscriptionTopicKey = topicUnionKey(
+        subscriptions.map((subscription) => subscription.topic.name),
+    );
+
+    const committedTopicKeyRef = useRef<null | string>(null);
+    const lastEventAtRef = useRef(0);
+    const readyRef = useRef(false);
+    const settleTimerRef = useRef<null | ReturnType<typeof setTimeout>>(null);
+    const subscriberIdRef = useRef(0);
+    const subscribersRef = useRef(new Map<number, RealtimeSubscriber>());
+    const subscriptionTopicKeyRef = useRef(subscriptionTopicKey);
+
+    subscriptionTopicKeyRef.current = subscriptionTopicKey;
+
+    const commitTopicUnion = useCallback(() => {
+        if (!readyRef.current) {
+            return;
+        }
+
+        const union = new Set<string>();
+
+        for (const topicName of subscriptionTopicKeyRef.current.split(',')) {
+            if (topicName) {
+                union.add(topicName);
+            }
+        }
+
+        for (const subscriber of subscribersRef.current.values()) {
+            subscriber.topicNames.forEach((topicName) => union.add(topicName));
+        }
+
+        const topicKey = topicUnionKey(union);
+
+        // The whole point of the settle window: an unmount/remount pair across a
+        // route transition produces the same key, so the stream is left alone.
+        if (topicKey === committedTopicKeyRef.current) {
+            return;
+        }
+
+        const isReconnect = committedTopicKeyRef.current !== null;
+
+        committedTopicKeyRef.current = topicKey;
+
+        const topicNames = topicKey ? topicKey.split(',') : [];
+        // Replaying on the very first connect would duplicate rows the queries
+        // already fetched; only a reconnect has a gap worth filling.
+        const since = isReconnect
+            ? Math.max(lastEventAtRef.current, Date.now() - REALTIME_MAX_REPLAY_WINDOW_MS)
+            : undefined;
+
+        setStatus('connecting');
+        setConnection({ topicKey, url: sseMultiUrl(topicNames, since) });
+    }, []);
+
+    const scheduleTopicUnionCommit = useCallback(() => {
+        if (settleTimerRef.current) {
+            clearTimeout(settleTimerRef.current);
+        }
+
+        settleTimerRef.current = setTimeout(() => {
+            settleTimerRef.current = null;
+            commitTopicUnion();
+        }, REALTIME_SETTLE_DELAY_MS);
+    }, [commitTopicUnion]);
+
+    const subscribe = useCallback(
+        (subscriber: RealtimeSubscriber) => {
+            const id = subscriberIdRef.current++;
+
+            subscribersRef.current.set(id, subscriber);
+            scheduleTopicUnionCommit();
+
+            return () => {
+                subscribersRef.current.delete(id);
+                scheduleTopicUnionCommit();
+            };
+        },
+        [scheduleTopicUnionCommit],
+    );
+
+    const ready = !authLoading && !subscriptionsLoading;
+
+    readyRef.current = ready;
+
+    useEffect(() => {
+        if (!ready) {
+            return;
+        }
+
+        scheduleTopicUnionCommit();
+    }, [ready, scheduleTopicUnionCommit, subscriptionTopicKey]);
+
+    useEffect(() => {
+        return () => {
+            if (settleTimerRef.current) {
+                clearTimeout(settleTimerRef.current);
+            }
+        };
+    }, []);
+
+    useSSE({
+        onError: () => setStatus('error'),
+        onEvent: (event, data) => {
+            if (event !== 'message' || !isRealtimeMessage(data)) {
+                return;
+            }
+
+            lastEventAtRef.current = Math.max(lastEventAtRef.current, data.createdAt);
+
+            for (const subscriber of subscribersRef.current.values()) {
+                if (!subscriber.topicNames.includes(data.topicName)) {
+                    continue;
+                }
+
+                // A widened union replays the new topic's backlog. A subscriber
+                // that mounted after those messages already has them from its own
+                // query, so only forward what it could actually have missed.
+                if (data.createdAt < subscriber.registeredAt) {
+                    continue;
+                }
+
+                subscriber.handlerRef.current(data);
+            }
+        },
+        onOpen: () => setStatus('open'),
+        url: connection.url,
+    });
+
+    const value = useMemo<RealtimeContextValue>(
+        () => ({
+            connectedTopicNames: connection.topicKey ? connection.topicKey.split(',') : [],
+            status,
+            subscribe,
+        }),
+        [connection.topicKey, status, subscribe],
+    );
+
+    return <RealtimeContext.Provider value={value}>{children}</RealtimeContext.Provider>;
+}
+
+export function useRealtime(): RealtimeContextValue {
+    const context = useContext(RealtimeContext);
+
+    if (!context) {
+        throw new Error('useRealtime must be used within a RealtimeProvider');
+    }
+
+    return context;
+}
+
+export function useRealtimeTopics({
+    enabled = true,
+    onMessage,
+    topicNames,
+}: UseRealtimeTopicsOptions): void {
+    const { subscribe } = useRealtime();
+
+    const handlerRef = useRef(onMessage);
+
+    handlerRef.current = onMessage;
+
+    const topicKey = topicUnionKey(topicNames);
+
+    useEffect(() => {
+        if (!enabled || !topicKey) {
+            return;
+        }
+
+        return subscribe({
+            handlerRef,
+            registeredAt: Date.now(),
+            topicNames: topicKey.split(','),
+        });
+    }, [enabled, subscribe, topicKey]);
+}

--- a/packages/emitsignal-website/src/hooks/use-emit-signal.ts
+++ b/packages/emitsignal-website/src/hooks/use-emit-signal.ts
@@ -5,7 +5,7 @@ import type { Message, MessageFilterParams, PaginatedResponse, TopicMetrics } fr
 
 import { useSession } from '#/ctx/session';
 import { useSubscriptions } from '#/ctx/subscriptions';
-import { api, matchesMessageFilter, sseMultiUrl, sseUrl } from '#/lib/api';
+import { api, matchesMessageFilter } from '#/lib/api';
 import { queryKeys } from '#/lib/query-client';
 import { getDeviceId } from '#/lib/storage';
 
@@ -18,13 +18,11 @@ export function useFeed() {
 
     const userId = user?.id;
     const scope = userId ?? deviceId;
-    const topicNames = subscriptions.map((subscription) => subscription.topic.name);
+    const subscriptionTopicNames = subscriptions.map((subscription) => subscription.topic.name);
 
     const query = useLiveInfiniteQuery<Message>({
         enabled: !authLoading,
-        onMessage: (queryClient, data, queryKey) => {
-            const incoming = data as { topicName?: string } & Message;
-
+        onMessage: (queryClient, message, queryKey) => {
             queryClient.setQueryData<InfiniteData<PaginatedResponse<Message>>>(
                 queryKey,
                 (previous) => {
@@ -34,14 +32,14 @@ export function useFeed() {
 
                     const firstPage = previous.pages[0];
 
-                    if (!firstPage || firstPage.data.some((m) => m.id === incoming.id)) {
+                    if (!firstPage || firstPage.data.some((m) => m.id === message.id)) {
                         return previous;
                     }
 
                     return {
                         ...previous,
                         pages: [
-                            { ...firstPage, data: [incoming, ...firstPage.data] },
+                            { ...firstPage, data: [message, ...firstPage.data] },
                             ...previous.pages.slice(1),
                         ],
                     };
@@ -50,7 +48,7 @@ export function useFeed() {
         },
         queryFn: (cursor) => api.listSubscriptionMessages(deviceId, { cursor, limit: 50 }),
         queryKey: queryKeys.feed(scope),
-        sseUrl: () => (topicNames.length ? sseMultiUrl(topicNames) : null),
+        topicNames: () => subscriptionTopicNames,
     });
 
     return {
@@ -80,16 +78,14 @@ export function useTopicMessages(
 
     const query = useLiveInfiniteQuery<Message>({
         enabled: Boolean(topicName),
-        onMessage: (queryClient, data, queryKey) => {
+        onMessage: (queryClient, message, queryKey) => {
             if (!topicName) {
                 return;
             }
 
-            const incoming = data as Message;
+            onNewMessageRef.current?.(message);
 
-            onNewMessageRef.current?.(incoming);
-
-            if (!matchesMessageFilter(incoming, filtersRef.current)) {
+            if (!matchesMessageFilter(message, filtersRef.current)) {
                 return;
             }
 
@@ -102,14 +98,14 @@ export function useTopicMessages(
 
                     const firstPage = previous.pages[0];
 
-                    if (!firstPage || firstPage.data.some((m) => m.id === incoming.id)) {
+                    if (!firstPage || firstPage.data.some((m) => m.id === message.id)) {
                         return previous;
                     }
 
                     return {
                         ...previous,
                         pages: [
-                            { ...firstPage, data: [incoming, ...firstPage.data] },
+                            { ...firstPage, data: [message, ...firstPage.data] },
                             ...previous.pages.slice(1),
                         ],
                     };
@@ -125,7 +121,7 @@ export function useTopicMessages(
                 topicName: topicName as string,
             }),
         queryKey: queryKeys.topicMessages(topicName ?? '', filters),
-        sseUrl: () => (topicName ? sseUrl(topicName) : null),
+        topicNames: () => (topicName ? [topicName] : []),
     });
 
     return {

--- a/packages/emitsignal-website/src/hooks/use-live-infinite-query.ts
+++ b/packages/emitsignal-website/src/hooks/use-live-infinite-query.ts
@@ -7,17 +7,16 @@ import {
 } from '@tanstack/react-query';
 
 import type { PaginatedResponse } from '#/lib/api';
+import type { RealtimeMessage } from '#/lib/realtime';
 
-import { useSession } from '#/ctx/session';
-
-import { useSSE } from './use-sse';
+import { useRealtimeTopics } from '#/ctx/realtime';
 
 interface UseLiveInfiniteQueryOptions<TItem> {
     enabled?: boolean;
-    onMessage: (queryClient: QueryClient, data: unknown, queryKey: QueryKey) => void;
+    onMessage: (queryClient: QueryClient, message: RealtimeMessage, queryKey: QueryKey) => void;
     queryFn: (cursor: string | undefined) => Promise<PaginatedResponse<TItem>>;
     queryKey: QueryKey;
-    sseUrl: (data: InfiniteData<PaginatedResponse<TItem>> | undefined) => null | string;
+    topicNames: (data: InfiniteData<PaginatedResponse<TItem>> | undefined) => readonly string[];
 }
 
 export function useLiveInfiniteQuery<TItem>({
@@ -25,10 +24,9 @@ export function useLiveInfiniteQuery<TItem>({
     onMessage,
     queryFn,
     queryKey,
-    sseUrl,
+    topicNames,
 }: UseLiveInfiniteQueryOptions<TItem>) {
     const queryClient = useQueryClient();
-    const { loading: authLoading } = useSession();
 
     const query = useInfiniteQuery<
         PaginatedResponse<TItem>,
@@ -44,17 +42,10 @@ export function useLiveInfiniteQuery<TItem>({
         queryKey,
     });
 
-    const target = sseUrl(query.data);
-
-    useSSE({
-        onEvent: (event, data) => {
-            if (event !== 'message') {
-                return;
-            }
-
-            onMessage(queryClient, data, queryKey);
-        },
-        url: !authLoading && target ? target : null,
+    useRealtimeTopics({
+        enabled: enabled !== false,
+        onMessage: (message) => onMessage(queryClient, message, queryKey),
+        topicNames: topicNames(query.data),
     });
 
     return query;

--- a/packages/emitsignal-website/src/hooks/use-live-query.test.tsx
+++ b/packages/emitsignal-website/src/hooks/use-live-query.test.tsx
@@ -1,0 +1,95 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { RealtimeMessage } from '#/lib/realtime';
+
+import { RealtimeProvider } from '#/ctx/realtime';
+import { REALTIME_SETTLE_DELAY_MS } from '#/lib/realtime';
+
+import { useLiveQuery } from './use-live-query';
+
+const mockFetchEventSource = vi.fn();
+
+vi.mock('@microsoft/fetch-event-source', () => ({
+    fetchEventSource: (...args: unknown[]) => mockFetchEventSource(...args),
+}));
+
+vi.mock('#/ctx/session', () => ({
+    useSession: () => ({ loading: false, user: { id: 'user-1' } }),
+}));
+
+vi.mock('#/ctx/subscriptions', () => ({
+    useSubscriptions: () => ({ loading: false, subscriptions: [] }),
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    return (
+        <QueryClientProvider client={queryClient}>
+            <RealtimeProvider>{children}</RealtimeProvider>
+        </QueryClientProvider>
+    );
+}
+
+describe('useLiveQuery', () => {
+    beforeEach(() => {
+        mockFetchEventSource.mockReset();
+        mockFetchEventSource.mockResolvedValue(undefined);
+    });
+
+    it('derives its topics from query data once the query resolves', async () => {
+        renderHook(
+            () =>
+                useLiveQuery<{ topicName: string }[]>({
+                    onMessage: vi.fn(),
+                    queryFn: async () => [{ topicName: 'billing' }],
+                    queryKey: ['live-query-topics'],
+                    topicNames: (data) => (data ?? []).map((row) => row.topicName),
+                }),
+            { wrapper },
+        );
+
+        await waitFor(() => expect(mockFetchEventSource).toHaveBeenCalledOnce(), {
+            timeout: REALTIME_SETTLE_DELAY_MS * 10,
+        });
+
+        expect(mockFetchEventSource.mock.calls[0][0]).toContain('topics=billing');
+    });
+
+    it('hands the query client a typed message', async () => {
+        const onMessage = vi.fn();
+
+        renderHook(
+            () =>
+                useLiveQuery<{ topicName: string }[]>({
+                    onMessage,
+                    queryFn: async () => [{ topicName: 'billing' }],
+                    queryKey: ['live-query-dispatch'],
+                    topicNames: (data) => (data ?? []).map((row) => row.topicName),
+                }),
+            { wrapper },
+        );
+
+        await waitFor(() => expect(mockFetchEventSource).toHaveBeenCalledOnce(), {
+            timeout: REALTIME_SETTLE_DELAY_MS * 10,
+        });
+
+        const options = mockFetchEventSource.mock.lastCall?.[1] as {
+            onmessage: (frame: { data: string; event: string }) => void;
+        };
+        const message: Partial<RealtimeMessage> = {
+            createdAt: Date.now() + 1_000,
+            id: 'message-1',
+            topicName: 'billing',
+        };
+
+        act(() => {
+            options.onmessage({ data: JSON.stringify(message), event: 'message' });
+        });
+
+        expect(onMessage).toHaveBeenCalledWith(expect.anything(), message);
+    });
+});

--- a/packages/emitsignal-website/src/hooks/use-live-query.ts
+++ b/packages/emitsignal-website/src/hooks/use-live-query.ts
@@ -1,23 +1,23 @@
 import { type QueryClient, type QueryKey, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { useSession } from '#/ctx/session';
+import type { RealtimeMessage } from '#/lib/realtime';
 
-import { useSSE } from './use-sse';
+import { useRealtimeTopics } from '#/ctx/realtime';
 
 interface UseLiveQueryOptions<TData> {
     enabled?: boolean;
-    onMessage: (queryClient: QueryClient, data: unknown) => void;
+    onMessage: (queryClient: QueryClient, message: RealtimeMessage) => void;
     queryFn: () => Promise<TData>;
     queryKey: QueryKey;
-    sseUrl: (data: TData | undefined) => null | string;
     staleTime?: number;
+    topicNames: (data: TData | undefined) => readonly string[];
 }
 
 /**
- * Combines a cached `useQuery` with a live SSE connection. The query owns the
- * data (cache, staleTime, cross-navigation reuse); SSE `message` events patch
- * that same cache through `onMessage`, so live updates and navigated data stay
- * in sync. The stream URL is derived from the current query data so hooks whose
+ * Combines a cached `useQuery` with the shell's shared SSE stream. The query owns
+ * the data (cache, staleTime, cross-navigation reuse); live `message` events patch
+ * that same cache through `onMessage`, so live updates and navigated data stay in
+ * sync. The topic list is derived from the current query data so hooks whose
  * topics come from their own result (feed, webhooks) work without extra state.
  */
 export function useLiveQuery<TData>({
@@ -25,25 +25,17 @@ export function useLiveQuery<TData>({
     onMessage,
     queryFn,
     queryKey,
-    sseUrl,
     staleTime,
+    topicNames,
 }: UseLiveQueryOptions<TData>) {
     const queryClient = useQueryClient();
-    const { loading: authLoading } = useSession();
 
     const query = useQuery({ enabled, queryFn, queryKey, staleTime });
 
-    const target = sseUrl(query.data);
-
-    useSSE({
-        onEvent: (event, data) => {
-            if (event !== 'message') {
-                return;
-            }
-
-            onMessage(queryClient, data);
-        },
-        url: !authLoading && target ? target : null,
+    useRealtimeTopics({
+        enabled: enabled !== false,
+        onMessage: (message) => onMessage(queryClient, message),
+        topicNames: topicNames(query.data),
     });
 
     return query;

--- a/packages/emitsignal-website/src/hooks/use-sse.test.ts
+++ b/packages/emitsignal-website/src/hooks/use-sse.test.ts
@@ -84,4 +84,45 @@ describe('useSSE', () => {
 
         expect(mockFetchEventSource).not.toHaveBeenCalled();
     });
+
+    it('aborts the connection on unmount', () => {
+        captureOnMessage();
+
+        const { unmount } = renderHook(() => useSSE({ onEvent: vi.fn(), url: 'http://a/sse' }));
+
+        const { signal } = mockFetchEventSource.mock.calls[0][1] as { signal: AbortSignal };
+
+        expect(signal.aborted).toBe(false);
+
+        unmount();
+
+        expect(signal.aborted).toBe(true);
+    });
+
+    it('reconnects when the url changes', () => {
+        captureOnMessage();
+
+        const { rerender } = renderHook(
+            ({ url }: { url: string }) => useSSE({ onEvent: vi.fn(), url }),
+            {
+                initialProps: { url: 'http://a/sse' },
+            },
+        );
+
+        expect(mockFetchEventSource).toHaveBeenCalledOnce();
+
+        rerender({ url: 'http://a/sse?since=1' });
+
+        expect(mockFetchEventSource).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not reconnect when only the event handler identity changes', () => {
+        captureOnMessage();
+
+        const { rerender } = renderHook(() => useSSE({ onEvent: vi.fn(), url: 'http://a/sse' }));
+
+        rerender();
+
+        expect(mockFetchEventSource).toHaveBeenCalledOnce();
+    });
 });

--- a/packages/emitsignal-website/src/hooks/use-sse.ts
+++ b/packages/emitsignal-website/src/hooks/use-sse.ts
@@ -2,14 +2,13 @@ import { fetchEventSource } from '@microsoft/fetch-event-source';
 import { useEffect, useRef } from 'react';
 
 interface SSEOptions {
-    headers?: Record<string, string>;
     onError?: (error: unknown) => void;
     onEvent: (event: string, data: unknown) => void;
     onOpen?: () => void;
     url: null | string;
 }
 
-export function useSSE({ headers, onError, onEvent, onOpen, url }: SSEOptions) {
+export function useSSE({ onError, onEvent, onOpen, url }: SSEOptions) {
     const onErrorRef = useRef(onError);
     const onEventRef = useRef(onEvent);
     const onOpenRef = useRef(onOpen);
@@ -27,7 +26,6 @@ export function useSSE({ headers, onError, onEvent, onOpen, url }: SSEOptions) {
 
         fetchEventSource(url, {
             credentials: 'include',
-            headers,
             onerror(error) {
                 onErrorRef.current?.(error);
                 throw error;
@@ -54,5 +52,5 @@ export function useSSE({ headers, onError, onEvent, onOpen, url }: SSEOptions) {
         });
 
         return () => controller.abort();
-    }, [url, headers]);
+    }, [url]);
 }

--- a/packages/emitsignal-website/src/hooks/use-webhook-deliveries.ts
+++ b/packages/emitsignal-website/src/hooks/use-webhook-deliveries.ts
@@ -1,6 +1,6 @@
 import type { WebhookDelivery } from '#/lib/api';
 
-import { api, sseUrl } from '#/lib/api';
+import { api } from '#/lib/api';
 import { queryKeys } from '#/lib/query-client';
 
 import { useLiveQuery } from './use-live-query';
@@ -17,7 +17,7 @@ export function useWebhookDeliveries(webhookId: string, topicName?: string) {
         },
         queryFn: () => api.listWebhookDeliveries(webhookId),
         queryKey: queryKeys.webhookDeliveries(webhookId),
-        sseUrl: () => (topicName ? sseUrl(topicName) : null),
+        topicNames: () => (topicName ? [topicName] : []),
     });
 
     return {

--- a/packages/emitsignal-website/src/hooks/use-webhooks.ts
+++ b/packages/emitsignal-website/src/hooks/use-webhooks.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import type { Webhook } from '#/lib/api';
 
-import { api, sseMultiUrl } from '#/lib/api';
+import { api } from '#/lib/api';
 import { queryKeys } from '#/lib/query-client';
 
 import { useLiveQuery } from './use-live-query';
@@ -11,12 +11,8 @@ export function useWebhooks() {
     const queryClient = useQueryClient();
 
     const query = useLiveQuery<Webhook[]>({
-        onMessage: (client, data) => {
-            const { topicName } = data as { topicName?: string };
-
-            if (!topicName) {
-                return;
-            }
+        onMessage: (client, message) => {
+            const { topicName } = message;
 
             client.setQueryData<Webhook[]>(queryKeys.webhooks, (previous = []) =>
                 previous.map((webhook) =>
@@ -32,12 +28,8 @@ export function useWebhooks() {
         },
         queryFn: () => api.listWebhooks(),
         queryKey: queryKeys.webhooks,
-        sseUrl: (data) => {
-            const topicNames = [...new Set((data ?? []).map((webhook) => webhook.topicName))];
-
-            return topicNames.length > 0 ? sseMultiUrl(topicNames) : null;
-        },
         staleTime: 5 * 60_000,
+        topicNames: (data) => [...new Set((data ?? []).map((webhook) => webhook.topicName))],
     });
 
     const invalidate = () => queryClient.invalidateQueries({ queryKey: queryKeys.webhooks });

--- a/packages/emitsignal-website/src/lib/realtime.ts
+++ b/packages/emitsignal-website/src/lib/realtime.ts
@@ -1,0 +1,33 @@
+import type { Message } from '#/lib/api';
+
+export interface RealtimeMessage extends Message {
+    topicName: string;
+}
+
+export type RealtimeStatus = 'closed' | 'connecting' | 'error' | 'open';
+
+// A route transition unmounts one component and mounts the next in separate
+// commits. Waiting this long before committing a topic set lets both halves land
+// so an unchanged set never tears the connection down.
+export const REALTIME_SETTLE_DELAY_MS = 200;
+
+export const REALTIME_MAX_REPLAY_WINDOW_MS = 5 * 60_000;
+
+export function isRealtimeMessage(value: unknown): value is RealtimeMessage {
+    if (typeof value !== 'object' || value === null) {
+        return false;
+    }
+
+    const candidate = value as Partial<RealtimeMessage>;
+
+    return (
+        typeof candidate.id === 'string' &&
+        typeof candidate.topicName === 'string' &&
+        typeof candidate.createdAt === 'number' &&
+        Number.isFinite(candidate.createdAt)
+    );
+}
+
+export function topicUnionKey(topicNames: Iterable<string>): string {
+    return [...new Set(topicNames)].sort().join(',');
+}

--- a/packages/emitsignal-website/src/routes/app.tsx
+++ b/packages/emitsignal-website/src/routes/app.tsx
@@ -4,6 +4,7 @@ import { createIsomorphicFn } from '@tanstack/react-start';
 import { Sidebar } from '#/components/app/sidebar';
 import { DebugSectionsProvider } from '#/ctx/debug-sections';
 import { FeedStyleProvider } from '#/ctx/feed-style';
+import { RealtimeProvider } from '#/ctx/realtime';
 import { SubscriptionsProvider } from '#/ctx/subscriptions';
 import { ThemeProvider, useTheme } from '#/ctx/theme';
 import { ToastProvider } from '#/ctx/toast';
@@ -110,7 +111,9 @@ function WebShell() {
                 <DebugSectionsProvider initialSections={debugSections}>
                     <SubscriptionsProvider>
                         <ToastProvider>
-                            <DashboardShell />
+                            <RealtimeProvider>
+                                <DashboardShell />
+                            </RealtimeProvider>
                         </ToastProvider>
                     </SubscriptionsProvider>
                 </DebugSectionsProvider>


### PR DESCRIPTION
## Problem

The server log showed a stream of `/listen 200` and `/listen 4xx` lines during ordinary use.

There was no SSE connection at the `/app` layout. All four consumers — `useFeed`, `useTopicMessages`, `useWebhooks`, `useWebhookDeliveries` — opened their own stream from a leaf route via `useSSE`.

The worst case: `/app/inbox/` and `/app/inbox/$messageId` are *sibling* routes that both render `<InboxLayout/>`. TanStack unmounts one and mounts the other, so **clicking any inbox row aborted and reopened the feed stream**. The React Query cache survives that transition; the SSE connection did not. StrictMode doubled it in dev, and `webhooks/$webhookId` → `.edit` briefly held two streams on the same topic.

The `4xx` were `429 too_many_sse_connections`: `acquireSseSlot` caps an authenticated user at 10 concurrent slots (`SSE_MAX_AUTH`), and the churn outran slot release.

## Change

`src/ctx/realtime.tsx` — a `RealtimeProvider` mounted in `src/routes/app.tsx` inside `SubscriptionsProvider`/`ToastProvider`, owning one connection for the whole shell:

- Consumers call `useRealtimeTopics({ topicNames, onMessage })`. The provider unions their topics with the subscription list and opens a single `GET /listen?topics=<union>`.
- **A 200 ms settle window before committing a topic set.** An unmount/remount pair produces an identical key, so the commit is skipped entirely and the stream is left alone. That is the actual fix.
- Events dispatch by `topicName` (the server stamps it on every `MessageEvent`), so the single-topic consumers fold into the shared stream instead of opening `/topics/:name/listen`.
- Reconnects — a widened union, e.g. entering `/app/channels` with an ad-hoc topic — now carry `?since=<last createdAt>`, clamped to 5 minutes, so the gap is backfilled. Never on first connect: that would duplicate rows the query already fetched. A `createdAt >= registeredAt` guard stops a freshly-mounted subscriber from ingesting the replayed backlog.

`useLiveQuery` / `useLiveInfiniteQuery` swap `sseUrl: (data) => string | null` for `topicNames: (data) => readonly string[]`, and `onMessage` now receives a typed `RealtimeMessage` — the `data as { topicName?: string } & Message` casts are gone.

`useSSE` stays the low-level primitive, provider-only, with the unused `headers` option dropped (an object literal in the dep array is a churn footgun).

No server change.

## Verification

`bun lint`, `tsc --noEmit`, and 35 Vitest tests pass. The regression test that matters is `realtime.test.tsx` → *"does not reconnect when a subscriber remounts with the same topics"*.

Not yet verified against a running stack. To confirm end to end: `docker compose -f packages/emitsignal-docker/docker-compose.dev.yml up`, click through 10+ inbox rows, expect **zero** new `/listen` lines.

## Known follow-ups

- `useSSE`'s `onerror` still rethrows, which permanently disables `@microsoft/fetch-event-source`'s retry — a network drop or 5xx is terminal until the topic union changes. Worth fixing now that there is exactly one connection to manage.
- For authenticated users, bare `/listen` (no `?topics=`) lets the server resolve owned ∪ subscribed itself. Worth adopting where no ad-hoc topic is in play; note it does *not* remove the reconnect on subscribe, since `resolveOwnTopicNames` runs once at connect time.