### PR TITLE
Add "es config reset" command

### DIFF
--- a/packages/emitsignal-cli/src/commands/config-cmd.ts
+++ b/packages/emitsignal-cli/src/commands/config-cmd.ts
@@ -1,7 +1,19 @@
 import type { Command } from 'commander';
 
-import { configPath, getBaseUrl, getConsoleUrl, readConfig, writeConfig } from '../config.ts';
-import { color, err, ok } from '../output.ts';
+import { once } from 'node:events';
+import { createInterface } from 'node:readline/promises';
+
+import {
+    configPath,
+    deleteConfig,
+    getBaseUrl,
+    getConsoleUrl,
+    IDENTITY_SECTIONS,
+    readConfig,
+    resetConfig,
+    writeConfig,
+} from '../config.ts';
+import { arrow, color, err, ok } from '../output.ts';
 
 export function registerConfigCommand(program: Command): void {
     const cfg = program
@@ -46,6 +58,44 @@ export function registerConfigCommand(program: Command): void {
                 }
                 console.log();
             }
+        });
+
+    cfg.command('reset')
+        .description('Restore the built-in defaults, keeping your login and device id')
+        .option('--all', 'also clear the saved login and device id')
+        .option('-y, --yes', 'skip the confirmation prompt')
+        .action(async (options: { all?: boolean; yes?: boolean }) => {
+            const cleared = Object.keys(readConfig()).filter(
+                (section) => options.all === true || !IDENTITY_SECTIONS.includes(section),
+            );
+
+            if (cleared.length === 0) {
+                arrow('already at defaults; nothing to reset');
+
+                return;
+            }
+
+            const summary = cleared.map((section) => `[${section}]`).join(' ');
+
+            if (options.yes !== true) {
+                const confirmed = await confirm(
+                    `Clear ${color.violet(summary)} from ${configPath}?`,
+                );
+
+                if (!confirmed) {
+                    arrow('aborted; nothing changed');
+
+                    return;
+                }
+            }
+
+            if (options.all === true) {
+                deleteConfig();
+            } else {
+                resetConfig();
+            }
+
+            ok(`reset ${color.violet(summary)}`);
         });
 
     cfg.command('path')
@@ -97,6 +147,28 @@ function coerce(value: string): unknown {
     const number = Number(value);
 
     return isNaN(number) ? value : number;
+}
+
+async function confirm(question: string): Promise<boolean> {
+    if (!process.stdin.isTTY) {
+        err('refusing to reset without a confirmation prompt; re-run with --yes');
+        process.exit(2);
+    }
+
+    const readline = createInterface({ input: process.stdin, output: process.stdout });
+
+    try {
+        // Ctrl+D both rejects `question` and emits `close`, in no guaranteed
+        // order; either way an unanswered prompt must read as "no".
+        const answer = await Promise.race([
+            readline.question(`${question} ${color.fgDim('[y/N]')} `).catch(() => ''),
+            once(readline, 'close').then(() => ''),
+        ]);
+
+        return /^y(es)?$/i.test(answer.trim());
+    } finally {
+        readline.close();
+    }
 }
 
 function getNestedValue(obj: unknown, keyPath: string): unknown {

--- a/packages/emitsignal-cli/src/config.ts
+++ b/packages/emitsignal-cli/src/config.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { chmodSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { parse, stringify } from 'smol-toml';
@@ -14,6 +14,13 @@ export interface CliConfig {
 }
 
 export const configPath = join(homedir(), '.emitsignalrc');
+
+/** Sections that identify the user rather than configure the CLI. */
+export const IDENTITY_SECTIONS: readonly string[] = ['auth', 'device'];
+
+export function deleteConfig(): void {
+    rmSync(configPath, { force: true });
+}
 
 export function getBaseUrl(): string {
     return process.env['ES_BASE_URL'] ?? readConfig().server?.url ?? 'https://api.emitsignal.com';
@@ -53,6 +60,27 @@ export function readConfig(): CliConfig {
     } catch {
         return {};
     }
+}
+
+/**
+ * Drop every stored setting so the built-in defaults apply again, keeping the
+ * sections that identify the user rather than configure the CLI: `auth` would
+ * log them out, and a regenerated `device.id` would orphan their push
+ * subscriptions. Use `deleteConfig` to clear those too.
+ */
+export function resetConfig(): void {
+    const { auth, device } = readConfig();
+    const preserved: CliConfig = {};
+
+    if (auth) {
+        preserved.auth = auth;
+    }
+
+    if (device) {
+        preserved.device = device;
+    }
+
+    writeConfig(preserved);
 }
 
 export function writeConfig(config: CliConfig): void {


### PR DESCRIPTION
Adds `es config reset` for restoring the CLI back to its built-in defaults.

By default it clears the configured settings but keeps `[auth]` and `[device]` — wiping those would log the user out and orphan their push subscriptions. `--all` clears those too by removing the file outright.

- Prompts for confirmation, listing exactly which sections it will clear; `--yes` skips the prompt.
- Refuses with exit 2 in a non-TTY unless `--yes`, so a script cannot clear a config unattended.
- Ctrl+D at the prompt aborts without changes.

No breaking changes.