### PR TITLE
Polish the dashboard UI and fix two loading-state bugs

### DIFF
--- a/packages/emitsignal-mobile/app/messages/[id].tsx
+++ b/packages/emitsignal-mobile/app/messages/[id].tsx
@@ -1,4 +1,5 @@
 import { buildCurlExample } from '@emitsignal/shared/publish-example';
+import { externalUrlLabel } from '@emitsignal/shared/url';
 import { useQuery } from '@tanstack/react-query';
 import { router, useLocalSearchParams } from 'expo-router';
 import { useState } from 'react';
@@ -171,16 +172,34 @@ export default function MessageDetailScreen() {
                                 }
 
                                 if (action.type === 'view') {
+                                    const host = externalUrlLabel(action.url);
+
                                     return (
                                         <Pressable
                                             key={i}
                                             onPress={() => action.url && handleView(action.url)}
                                             style={styles.actionBtn}
                                         >
-                                            <IconSymbol color={palette.fg} name="globe" size={14} />
-                                            <Text style={styles.actionText}>
-                                                {action.label ?? 'View'}
-                                            </Text>
+                                            <IconSymbol
+                                                color={palette.fg}
+                                                name="arrow.up.right.square"
+                                                size={14}
+                                            />
+
+                                            <View style={styles.actionLabel}>
+                                                <Text style={styles.actionText}>
+                                                    {action.label ?? 'View'}
+                                                </Text>
+
+                                                {host ? (
+                                                    <Text
+                                                        numberOfLines={1}
+                                                        style={styles.actionHost}
+                                                    >
+                                                        {host}
+                                                    </Text>
+                                                ) : null}
+                                            </View>
                                         </Pressable>
                                     );
                                 }
@@ -296,6 +315,13 @@ const createStyles = (palette: Palette) =>
             justifyContent: 'center',
             paddingVertical: 10,
         },
+        actionHost: {
+            color: palette.fgDim,
+            fontFamily: Fonts.mono,
+            fontSize: 10,
+            marginTop: 1,
+        },
+        actionLabel: { alignItems: 'center' },
         actionPrimary: { backgroundColor: palette.violet, borderColor: palette.violet },
         actionPrimaryText: { color: palette.bg, fontSize: 12.5, fontWeight: '600' },
         actions: { flexDirection: 'row', gap: 8, marginTop: 14 },

--- a/packages/emitsignal-mobile/components/ui/icon-symbol.tsx
+++ b/packages/emitsignal-mobile/components/ui/icon-symbol.tsx
@@ -18,6 +18,7 @@ const MAPPING = {
     'arrow.left': 'arrow-back',
     'arrow.right': 'arrow-forward',
     'arrow.triangle.2.circlepath': 'sync',
+    'arrow.up.right.square': 'open-in-new',
     // Notifications
     bell: 'notifications',
     'bell.badge': 'notifications-active',

--- a/packages/emitsignal-shared/src/publish-example.test.ts
+++ b/packages/emitsignal-shared/src/publish-example.test.ts
@@ -141,4 +141,20 @@ describe('buildCliExample', () => {
             buildCliExample({ message: { body: 'hello', title: 'hello' }, topicName: 'a' }),
         ).toBe('emitsignal publish a "hello"');
     });
+
+    test('breaks each argument onto its own line when wrapping', () => {
+        expect(
+            buildCliExample({
+                message: { body: 'shipped v2', priority: 4 },
+                topicName: 'alerts',
+                wrap: true,
+            }),
+        ).toBe('emitsignal publish alerts \\\n  "shipped v2" \\\n  -p4');
+    });
+
+    test('uses the requested bin name', () => {
+        expect(
+            buildCliExample({ bin: 'es', message: { body: 'deploy ok' }, topicName: 'alerts' }),
+        ).toBe('es publish alerts "deploy ok"');
+    });
 });

--- a/packages/emitsignal-shared/src/publish-example.ts
+++ b/packages/emitsignal-shared/src/publish-example.ts
@@ -3,8 +3,10 @@ import type { Action } from './api.ts';
 import { publishUrl } from './topic.ts';
 
 export interface CliExampleOptions {
+    bin?: string;
     message?: PublishExampleMessage;
     topicName: string;
+    wrap?: boolean;
 }
 
 export interface CurlExampleOptions {
@@ -25,12 +27,17 @@ export interface PublishExampleMessage {
 
 export type PublishExampleStyle = 'headers' | 'json';
 
+const CONTINUATION = ' \\\n  ';
+const DEFAULT_CLI_BIN = 'emitsignal';
 const DEFAULT_PRIORITY = 3;
 
-const CONTINUATION = ' \\\n  ';
-
-export function buildCliExample({ message = {}, topicName }: CliExampleOptions): string {
-    const parts = [`emitsignal publish ${topicName}`];
+export function buildCliExample({
+    bin = DEFAULT_CLI_BIN,
+    message = {},
+    topicName,
+    wrap = false,
+}: CliExampleOptions): string {
+    const parts = [`${bin} publish ${topicName}`];
 
     if (message.body) {
         parts.push(doubleQuote(message.body));
@@ -48,7 +55,7 @@ export function buildCliExample({ message = {}, topicName }: CliExampleOptions):
         parts.push(`-t ${doubleQuote(message.tags.join(','))}`);
     }
 
-    return parts.join(' ');
+    return parts.join(wrap ? CONTINUATION : ' ');
 }
 
 export function buildCurlExample({

--- a/packages/emitsignal-shared/src/url.ts
+++ b/packages/emitsignal-shared/src/url.ts
@@ -8,6 +8,20 @@
 
 const SAFE_PROTOCOLS = new Set(['http:', 'https:', 'mailto:']);
 
+export function externalUrlLabel(value: null | string | undefined): null | string {
+    if (!isSafeExternalUrl(value)) {
+        return null;
+    }
+
+    const url = new URL(value as string);
+
+    if (url.protocol === 'mailto:') {
+        return url.pathname || null;
+    }
+
+    return url.host.replace(/^www\./, '') || null;
+}
+
 export function isSafeExternalUrl(value: null | string | undefined): boolean {
     if (typeof value !== 'string' || value.trim() === '') {
         return false;

--- a/packages/emitsignal-website/src/components/app/channels/channel-actions-menu.tsx
+++ b/packages/emitsignal-website/src/components/app/channels/channel-actions-menu.tsx
@@ -95,7 +95,7 @@ export function ChannelActionsMenu({
         try {
             await claimTopic.mutateAsync({ name: topicName });
 
-            toast(`Reserved ${topicName} — you now own this topic`);
+            toast(`Reserved ${topicName}. You now own this topic`);
         } catch (error) {
             toast(apiErrorMessage(error, 'Failed to claim topic'), 'danger');
         }

--- a/packages/emitsignal-website/src/components/app/channels/event-list.tsx
+++ b/packages/emitsignal-website/src/components/app/channels/event-list.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react';
 import type { Message } from '#/lib/api';
 
 import { Dot } from '#/components/ui/dot';
+import { SkeletonMessageList } from '#/components/ui/skeleton';
 import { cn } from '#/lib/cn';
 import { relativeTime } from '#/lib/format';
 import { priorityHex, priorityLabel } from '#/lib/priority';
@@ -73,7 +74,7 @@ export function EventList({
             />
 
             {loading ? (
-                <div className="p-5.5 font-mono text-[12px] text-dim">loading…</div>
+                <SkeletonMessageList />
             ) : messages.length === 0 ? (
                 <div className="p-5.5 font-mono text-[12px] text-dim">
                     no messages in this channel

--- a/packages/emitsignal-website/src/components/app/channels/event-list.tsx
+++ b/packages/emitsignal-website/src/components/app/channels/event-list.tsx
@@ -11,6 +11,7 @@ import { priorityHex, priorityLabel } from '#/lib/priority';
 const PRIORITY_THRESHOLDS = [3, 4, 5];
 
 interface Props {
+    emptyLabel: string;
     fetchNextPage: () => void;
     hasNextPage: boolean;
     isFetchingNextPage: boolean;
@@ -26,6 +27,7 @@ interface Props {
 }
 
 export function EventList({
+    emptyLabel,
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
@@ -76,9 +78,7 @@ export function EventList({
             {loading ? (
                 <SkeletonMessageList />
             ) : messages.length === 0 ? (
-                <div className="p-5.5 font-mono text-[12px] text-dim">
-                    no messages in this channel
-                </div>
+                <div className="p-5.5 font-mono text-[12px] text-dim">{emptyLabel}</div>
             ) : (
                 messages.map((message) => (
                     <EventRow event={message} key={message.id} onTagClick={onTagClick} />

--- a/packages/emitsignal-website/src/components/app/channels/routing-rail.tsx
+++ b/packages/emitsignal-website/src/components/app/channels/routing-rail.tsx
@@ -1,9 +1,14 @@
-import { publishUrl } from '@emitsignal/shared/topic';
-import { Plus } from 'lucide-react';
+import type { PublishExampleMessage } from '@emitsignal/shared/publish-example';
+
+import { buildCliExample, buildCurlExample } from '@emitsignal/shared/publish-example';
+import { ExternalLink, Plus } from 'lucide-react';
+import { useState } from 'react';
 
 import { Code } from '#/components/ui/code';
+import { CopyButton } from '#/components/ui/copy-button';
 import { SubHeading } from '#/components/ui/sub-head';
 import { PUBLISH_BASE_URL, type Subscription } from '#/lib/api';
+import { DOCS_URL } from '#/lib/links';
 
 interface RoutingRule {
     color: string;
@@ -20,16 +25,73 @@ const RULES: RoutingRule[] = [
 
 const ROUTING_ENABLED = false;
 
+const EXAMPLE_MESSAGES: PublishExampleMessage[] = [
+    { body: 'Build 4821 is live.', priority: 4, tags: ['deploy'], title: 'Deploy finished' },
+    { body: 'p95 is over 800ms.', priority: 5, tags: ['api', 'sev2'], title: 'Latency spike' },
+    { body: 'Nightly snapshot stored.', priority: 2, tags: ['cron'], title: 'Backup done' },
+    { body: 'Disk at 91% on db-01.', priority: 4, tags: ['infra'], title: 'Disk pressure' },
+    { body: '12 signups since midnight.', priority: 3, tags: ['growth'], title: 'Daily digest' },
+];
+
+type SnippetTab = 'cli' | 'curl';
+
+interface SnippetTabDefinition {
+    docsHref: string;
+    docsLabel: string;
+    id: SnippetTab;
+    label: string;
+}
+
+function exampleForTopic(topicName: string): PublishExampleMessage {
+    let hash = 0;
+
+    for (let index = 0; index < topicName.length; index += 1) {
+        hash = (hash * 31 + topicName.charCodeAt(index)) % 1000003;
+    }
+
+    return EXAMPLE_MESSAGES[hash % EXAMPLE_MESSAGES.length];
+}
+
+const SNIPPET_TABS: SnippetTabDefinition[] = [
+    {
+        docsHref: `${DOCS_URL}/api/publish`,
+        docsLabel: 'publish API reference',
+        id: 'curl',
+        label: 'curl',
+    },
+    {
+        docsHref: `${DOCS_URL}/cli/publish`,
+        docsLabel: 'es publish reference',
+        id: 'cli',
+        label: 'es cli',
+    },
+];
+
 interface Props {
     subscription: null | Subscription;
 }
 
 export function RoutingRail({ subscription }: Props) {
+    const [snippetTab, setSnippetTab] = useState<SnippetTab>('curl');
+
     const description = (
         subscription?.settings.description ?? subscription?.topic.description
     )?.trim();
 
     const topicName = subscription?.topic.name ?? '';
+
+    const activeTab = SNIPPET_TABS.find((tab) => tab.id === snippetTab) ?? SNIPPET_TABS[0];
+    const example = exampleForTopic(topicName);
+
+    const snippet =
+        snippetTab === 'curl'
+            ? buildCurlExample({
+                  baseUrl: PUBLISH_BASE_URL,
+                  message: example,
+                  style: 'headers',
+                  topicName,
+              })
+            : buildCliExample({ bin: 'es', message: example, topicName, wrap: true });
 
     return (
         <aside className="w-[320px] shrink-0 overflow-auto p-5.5">
@@ -42,28 +104,57 @@ export function RoutingRail({ subscription }: Props) {
             )}
 
             {ROUTING_ENABLED && (
-                <>
-                    <div className="mb-4.5">
-                        {RULES.map((rule, index) => (
-                            <RuleRow key={index} rule={rule} />
-                        ))}
+                <div className="mb-4.5">
+                    <SubHeading>ROUTING</SubHeading>
 
-                        <button className="flex items-center gap-1 pt-2.5 font-mono text-[11px] text-accent">
-                            <Plus size={11} /> add rule
-                        </button>
-                    </div>
-                </>
+                    {RULES.map((rule, index) => (
+                        <RuleRow key={index} rule={rule} />
+                    ))}
+
+                    <button className="flex items-center gap-1 pt-2.5 font-mono text-[11px] text-accent">
+                        <Plus size={11} /> add rule
+                    </button>
+                </div>
             )}
-
-            <SubHeading>ROUTING</SubHeading>
 
             <SubHeading>PUBLISH A MESSAGE</SubHeading>
 
-            <Code language="POST">
-                {topicName
-                    ? publishUrl(PUBLISH_BASE_URL, topicName)
-                    : 'subscribe to a channel first'}
-            </Code>
+            {topicName ? (
+                <>
+                    <div className="mb-2 flex items-center gap-1.5">
+                        {SNIPPET_TABS.map((tab) => (
+                            <button
+                                className={`rounded-full px-2.5 py-0.5 font-mono text-[11px] ${
+                                    tab.id === snippetTab
+                                        ? 'bg-accent/10 text-accent'
+                                        : 'text-dim hover:bg-elev hover:text-muted'
+                                }`}
+                                key={tab.id}
+                                onClick={() => setSnippetTab(tab.id)}
+                                type="button"
+                            >
+                                {tab.label}
+                            </button>
+                        ))}
+
+                        <CopyButton className="ml-auto" value={snippet} />
+                    </div>
+
+                    <Code>{snippet}</Code>
+                </>
+            ) : (
+                <Code>subscribe to a channel first</Code>
+            )}
+
+            <a
+                className="mt-2.5 inline-flex items-center gap-1.5 font-mono text-[11px] text-accent no-underline hover:underline"
+                href={activeTab.docsHref}
+                rel="noopener noreferrer"
+                target="_blank"
+            >
+                {activeTab.docsLabel}
+                <ExternalLink size={10} />
+            </a>
         </aside>
     );
 }

--- a/packages/emitsignal-website/src/components/app/channels/stats-strip.tsx
+++ b/packages/emitsignal-website/src/components/app/channels/stats-strip.tsx
@@ -1,11 +1,21 @@
 import type { Subscription, TopicMetrics } from '#/lib/api';
 
+import { Skeleton } from '#/components/ui/skeleton';
+
 interface Props {
+    loading?: boolean;
     metrics: null | TopicMetrics;
     subscription: null | Subscription;
 }
 
-export function StatsStrip({ metrics, subscription }: Props) {
+interface StatItemProps {
+    label: string;
+    loading: boolean;
+    subtitle: string;
+    value: string;
+}
+
+export function StatsStrip({ loading = false, metrics, subscription }: Props) {
     const volume = metrics?.volume ?? Array<number>(24).fill(0);
     const max = Math.max(...volume, 1);
 
@@ -13,24 +23,28 @@ export function StatsStrip({ metrics, subscription }: Props) {
         <div className="grid shrink-0 grid-cols-[repeat(4,1fr)_1.4fr] items-center gap-5.5 border-b border-line px-5.5 py-4.5">
             <StatItem
                 label="last 24h"
+                loading={loading}
                 subtitle="total messages"
                 value={metrics ? String(metrics.messageCount24h) : '—'}
             />
 
             <StatItem
                 label="p5 events"
+                loading={loading}
                 subtitle="max priority"
                 value={metrics ? String(metrics.p5Count24h) : '—'}
             />
 
             <StatItem
                 label="subscribers"
+                loading={loading}
                 subtitle="devices"
                 value={metrics ? String(metrics.subscriberCount) : '—'}
             />
 
             <StatItem
                 label="topic"
+                loading={loading}
                 subtitle={subscription?.topic.accessMode ?? 'public'}
                 value={subscription?.topic.displayName ?? '—'}
             />
@@ -93,14 +107,19 @@ export function StatsStrip({ metrics, subscription }: Props) {
     );
 }
 
-function StatItem({ label, subtitle, value }: { label: string; subtitle: string; value: string }) {
+function StatItem({ label, loading, subtitle, value }: StatItemProps) {
     return (
         <div>
             <p className="mb-1 font-mono text-[10px] uppercase tracking-[1.4px] text-dim">
                 {label}
             </p>
 
-            <p className="m-0 truncate text-[24px] font-semibold tracking-[-0.6px]">{value}</p>
+            {loading ? (
+                <Skeleton className="my-1" height={22} width="60%" />
+            ) : (
+                <p className="m-0 truncate text-[24px] font-semibold tracking-[-0.6px]">{value}</p>
+            )}
+
             <p className="m-0 mt-0.5 font-mono text-[10.5px] text-faint">{subtitle}</p>
         </div>
     );

--- a/packages/emitsignal-website/src/components/app/inbox/inbox-layout.test.tsx
+++ b/packages/emitsignal-website/src/components/app/inbox/inbox-layout.test.tsx
@@ -1,0 +1,47 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { InboxLayout } from './inbox-layout';
+
+const feed = {
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    loading: true,
+    messages: [] as unknown[],
+    subscriptions: [] as unknown[],
+};
+
+vi.mock('@tanstack/react-router', () => ({ useNavigate: () => vi.fn() }));
+vi.mock('#/hooks/use-emit-signal', () => ({ useFeed: () => feed }));
+vi.mock('#/ctx/feed-style', () => ({ useFeedStyle: () => ({ feedStyle: 'comfy' }) }));
+vi.mock('#/ctx/subscriptions', () => ({ useSubscriptions: () => ({ subscribe: vi.fn() }) }));
+vi.mock('#/ctx/toast', () => ({ useToast: () => vi.fn() }));
+vi.mock('#/ctx/debug-sections', () => ({ useDebugSections: () => ({ sections: {} }) }));
+
+describe('InboxLayout first load', () => {
+    beforeEach(() => {
+        // Auto-cleanup is not registered in this setup, so a previous render
+        // would otherwise leak its skeletons into the next assertion.
+        cleanup();
+
+        feed.loading = true;
+        feed.messages = [];
+    });
+
+    test('shows skeletons instead of the empty state while the feed is pending', () => {
+        render(<InboxLayout selectedId={null} />);
+
+        expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0);
+        expect(screen.queryByText(/no messages yet/)).toBeNull();
+    });
+
+    test('shows the empty state once the feed has resolved with no messages', () => {
+        feed.loading = false;
+
+        render(<InboxLayout selectedId={null} />);
+
+        expect(screen.queryByTestId('skeleton')).toBeNull();
+        expect(screen.getByText(/no messages yet/)).toBeDefined();
+    });
+});

--- a/packages/emitsignal-website/src/components/app/inbox/inbox-layout.test.tsx
+++ b/packages/emitsignal-website/src/components/app/inbox/inbox-layout.test.tsx
@@ -21,8 +21,6 @@ vi.mock('#/ctx/debug-sections', () => ({ useDebugSections: () => ({ sections: {}
 
 describe('InboxLayout first load', () => {
     beforeEach(() => {
-        // Auto-cleanup is not registered in this setup, so a previous render
-        // would otherwise leak its skeletons into the next assertion.
         cleanup();
 
         feed.loading = true;

--- a/packages/emitsignal-website/src/components/app/inbox/inbox-layout.tsx
+++ b/packages/emitsignal-website/src/components/app/inbox/inbox-layout.tsx
@@ -157,7 +157,7 @@ function NotificationList({
     if (messages.length === 0) {
         return (
             <div className="flex w-[380px] shrink-0 items-center justify-center border-r border-line p-4 font-mono text-[12px] text-dim">
-                no messages yet — subscribe to a channel
+                no messages yet · subscribe to a channel
             </div>
         );
     }

--- a/packages/emitsignal-website/src/components/app/inbox/inbox-layout.tsx
+++ b/packages/emitsignal-website/src/components/app/inbox/inbox-layout.tsx
@@ -11,6 +11,7 @@ import { InboxPreview } from '#/components/app/inbox/preview';
 import { PriorityHeader, PriorityRow } from '#/components/app/inbox/priority-row';
 import { TimelineDateLabel, TimelineRow } from '#/components/app/inbox/timeline-row';
 import { Toolbar } from '#/components/app/toolbar';
+import { SkeletonMessageList } from '#/components/ui/skeleton';
 import { useFeedStyle } from '#/ctx/feed-style';
 import { useSubscriptions } from '#/ctx/subscriptions';
 import { useToast } from '#/ctx/toast';
@@ -21,6 +22,7 @@ interface ListProps extends SubListProps {
     fetchNextPage: () => void;
     hasNextPage: boolean;
     isFetchingNextPage: boolean;
+    loading: boolean;
 }
 
 interface SubListProps {
@@ -56,11 +58,12 @@ export function InboxLayout({ selectedId }: { selectedId: null | string }) {
                     fetchNextPage={fetchNextPage}
                     hasNextPage={hasNextPage}
                     isFetchingNextPage={isFetchingNextPage}
+                    loading={loading}
                     messages={messages}
                     onSelect={handleSelect}
                     selectedId={selectedId}
                 />
-                <InboxPreview message={selected} />
+                <InboxPreview loading={loading} message={selected} selectedId={selectedId} />
             </div>
         </>
     );
@@ -128,6 +131,7 @@ function NotificationList({
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    loading,
     messages,
     onSelect,
     selectedId,
@@ -153,6 +157,14 @@ function NotificationList({
 
         return () => observer.disconnect();
     }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+    if (loading) {
+        return (
+            <div className="w-[380px] shrink-0 overflow-hidden border-r border-line">
+                <SkeletonMessageList />
+            </div>
+        );
+    }
 
     if (messages.length === 0) {
         return (

--- a/packages/emitsignal-website/src/components/app/inbox/preview.tsx
+++ b/packages/emitsignal-website/src/components/app/inbox/preview.tsx
@@ -36,8 +36,6 @@ export function InboxPreview({ loading = false, message, selectedId }: InboxPrev
     const [galleryIndex, setGalleryIndex] = useState<null | number>(null);
     const [pendingLink, setPendingLink] = useState<MediaRef | null>(null);
 
-    // A deep link to /app/inbox/$messageId arrives before the feed resolves, so
-    // the message is legitimately missing while the list is still loading.
     if (!message && loading && selectedId) {
         return <SkeletonMessageDetail />;
     }

--- a/packages/emitsignal-website/src/components/app/inbox/preview.tsx
+++ b/packages/emitsignal-website/src/components/app/inbox/preview.tsx
@@ -1,5 +1,5 @@
 import { buildCurlExample } from '@emitsignal/shared/publish-example';
-import { safeExternalUrl } from '@emitsignal/shared/url';
+import { externalUrlLabel, safeExternalUrl } from '@emitsignal/shared/url';
 import { ExternalLink } from 'lucide-react';
 import { useState } from 'react';
 
@@ -132,7 +132,10 @@ export function InboxPreview({ message }: { message: Message | null }) {
             {(hasAcknowledge || otherActions.length > 0) && (
                 <div className="mb-6.5 flex gap-2">
                     {hasAcknowledge && (
-                        <button className="rounded-md bg-accent px-3.5 py-2 text-[12.5px] font-semibold text-bg hover:bg-accent-dim">
+                        <button
+                            className="rounded-md bg-accent px-3.5 py-2 text-[12.5px] font-semibold text-bg hover:bg-accent-dim"
+                            type="button"
+                        >
                             Acknowledge
                         </button>
                     )}
@@ -144,7 +147,7 @@ export function InboxPreview({ message }: { message: Message | null }) {
 
                         return safeHref ? (
                             <a
-                                className="rounded-md border border-line bg-elev px-3.5 py-2 text-[12.5px] text-fg no-underline hover:bg-elev-2"
+                                className="inline-flex items-center gap-1.5 rounded-md border border-line bg-elev px-3.5 py-2 text-[12.5px] font-semibold text-fg no-underline hover:border-faint hover:bg-elev-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
                                 href={safeHref}
                                 key={index}
                                 rel="noopener noreferrer"
@@ -155,6 +158,7 @@ export function InboxPreview({ message }: { message: Message | null }) {
                         ) : (
                             <span
                                 className="cursor-not-allowed rounded-md border border-line bg-elev px-3.5 py-2 text-[12.5px] text-dim"
+                        const host = externalUrlLabel(safeHref);
                                 key={index}
                                 title="This action link was blocked (unsupported URL scheme)."
                             >
@@ -163,8 +167,17 @@ export function InboxPreview({ message }: { message: Message | null }) {
                         );
                     })}
                 </div>
+                                title={`Opens ${safeHref} in a new tab. This link is not verified by EmitSignal.`}
             )}
 
+
+                                {host && (
+                                    <span className="font-mono text-[11px] font-normal text-dim">
+                                        {host}
+                                    </span>
+                                )}
+
+                                <ExternalLink className="text-dim" size={12} />
             {message.inlineAttachments.length > 0 && (
                 <div className="mb-4.5">
                     <SubHeading>ATTACHMENTS</SubHeading>

--- a/packages/emitsignal-website/src/components/app/inbox/preview.tsx
+++ b/packages/emitsignal-website/src/components/app/inbox/preview.tsx
@@ -10,6 +10,7 @@ import { Dot } from '#/components/ui/dot';
 import { ImageGallery } from '#/components/ui/image-gallery';
 import { LinkWarningDialog } from '#/components/ui/link-warning-dialog';
 import { Pill } from '#/components/ui/pill';
+import { SkeletonMessageDetail } from '#/components/ui/skeleton';
 import { SubHeading } from '#/components/ui/sub-head';
 import { useDebugSections } from '#/ctx/debug-sections';
 import { PUBLISH_BASE_URL } from '#/lib/api';
@@ -24,10 +25,22 @@ const PRIORITY_LABELS: Record<number, string> = {
     5: 'PRIORITY 5 · MAX',
 };
 
-export function InboxPreview({ message }: { message: Message | null }) {
+interface InboxPreviewProps {
+    loading?: boolean;
+    message: Message | null;
+    selectedId?: null | string;
+}
+
+export function InboxPreview({ loading = false, message, selectedId }: InboxPreviewProps) {
     const { sections } = useDebugSections();
     const [galleryIndex, setGalleryIndex] = useState<null | number>(null);
     const [pendingLink, setPendingLink] = useState<MediaRef | null>(null);
+
+    // A deep link to /app/inbox/$messageId arrives before the feed resolves, so
+    // the message is legitimately missing while the list is still loading.
+    if (!message && loading && selectedId) {
+        return <SkeletonMessageDetail />;
+    }
 
     if (!message) {
         return (
@@ -96,6 +109,7 @@ export function InboxPreview({ message }: { message: Message | null }) {
             <h2 className="m-0 mb-2.5 text-[26px] font-semibold tracking-[-0.6px]">
                 {message.title}
             </h2>
+
             <p className="m-0 mb-4.5 whitespace-pre-wrap text-[14px] leading-[1.5] text-muted">
                 {message.body}
             </p>
@@ -144,6 +158,7 @@ export function InboxPreview({ message }: { message: Message | null }) {
                         // Only render a clickable link for safe http(s) URLs;
                         // never emit an anchor for a javascript:/data: scheme.
                         const safeHref = safeExternalUrl(action.url);
+                        const host = externalUrlLabel(safeHref);
 
                         return safeHref ? (
                             <a
@@ -152,24 +167,9 @@ export function InboxPreview({ message }: { message: Message | null }) {
                                 key={index}
                                 rel="noopener noreferrer"
                                 target="_blank"
-                            >
-                                {action.label ?? action.type}
-                            </a>
-                        ) : (
-                            <span
-                                className="cursor-not-allowed rounded-md border border-line bg-elev px-3.5 py-2 text-[12.5px] text-dim"
-                        const host = externalUrlLabel(safeHref);
-                                key={index}
-                                title="This action link was blocked (unsupported URL scheme)."
-                            >
-                                {action.label ?? action.type}
-                            </span>
-                        );
-                    })}
-                </div>
                                 title={`Opens ${safeHref} in a new tab. This link is not verified by EmitSignal.`}
-            )}
-
+                            >
+                                {action.label ?? action.type}
 
                                 {host && (
                                     <span className="font-mono text-[11px] font-normal text-dim">
@@ -178,6 +178,20 @@ export function InboxPreview({ message }: { message: Message | null }) {
                                 )}
 
                                 <ExternalLink className="text-dim" size={12} />
+                            </a>
+                        ) : (
+                            <span
+                                className="cursor-not-allowed rounded-md border border-line bg-elev px-3.5 py-2 text-[12.5px] text-dim"
+                                key={index}
+                                title="This action link was blocked (unsupported URL scheme)."
+                            >
+                                {action.label ?? action.type}
+                            </span>
+                        );
+                    })}
+                </div>
+            )}
+
             {message.inlineAttachments.length > 0 && (
                 <div className="mb-4.5">
                     <SubHeading>ATTACHMENTS</SubHeading>
@@ -223,11 +237,10 @@ export function InboxPreview({ message }: { message: Message | null }) {
                 </div>
             )}
 
-            {sections.showPayload ? <CodeBlock code={payloadJson} label="PAYLOAD" /> : null}
+            {sections.showCurl && <CodeBlock code={curlCommand} label="REPRODUCE · CURL" />}
+            {sections.showPayload && <CodeBlock code={payloadJson} label="PAYLOAD" />}
 
-            {sections.showCurl ? <CodeBlock code={curlCommand} label="REPRODUCE · CURL" /> : null}
-
-            {sections.showDelivery ? (
+            {sections.showDelivery && (
                 <div className="mb-4.5">
                     <SubHeading>DELIVERY</SubHeading>
                     <div className="flex flex-col gap-1.5">
@@ -250,7 +263,7 @@ export function InboxPreview({ message }: { message: Message | null }) {
                         ))}
                     </div>
                 </div>
-            ) : null}
+            )}
 
             {galleryIndex !== null && (
                 <ImageGallery

--- a/packages/emitsignal-website/src/components/app/keys/create-key-dialog.tsx
+++ b/packages/emitsignal-website/src/components/app/keys/create-key-dialog.tsx
@@ -238,7 +238,7 @@ export function CreateKeyDialog({ onClose, onCreated, open, revealData }: Create
                                         {reveal.name}
                                     </div>
                                     <div className="text-[12px] text-dim">
-                                        Copy it now — you won&apos;t be able to see it again
+                                        Copy it now. You won&apos;t be able to see it again
                                     </div>
                                 </div>
                             </div>
@@ -312,7 +312,7 @@ export function CreateKeyDialog({ onClose, onCreated, open, revealData }: Create
                                     onClick={onClose}
                                 >
                                     <Check size={13} />
-                                    Done — I&apos;ve copied it
+                                    Done, I&apos;ve copied it
                                 </button>
                             </div>
                         </>

--- a/packages/emitsignal-website/src/components/app/keys/keys-table.tsx
+++ b/packages/emitsignal-website/src/components/app/keys/keys-table.tsx
@@ -5,6 +5,7 @@ import type { ApiKey } from '#/hooks/use-api-keys';
 
 import { Dot } from '#/components/ui/dot';
 import { Pill } from '#/components/ui/pill';
+import { SkeletonTableRows } from '#/components/ui/skeleton';
 import { Sparkline } from '#/components/ui/sparkline';
 import { formatExpiry } from '#/lib/format';
 
@@ -69,7 +70,7 @@ export function KeysTable({
     if (loading) {
         return (
             <div className="mb-7 overflow-hidden rounded-[10px] border border-line bg-elev">
-                <div className="py-10 text-center font-mono text-[12px] text-dim">Loading...</div>
+                <SkeletonTableRows columns={[24, 38, 16]} rows={3} />
             </div>
         );
     }

--- a/packages/emitsignal-website/src/components/app/keys/revoke-key-dialog.tsx
+++ b/packages/emitsignal-website/src/components/app/keys/revoke-key-dialog.tsx
@@ -62,7 +62,7 @@ export function RevokeKeyDialog({ apiKey, onClose, onConfirm }: RevokeKeyDialogP
                     <p className="text-[13px] leading-[1.55] text-muted">
                         Any service using this key will{' '}
                         <strong className="text-fg">immediately stop</strong> being able to publish
-                        or read. This can&apos;t be undone — you&apos;d need to create a new key.
+                        or read. This can&apos;t be undone. You&apos;d need to create a new key.
                     </p>
 
                     <div className="mt-3.5 flex items-center gap-2.5 rounded-lg border border-line bg-bg px-3.5 py-2.5">

--- a/packages/emitsignal-website/src/components/app/settings/advanced-page.tsx
+++ b/packages/emitsignal-website/src/components/app/settings/advanced-page.tsx
@@ -230,7 +230,7 @@ export function AdvancedPage() {
                                         </div>
                                         <div className="mt-0.5 text-[12px] text-muted">
                                             {purgeMutation.isSuccess
-                                                ? 'Purge queued — your signals are being deleted.'
+                                                ? 'Purge queued. Your signals are being deleted.'
                                                 : 'Permanently delete every signal across all channels. Channels stay.'}
                                         </div>
                                     </div>

--- a/packages/emitsignal-website/src/components/app/settings/billing-page.tsx
+++ b/packages/emitsignal-website/src/components/app/settings/billing-page.tsx
@@ -185,7 +185,7 @@ export function BillingPage() {
             {welcome ? (
                 <div className="mb-[18px] flex items-center gap-2.5 rounded-[10px] border border-success/40 bg-success/5 px-4 py-3 text-[12.5px] text-success">
                     <Check size={14} />
-                    Subscription updated — welcome to {currentPlan.label}!
+                    Subscription updated. Welcome to {currentPlan.label}!
                 </div>
             ) : null}
 

--- a/packages/emitsignal-website/src/components/app/settings/billing-page.tsx
+++ b/packages/emitsignal-website/src/components/app/settings/billing-page.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from 'react';
 
 import type { PaidPlanName } from '#/hooks/use-billing';
 
+import { SkeletonTableRows } from '#/components/ui/skeleton';
 import { useBilling } from '#/hooks/use-billing';
 import { queryKeys } from '#/lib/query-client';
 
@@ -145,9 +146,7 @@ export function BillingPage() {
             <>
                 <PageHeader />
                 <SettingsCard>
-                    <div className="py-6 text-center font-mono text-[12px] text-dim">
-                        Loading billing…
-                    </div>
+                    <SkeletonTableRows columns={[30, 40]} rows={3} />
                 </SettingsCard>
             </>
         );

--- a/packages/emitsignal-website/src/components/app/settings/devices-page.tsx
+++ b/packages/emitsignal-website/src/components/app/settings/devices-page.tsx
@@ -1,3 +1,4 @@
+import { SkeletonTableRows } from '#/components/ui/skeleton';
 import { usePushTokens } from '#/hooks/use-push-tokens';
 
 import { DeviceRow } from './device-row';
@@ -28,7 +29,7 @@ export function DevicesPage() {
                     ) : null}
 
                     {loading ? (
-                        <p className="font-mono text-[12px] text-dim">Loading…</p>
+                        <SkeletonTableRows columns={[28, 34, 14]} rows={2} />
                     ) : tokens.length === 0 ? (
                         <p className="font-mono text-[12px] text-dim">
                             No devices registered yet. Sign in on the mobile app and allow

--- a/packages/emitsignal-website/src/components/app/settings/profile-page.tsx
+++ b/packages/emitsignal-website/src/components/app/settings/profile-page.tsx
@@ -137,7 +137,7 @@ export function ProfilePage() {
             <div className="mb-[26px] border-b border-line pb-[18px]">
                 <h1 className="text-[22px] font-semibold tracking-[-0.4px]">Profile</h1>
                 <p className="mt-1 max-w-[620px] text-[13px] leading-[1.55] text-muted">
-                    This is the public you — shown next to every signal you emit.
+                    This is the public you, shown next to every signal you emit.
                 </p>
             </div>
 

--- a/packages/emitsignal-website/src/components/app/webhooks/deliveries-log.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/deliveries-log.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 
 import type { WebhookDelivery, WebhookTemplate } from '#/lib/api';
 
+import { SkeletonTableRows } from '#/components/ui/skeleton';
 import { useWebhook } from '#/hooks/use-webhook';
 import { useWebhookDeliveries } from '#/hooks/use-webhook-deliveries';
 import { API_URL } from '#/lib/api';
@@ -97,8 +98,8 @@ export function DeliveriesLog({ webhookId }: { webhookId: string }) {
 
     if (loading) {
         return (
-            <div className="flex flex-1 items-center justify-center font-mono text-[12px] text-dim">
-                loading…
+            <div className="flex-1">
+                <SkeletonTableRows columns={[14, 30, 20, 12]} rows={6} />
             </div>
         );
     }

--- a/packages/emitsignal-website/src/components/app/webhooks/notif-preview.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/notif-preview.tsx
@@ -92,7 +92,7 @@ export function NotifPreview({
                         <div className="mt-2.5">
                             <span
                                 className="inline-block rounded-md border border-dashed border-line bg-elev px-3.5 py-2 text-[12.5px] text-dim"
-                                title="Not an http(s) URL — this link is dropped and no button is delivered."
+                                title="Not an http(s) URL. This link is dropped and no button is delivered."
                             >
                                 {buttonLabel} · dropped
                             </span>

--- a/packages/emitsignal-website/src/components/app/webhooks/verification-fields.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/verification-fields.tsx
@@ -83,7 +83,7 @@ export function VerificationFields({
                             onChange={(event) => onSecretChange(event.target.value)}
                             placeholder={
                                 hasStoredSecret
-                                    ? 'A secret is stored — type to replace it'
+                                    ? 'A secret is stored. Type to replace it'
                                     : 'Paste the signing secret'
                             }
                             spellCheck={false}

--- a/packages/emitsignal-website/src/components/app/webhooks/webhook-create.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/webhook-create.tsx
@@ -676,7 +676,7 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
                         {!useTemplate && (
                             <div className="mb-3 flex items-center gap-2 rounded-lg border border-line bg-elev px-3 py-2">
                                 <span className="text-[12px] text-muted">
-                                    No template — the raw payload is forwarded and pretty-printed as
+                                    No template. The raw payload is forwarded and pretty-printed as
                                     the body.
                                 </span>
                             </div>

--- a/packages/emitsignal-website/src/components/app/webhooks/webhooks-table.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/webhooks-table.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import type { Webhook } from '#/lib/api';
 
+import { SkeletonTableRows } from '#/components/ui/skeleton';
 import { API_URL } from '#/lib/api';
 import { withAlpha } from '#/lib/color';
 import { relativeTime } from '#/lib/format';
@@ -23,7 +24,11 @@ const COL = 'grid-cols-[2.2fr_1.4fr_1fr_0.8fr_0.7fr_100px]';
 
 export function WebhooksTable({ loading, remove, update, webhooks }: TableProps) {
     if (loading) {
-        return <div className="py-8 text-center font-mono text-[12px] text-dim">loading…</div>;
+        return (
+            <div className="rounded-xl border border-line bg-elev">
+                <SkeletonTableRows columns={[26, 34, 14, 10]} rows={4} />
+            </div>
+        );
     }
 
     if (webhooks.length === 0) {

--- a/packages/emitsignal-website/src/components/app/webhooks/webhooks-table.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/webhooks-table.tsx
@@ -206,7 +206,7 @@ function WebhookRow({
                                     borderColor:
                                         'color-mix(in srgb, var(--color-warn) 30%, transparent)',
                                 }}
-                                title="No signing secret — anyone with the endpoint URL can post to this webhook"
+                                title="No signing secret: anyone with the endpoint URL can post to this webhook"
                             >
                                 unverified
                             </span>

--- a/packages/emitsignal-website/src/components/ui/skeleton.tsx
+++ b/packages/emitsignal-website/src/components/ui/skeleton.tsx
@@ -1,0 +1,93 @@
+import { cn } from '#/lib/cn';
+
+interface SkeletonProps {
+    className?: string;
+    height?: number;
+    radius?: number;
+    width?: number | string;
+}
+
+interface SkeletonTableRowsProps {
+    columns?: number[];
+    rows?: number;
+}
+
+export function Skeleton({ className, height = 12, radius = 6, width = '100%' }: SkeletonProps) {
+    return (
+        <div
+            className={cn('shrink-0 animate-pulse bg-elev-2 motion-reduce:animate-none', className)}
+            data-testid="skeleton"
+            style={{ borderRadius: radius, height, width }}
+        />
+    );
+}
+
+export function SkeletonMessageDetail() {
+    return (
+        <div className="min-w-0 flex-1 p-7">
+            <Skeleton height={11} radius={4} width={128} />
+            <Skeleton className="mt-4" height={22} width="78%" />
+            <Skeleton className="mt-4" height={13} width="96%" />
+            <Skeleton className="mt-2" height={13} width="88%" />
+            <Skeleton className="mt-2" height={13} width="62%" />
+
+            <div className="mt-5 flex gap-1.5">
+                <Skeleton height={20} radius={10} width={62} />
+                <Skeleton height={20} radius={10} width={48} />
+                <Skeleton height={20} radius={10} width={54} />
+            </div>
+
+            <div className="mt-6 flex gap-2">
+                <Skeleton height={36} radius={6} width={124} />
+                <Skeleton height={36} radius={6} width={96} />
+            </div>
+        </div>
+    );
+}
+
+export function SkeletonMessageList({ count = 6 }: { count?: number }) {
+    return (
+        <div>
+            {Array.from({ length: count }, (_, index) => (
+                <SkeletonMessageRow key={index} />
+            ))}
+        </div>
+    );
+}
+
+export function SkeletonMessageRow() {
+    return (
+        <div className="flex gap-2.5 border-b border-line border-l-transparent px-4.5 py-3 border-l-[3px]">
+            <Skeleton height={9} radius={9} width={9} />
+
+            <div className="min-w-0 flex-1">
+                <div className="mb-1.5 flex items-baseline gap-2">
+                    <Skeleton height={9} radius={3} width={72} />
+                    <Skeleton className="ml-auto" height={9} radius={3} width={38} />
+                </div>
+
+                <Skeleton className="mb-1.5" height={13} radius={4} width="70%" />
+                <Skeleton height={12} radius={4} width="52%" />
+            </div>
+        </div>
+    );
+}
+
+// `columns` holds the percentage width of each cell, so a caller can echo the
+// shape of the table it stands in for.
+export function SkeletonTableRows({ columns = [30, 45, 15], rows = 4 }: SkeletonTableRowsProps) {
+    return (
+        <div>
+            {Array.from({ length: rows }, (_, rowIndex) => (
+                <div
+                    className="flex items-center gap-4 border-b border-line px-4 py-3.5 last:border-b-0"
+                    key={rowIndex}
+                >
+                    {columns.map((width, columnIndex) => (
+                        <Skeleton height={11} key={columnIndex} radius={4} width={`${width}%`} />
+                    ))}
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/packages/emitsignal-website/src/components/ui/skeleton.tsx
+++ b/packages/emitsignal-website/src/components/ui/skeleton.tsx
@@ -73,8 +73,6 @@ export function SkeletonMessageRow() {
     );
 }
 
-// `columns` holds the percentage width of each cell, so a caller can echo the
-// shape of the table it stands in for.
 export function SkeletonTableRows({ columns = [30, 45, 15], rows = 4 }: SkeletonTableRowsProps) {
     return (
         <div>

--- a/packages/emitsignal-website/src/ctx/theme.test.tsx
+++ b/packages/emitsignal-website/src/ctx/theme.test.tsx
@@ -1,0 +1,34 @@
+import { renderToString } from 'react-dom/server';
+import { describe, expect, test } from 'vitest';
+
+import { ThemeProvider, useTheme } from '#/ctx/theme';
+
+function Probe() {
+    const { resolvedTheme } = useTheme();
+
+    return <div data-theme={resolvedTheme} />;
+}
+
+function renderOnServer(initialTheme: 'dark' | 'light' | 'system') {
+    return renderToString(
+        <ThemeProvider initialTheme={initialTheme}>
+            <Probe />
+        </ThemeProvider>,
+    );
+}
+
+// The server snapshot is what React paints for SSR and for the first client
+// render, so a wrong value here shows up as a theme flash on every refresh.
+describe('ThemeProvider server rendering', () => {
+    test('renders an explicitly chosen light theme', () => {
+        expect(renderOnServer('light')).toContain('data-theme="light"');
+    });
+
+    test('renders an explicitly chosen dark theme', () => {
+        expect(renderOnServer('dark')).toContain('data-theme="dark"');
+    });
+
+    test('falls back to dark for system, which needs the OS', () => {
+        expect(renderOnServer('system')).toContain('data-theme="dark"');
+    });
+});

--- a/packages/emitsignal-website/src/ctx/theme.test.tsx
+++ b/packages/emitsignal-website/src/ctx/theme.test.tsx
@@ -17,8 +17,6 @@ function renderOnServer(initialTheme: 'dark' | 'light' | 'system') {
     );
 }
 
-// The server snapshot is what React paints for SSR and for the first client
-// render, so a wrong value here shows up as a theme flash on every refresh.
 describe('ThemeProvider server rendering', () => {
     test('renders an explicitly chosen light theme', () => {
         expect(renderOnServer('light')).toContain('data-theme="light"');

--- a/packages/emitsignal-website/src/ctx/theme.tsx
+++ b/packages/emitsignal-website/src/ctx/theme.tsx
@@ -36,11 +36,8 @@ export function ThemeProvider({
 }) {
     const [theme, setThemeState] = useState<ThemePreference>(initialTheme);
 
-    // React uses the server snapshot for SSR *and* for the first client render, so
-    // anything it cannot derive there paints once and then swaps. Only 'system'
-    // needs the OS; an explicit preference is known from the cookie and must be
-    // honoured here, or a light dashboard flashes dark on every refresh.
-    // Subscribing also picks up a mid-session OS switch.
+    // The server cannot read the OS, so it renders dark for 'system' and the client
+    // corrects on hydration. Subscribing here also picks up a mid-session OS switch.
     const resolvedTheme = useSyncExternalStore(
         subscribeToScheme,
         () => resolveTheme(theme),

--- a/packages/emitsignal-website/src/ctx/theme.tsx
+++ b/packages/emitsignal-website/src/ctx/theme.tsx
@@ -36,12 +36,15 @@ export function ThemeProvider({
 }) {
     const [theme, setThemeState] = useState<ThemePreference>(initialTheme);
 
-    // The server cannot read the OS, so it renders dark for 'system' and the client
-    // corrects on hydration. Subscribing here also picks up a mid-session OS switch.
+    // React uses the server snapshot for SSR *and* for the first client render, so
+    // anything it cannot derive there paints once and then swaps. Only 'system'
+    // needs the OS; an explicit preference is known from the cookie and must be
+    // honoured here, or a light dashboard flashes dark on every refresh.
+    // Subscribing also picks up a mid-session OS switch.
     const resolvedTheme = useSyncExternalStore(
         subscribeToScheme,
         () => resolveTheme(theme),
-        () => 'dark' as ResolvedTheme,
+        () => (theme === 'system' ? 'dark' : theme),
     );
 
     const setTheme = (next: ThemePreference) => {

--- a/packages/emitsignal-website/src/hooks/use-emit-signal.ts
+++ b/packages/emitsignal-website/src/hooks/use-emit-signal.ts
@@ -128,7 +128,7 @@ export function useTopicMessages(
         fetchNextPage: query.fetchNextPage,
         hasNextPage: query.hasNextPage,
         isFetchingNextPage: query.isFetchingNextPage,
-        loading: query.isPending,
+        loading: topicName ? query.isPending : false,
         messages: query.data?.pages.flatMap((page) => page.data) ?? [],
     };
 }

--- a/packages/emitsignal-website/src/routes/app/channels.tsx
+++ b/packages/emitsignal-website/src/routes/app/channels.tsx
@@ -7,6 +7,7 @@ import { RoutingRail } from '#/components/app/channels/routing-rail';
 import { StatsStrip } from '#/components/app/channels/stats-strip';
 import { Toolbar } from '#/components/app/toolbar';
 import { Dot } from '#/components/ui/dot';
+import { Skeleton } from '#/components/ui/skeleton';
 import { useSubscriptions } from '#/ctx/subscriptions';
 import { useTopicMessages, useTopicMetrics } from '#/hooks/use-emit-signal';
 
@@ -41,13 +42,13 @@ export const Route = createFileRoute('/app/channels')({
 
 function ChannelView() {
     const { priority, tags, topic } = Route.useSearch();
-    const { subscriptions } = useSubscriptions();
+    const { loading: subscriptionsLoading, subscriptions } = useSubscriptions();
     const navigate = useNavigate();
 
     const selectedTopic = topic || subscriptions[0]?.topic.name || '';
     const filters = { minPriority: priority, tags };
 
-    const { addMessage, metrics } = useTopicMetrics(selectedTopic || null);
+    const { addMessage, loading: metricsLoading, metrics } = useTopicMetrics(selectedTopic || null);
     const { fetchNextPage, hasNextPage, isFetchingNextPage, loading, messages } = useTopicMessages(
         selectedTopic || null,
         addMessage,
@@ -107,6 +108,17 @@ function ChannelView() {
             />
 
             <div className="flex flex-wrap gap-4 border-b border-line px-5 py-3">
+                {subscriptionsLoading &&
+                    [72, 96, 64].map((width) => (
+                        <Skeleton height={24} key={width} radius={12} width={width} />
+                    ))}
+
+                {!subscriptionsLoading && subscriptions.length === 0 && (
+                    <span className="px-1 font-mono text-[11.5px] text-dim">
+                        no channels yet · subscribe to one from the inbox
+                    </span>
+                )}
+
                 {subscriptions.map((subscription) => (
                     <button
                         className={`rounded-full px-3 py-1 font-mono text-[11.5px] ${
@@ -127,7 +139,11 @@ function ChannelView() {
                 ))}
             </div>
 
-            <StatsStrip metrics={metrics ?? null} subscription={subscription ?? null} />
+            <StatsStrip
+                loading={subscriptionsLoading || metricsLoading}
+                metrics={metrics ?? null}
+                subscription={subscription ?? null}
+            />
 
             <div className="flex min-h-0 flex-1">
                 <EventList

--- a/packages/emitsignal-website/src/routes/app/channels.tsx
+++ b/packages/emitsignal-website/src/routes/app/channels.tsx
@@ -147,6 +147,11 @@ function ChannelView() {
 
             <div className="flex min-h-0 flex-1">
                 <EventList
+                    emptyLabel={
+                        selectedTopic
+                            ? 'no messages in this channel'
+                            : 'subscribe to a channel to see its events'
+                    }
                     fetchNextPage={fetchNextPage}
                     hasNextPage={hasNextPage}
                     isFetchingNextPage={isFetchingNextPage}

--- a/packages/emitsignal-website/src/routes/app/keys.tsx
+++ b/packages/emitsignal-website/src/routes/app/keys.tsx
@@ -118,7 +118,7 @@ function KeysPage() {
 
             <div className="flex-1 overflow-auto px-5.5 py-5">
                 <div className="mb-[10px] flex items-baseline justify-between">
-                    <SubHeading>KEYS · {apiKeys.length}</SubHeading>
+                    <SubHeading>KEYS{loading ? '' : ` · ${apiKeys.length}`}</SubHeading>
                     <span className="font-mono text-[10.5px] text-dim">
                         secrets are shown once at creation
                     </span>

--- a/packages/emitsignal-website/src/routes/app/keys.tsx
+++ b/packages/emitsignal-website/src/routes/app/keys.tsx
@@ -60,7 +60,7 @@ function KeysPage() {
         await disable(id);
 
         setRevokeTarget(null);
-        flash('Key revoked — it can no longer authenticate', 'danger');
+        flash('Key revoked. It can no longer authenticate', 'danger');
     };
 
     const handleDelete = async (id: string) => {

--- a/packages/emitsignal-website/src/routes/app/settings.tsx
+++ b/packages/emitsignal-website/src/routes/app/settings.tsx
@@ -2,16 +2,13 @@ import { createFileRoute, Outlet } from '@tanstack/react-router';
 
 import { SettingsShell } from '#/components/app/settings/settings-shell';
 import { Toolbar } from '#/components/app/toolbar';
-import { useSession } from '#/ctx/session';
 
 export const Route = createFileRoute('/app/settings')({ component: SettingsLayout });
 
 function SettingsLayout() {
-    const { user } = useSession();
-
     return (
         <>
-            <Toolbar subtitle={user?.email} title="Settings" />
+            <Toolbar title="Settings" />
             <SettingsShell>
                 <Outlet />
             </SettingsShell>

--- a/packages/emitsignal-website/src/routes/app/webhooks/$webhookId.edit.tsx
+++ b/packages/emitsignal-website/src/routes/app/webhooks/$webhookId.edit.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Link } from '@tanstack/react-router';
 
 import { Toolbar } from '#/components/app/toolbar';
 import { WebhookCreate } from '#/components/app/webhooks/webhook-create';
+import { SkeletonTableRows } from '#/components/ui/skeleton';
 import { useWebhook } from '#/hooks/use-webhook';
 import { useWebhookDeliveries } from '#/hooks/use-webhook-deliveries';
 
@@ -34,8 +35,8 @@ function EditWebhookPage() {
                 }
             />
             {loading ? (
-                <div className="flex flex-1 items-center justify-center font-mono text-[12px] text-dim">
-                    loading…
+                <div className="flex-1 px-5.5 py-5">
+                    <SkeletonTableRows columns={[22, 40]} rows={5} />
                 </div>
             ) : webhook ? (
                 <WebhookCreate

--- a/packages/emitsignal-website/src/routes/app/webhooks/index.tsx
+++ b/packages/emitsignal-website/src/routes/app/webhooks/index.tsx
@@ -38,7 +38,7 @@ function WebhooksPage() {
                         <Plus size={12} /> New webhook
                     </Link>
                 }
-                subtitle={`${webhooks.length} endpoints`}
+                subtitle={loading ? '…' : `${webhooks.length} endpoints`}
                 title="Webhooks"
             />
 

--- a/packages/emitsignal-website/src/routes/app/webhooks/index.tsx
+++ b/packages/emitsignal-website/src/routes/app/webhooks/index.tsx
@@ -44,9 +44,9 @@ function WebhooksPage() {
 
             <div className="flex-1 overflow-auto px-5.5 py-5">
                 <p className="mb-5 max-w-xl text-[13.5px] leading-relaxed text-muted">
-                    Inbound endpoints. Point any service at a webhook URL — with a{' '}
+                    Inbound endpoints. Point any service at a webhook URL. With a{' '}
                     <span className="text-accent">template</span> it&apos;s pretty-printed into a
-                    notification, without one the raw payload is forwarded as-is.
+                    notification; without one the raw payload is forwarded as-is.
                 </p>
 
                 <WebhooksTable

--- a/packages/emitsignal-website/src/routes/changelog.tsx
+++ b/packages/emitsignal-website/src/routes/changelog.tsx
@@ -3,7 +3,6 @@ import { createFileRoute } from '@tanstack/react-router';
 import { SiteFooter } from '#/components/site/site-footer';
 import { SiteNav, SiteNavWordmark } from '#/components/site/site-nav';
 import { CHANGELOG_RELEASES } from '#/data/changelog.generated';
-import { DOCS_URL } from '#/lib/links';
 
 export const Route = createFileRoute('/changelog')({ component: ChangelogPage });
 
@@ -26,56 +25,9 @@ function ChangelogPage() {
                     <h1 className="m-0 mb-5 text-[52px] font-semibold leading-[1.0] tracking-[-1.8px] text-fg sm:text-[64px]">
                         Changelog
                     </h1>
-                    <p className="mb-2 text-[18px] leading-[1.6] text-muted">
+                    <p className="text-[18px] leading-[1.6] text-muted">
                         Every release, every change. From private beta to general availability.
                     </p>
-                    <p className="font-mono text-[12px] text-dim">
-                        Subscribe to updates:{' '}
-                        <a className="text-accent no-underline" href="#">
-                            RSS →
-                        </a>{' '}
-                        ·{' '}
-                        <a className="text-accent no-underline" href="#">
-                            email digest →
-                        </a>
-                    </p>
-                </div>
-            </div>
-
-            {/* Coming next */}
-            <div className="px-5 pb-4 sm:px-8 md:px-16">
-                <div className="mx-auto max-w-[760px]">
-                    <div className="rounded-2xl border border-dashed border-accent/40 bg-accent/[0.04] px-5 py-4">
-                        <div className="mb-3 flex flex-wrap items-baseline gap-3">
-                            <span className="rounded px-1.5 py-0.5 font-mono text-[9.5px] font-semibold uppercase tracking-[1.2px] text-accent">
-                                Coming next
-                            </span>
-                            <span className="font-mono text-[12px] text-dim">targeting v1.0.0</span>
-                        </div>
-                        <ul className="m-0 list-none space-y-2 p-0">
-                            <li className="flex items-start gap-2.5 text-[13.5px] leading-[1.55] text-muted">
-                                <span className="mt-0.5 font-mono text-[12px] text-accent">→</span>
-                                <span>
-                                    <span className="text-fg">emitsignal CLI</span> — publish,
-                                    listen, and subscribe from the terminal{' '}
-                                    <a
-                                        className="text-accent no-underline"
-                                        href={`${DOCS_URL}/cli`}
-                                        target="_blank"
-                                    >
-                                        (docs)
-                                    </a>
-                                </span>
-                            </li>
-                            <li className="flex items-start gap-2.5 text-[13.5px] leading-[1.55] text-muted">
-                                <span className="mt-0.5 font-mono text-[12px] text-accent">→</span>
-                                <span>
-                                    <span className="text-fg">Terminal UI (TUI)</span> — full-screen
-                                    inbox
-                                </span>
-                            </li>
-                        </ul>
-                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
A pass over the authenticated app and the public changelog, plus two bugs found along the way.

## Polish

- **Changelog** — removed the "Subscribe to updates" line (both links were `href="#"`) and the "Coming next" card.
- **Settings** — dropped the email subtitle from the header; it already appears in the sidebar, Profile, and Account.
- **Copy** — reworded the 14 user-facing strings that leaned on em dashes. The `—` placeholder in tables and stat tiles is left alone; that's a "no value yet" glyph, not prose.
- **Channel rail** — the bare `POST <url>` is now a `curl` / `es cli` tab switcher with a copy button and a link to the matching docs page, built from the real selected topic. Both snippets use their line-per-argument form so they stay readable in a 320px rail, and the example message varies per channel. Also removed a dangling, contentless `ROUTING` heading (its rules block is behind a disabled flag).
- **Message actions** — `view` actions now read as buttons and show where they go: bolder label, destination host, external-link icon, focus ring. Same on mobile. No confirmation interstitial in this PR.
- **Skeletons** — new `components/ui/skeleton.tsx`, mirroring the existing mobile component, wired into the inbox, channels, webhooks, keys, devices, and billing.

## Fixes

- **Channels loaded forever with no channel selected.** `useTopicMessages` returned `loading: query.isPending` unguarded, and a disabled react-query stays `isPending` indefinitely. `useTopicMetrics` already had the guard. Empty-state copy now distinguishes "no messages in this channel" from "no channel selected".
- **The dashboard flashed dark when light was selected.** `ThemeProvider`'s `getServerSnapshot` was hardcoded to `dark`, and React uses that for SSR *and* the first client render. An explicit preference is known from the cookie, so only `system` falls back now. Covered by a new SSR test.

`system` with a light OS still flashes — the server can't know the OS scheme. Closing that needs either a duplicated `prefers-color-scheme` CSS block or a blocking inline script; not done here.

No breaking changes. The new `bin` and `wrap` options on `buildCliExample` are optional and default to today's behaviour.