### PR TITLE
Add pipe filters to webhook templates

### DIFF
--- a/packages/emitsignal-docs/api/webhooks.mdx
+++ b/packages/emitsignal-docs/api/webhooks.mdx
@@ -25,7 +25,8 @@ POST /webhooks
 </ParamField>
 <ParamField body="name" type="string" />
 <ParamField body="template" type="string | null">
-    Optional template used to render incoming payloads into a message.
+    Optional template used to render incoming payloads into a message. JSON-encoded; see
+    [Templates](/cli/webhooks#templates) for the fields, placeholder paths, and filters.
 </ParamField>
 <ParamField body="verification" type="string" default='"none"'>
     One of `none`, `github`, `stripe`, `svix`, `hmac`, `token`. Anything other than `none` requires

--- a/packages/emitsignal-docs/cli/webhooks.mdx
+++ b/packages/emitsignal-docs/cli/webhooks.mdx
@@ -228,6 +228,45 @@ placeholders resolved against the incoming payload.
 Dot paths walk nested objects (`repository.owner.login`); a `*` segment maps over
 an array (`commits.*.message`). Missing paths render as an empty string.
 
+### Filters
+
+A placeholder can pipe its value through one or more filters, applied left to
+right. Arguments follow a colon and are single-quoted when they contain spaces or
+punctuation. A placeholder with no `|` behaves exactly as before.
+
+```json template.json
+{
+    "body": "{{ data.object.items.data.*.price.unit_amount | divide:100 | currency:'usd' }} on {{ created | date:'YYYY-MM-DD HH:mm' }}",
+    "replacements": {
+        "active": "Ativa",
+        "customer.subscription.created": "Assinatura criada"
+    },
+    "title": "{{ type | map }}"
+}
+```
+
+| Filter                         | Does                                                                                          |
+| ------------------------------ | --------------------------------------------------------------------------------------------- |
+| `date`                         | Formats unix seconds, unix milliseconds, or an ISO string. Default `YYYY-MM-DD HH:mm`, UTC.   |
+| `date:'<pattern>'`             | Tokens `YYYY MMM MM DD HH mm ss`. Also accepts `'iso'` and `'relative'`.                      |
+| `divide:N`                     | Divides for the Stripe minor-units case (`500 \| divide:100` → `5`).                          |
+| `multiply:N`                   | Multiplies.                                                                                   |
+| `number` / `number:N`          | Thousands separators, optionally with `N` fixed decimals.                                     |
+| `currency:'usd'`               | Currency formatting. Optional second argument sets the locale (default `en-US`).              |
+| `upper` `lower` `title` `trim` | Case and whitespace.                                                                          |
+| `truncate:N`                   | Caps a string at `N` characters and appends `…`.                                              |
+| `default:'text'`               | Fallback when the path resolves to nothing.                                                   |
+| `map`                          | Looks the value up in the template's `replacements` map, for translating or normalizing text. |
+
+The `replacements` field is a flat string-to-string map used by `map`. A value with
+no entry passes through unchanged; `map:'fallback'` sets an explicit miss value.
+
+Filters apply to each element of a wildcard match individually, so
+`items.*.amount | divide:100 | currency:'usd'` renders `$5.00, $25.00` rather than
+formatting the joined string. A value a filter cannot handle passes through
+untouched, and an unrecognized filter name is ignored, so a template typo never fails
+a live delivery.
+
 <ParamField body="--file, -f" type="path">
     Path to the template file to attach or replace.
 </ParamField>

--- a/packages/emitsignal-server/src/http/webhooks/__tests__/receive.spec.ts
+++ b/packages/emitsignal-server/src/http/webhooks/__tests__/receive.spec.ts
@@ -460,3 +460,81 @@ describe('POST /h/:slug signature verification', () => {
         expect(prismaMock.message.create).not.toHaveBeenCalled();
     });
 });
+
+describe('POST /h/:slug template filters', () => {
+    const app = new Elysia().use(receiveWebhook);
+
+    // Trimmed to the fields the template touches.
+    const stripePayload = {
+        created: 1787142663,
+        data: {
+            object: {
+                items: { data: [{ price: { unit_amount: 500 } }] },
+                status: 'active',
+            },
+        },
+        type: 'customer.subscription.created',
+    };
+
+    function withTemplate(template: Record<string, unknown>) {
+        prismaMock.webhook.findUnique.mockResolvedValue({
+            id: 'wh-1',
+            secretCiphertext: null,
+            source: 'stripe',
+            status: 'active',
+            template: JSON.stringify(template),
+            topicName: 'billing',
+            userId: null,
+            verification: 'none',
+            verificationConfig: null,
+        });
+    }
+
+    function request(payload: unknown) {
+        return new Request('http://localhost/h/st_abc1234', {
+            body: JSON.stringify(payload),
+            headers: { 'Content-Type': 'application/json' },
+            method: 'POST',
+        });
+    }
+
+    function storedMessage() {
+        const calls = prismaMock.message.create.mock.calls;
+        const lastCall = calls[calls.length - 1] as unknown as [{ data: Record<string, unknown> }];
+
+        return lastCall[0].data;
+    }
+
+    beforeEach(() => {
+        prismaMock.message.create.mockClear();
+        mockPushQueue.add.mockClear();
+        prismaMock.topic.findUnique.mockResolvedValue({
+            displayName: 'billing',
+            id: 'topic-1',
+            name: 'billing',
+        });
+    });
+
+    it('renders a filter chain and the replacements dictionary end to end', async () => {
+        withTemplate({
+            body: "{{data.object.items.data.*.price.unit_amount | divide:100 | currency:'usd'}} on {{created | date:'YYYY-MM-DD'}}",
+            replacements: { 'customer.subscription.created': 'Assinatura criada' },
+            title: '{{type | map}}',
+        });
+
+        const res = await app.handle(request(stripePayload));
+        const message = storedMessage();
+
+        expect(res.status).toBe(200);
+        expect(message.title).toBe('Assinatura criada');
+        expect(message.body).toBe('$5.00 on 2026-08-19');
+    });
+
+    it('renders a filterless template exactly as before', async () => {
+        withTemplate({ title: '{{type}}' });
+
+        await app.handle(request(stripePayload));
+
+        expect(storedMessage().title).toBe('customer.subscription.created');
+    });
+});

--- a/packages/emitsignal-shared/package.json
+++ b/packages/emitsignal-shared/package.json
@@ -10,6 +10,7 @@
         "./topic": "./src/topic.ts",
         "./url": "./src/url.ts",
         "./webhook-template": "./src/webhook-template.ts",
+        "./webhook-transforms": "./src/webhook-transforms.ts",
         "./webhook-verification": "./src/webhook-verification.ts"
     },
     "license": "AGPL-3.0-only",

--- a/packages/emitsignal-shared/src/api.ts
+++ b/packages/emitsignal-shared/src/api.ts
@@ -151,6 +151,7 @@ export interface WebhookTemplate {
     link?: string;
     linkLabel?: string;
     priority?: string;
+    replacements?: Record<string, string>;
     tags?: string;
     title?: string;
 }

--- a/packages/emitsignal-shared/src/index.ts
+++ b/packages/emitsignal-shared/src/index.ts
@@ -7,4 +7,5 @@ export * from './publish-example.ts';
 export * from './topic.ts';
 export * from './url.ts';
 export * from './webhook-template.ts';
+export * from './webhook-transforms.ts';
 export * from './webhook-verification.ts';

--- a/packages/emitsignal-shared/src/webhook-template.test.ts
+++ b/packages/emitsignal-shared/src/webhook-template.test.ts
@@ -52,7 +52,7 @@ describe('applyTemplate wildcard iteration', () => {
     });
 
     test('honors a custom empty value', () => {
-        expect(applyTemplate('{{monitor.nope}}', payload, '—')).toBe('—');
+        expect(applyTemplate('{{monitor.nope}}', payload, { defaultValue: '—' })).toBe('—');
     });
 
     test('returns the empty value for wildcard on a non-array', () => {

--- a/packages/emitsignal-shared/src/webhook-template.ts
+++ b/packages/emitsignal-shared/src/webhook-template.ts
@@ -1,16 +1,54 @@
 import type { WebhookTemplate } from './api.ts';
+import type { TemplateFilter } from './webhook-transforms.ts';
+
+import { applyFilters } from './webhook-transforms.ts';
 
 // Labels interpolate payload values on a public endpoint, so the text is untrusted.
 export const MAX_LINK_LABEL_LENGTH = 40;
 
-export function applyTemplate(input: string, payload: unknown, defaultValue = ''): string {
-    return input.replace(/\{\{\s*([^}]+)\s*\}\}/g, (_, path: string) =>
-        formatValue(resolvePath(payload, path.trim().split('.')), defaultValue),
-    );
+// The dictionary rides inside the template column and is read on every delivery.
+export const MAX_REPLACEMENT_ENTRIES = 100;
+
+export interface ApplyTemplateOptions {
+    defaultValue?: string;
+    replacements?: Record<string, string>;
+}
+
+export interface ParsedPlaceholder {
+    filters: TemplateFilter[];
+    path: string;
+}
+
+export function applyTemplate(
+    input: string,
+    payload: unknown,
+    options: ApplyTemplateOptions = {},
+): string {
+    const { defaultValue = '', replacements } = options;
+
+    return input.replace(/\{\{\s*([^}]+)\s*\}\}/g, (_, raw: string) => {
+        const { filters, path } = parsePlaceholder(raw);
+        const resolved = resolvePath(payload, path.split('.'));
+
+        return formatValue(applyFilters(resolved, filters, { replacements }), defaultValue);
+    });
 }
 
 export function normalizeLinkLabel(label: string): string {
     return label.replace(/\s+/g, ' ').trim().slice(0, MAX_LINK_LABEL_LENGTH).trim();
+}
+
+// Splits `path | name:'arg','arg' | name` into its parts. Arguments are single-quoted
+// and may legally contain `|`, `:`, `,` and `.`, so every split is quote-aware.
+export function parsePlaceholder(raw: string): ParsedPlaceholder {
+    const [pathSegment = '', ...filterSegments] = splitUnquoted(raw, '|');
+
+    return {
+        filters: filterSegments
+            .map(parseFilter)
+            .filter((filter): filter is TemplateFilter => filter !== null),
+        path: pathSegment.trim(),
+    };
 }
 
 export function parseTemplate(raw: null | string): null | WebhookTemplate {
@@ -19,7 +57,9 @@ export function parseTemplate(raw: null | string): null | WebhookTemplate {
     }
 
     try {
-        return JSON.parse(raw) as WebhookTemplate;
+        const parsed = JSON.parse(raw) as WebhookTemplate;
+
+        return { ...parsed, replacements: sanitizeReplacements(parsed.replacements) };
     } catch {
         return null;
     }
@@ -36,16 +76,22 @@ export function renderTemplate(
     tags: string[];
     title: string;
 } {
-    const title = template.title ? applyTemplate(template.title, payload) : 'Webhook delivery';
-    const body = template.body ? applyTemplate(template.body, payload) : '';
+    const options: ApplyTemplateOptions = {
+        replacements: sanitizeReplacements(template.replacements),
+    };
+
+    const title = template.title
+        ? applyTemplate(template.title, payload, options)
+        : 'Webhook delivery';
+    const body = template.body ? applyTemplate(template.body, payload, options) : '';
     // An unset link, or one whose template path does not resolve, renders to ''.
     // Callers treat that as "no action" — a link is never required for delivery.
-    const link = template.link ? applyTemplate(template.link, payload).trim() : '';
+    const link = template.link ? applyTemplate(template.link, payload, options).trim() : '';
     const linkLabel =
         link && template.linkLabel
-            ? normalizeLinkLabel(applyTemplate(template.linkLabel, payload))
+            ? normalizeLinkLabel(applyTemplate(template.linkLabel, payload, options))
             : '';
-    const rawTags = template.tags ? applyTemplate(template.tags, payload) : '';
+    const rawTags = template.tags ? applyTemplate(template.tags, payload, options) : '';
     const tags = rawTags
         ? rawTags
               .split(',')
@@ -56,6 +102,18 @@ export function renderTemplate(
     const priority = Math.min(5, Math.max(1, parseInt(template.priority ?? '3', 10))) || 3;
 
     return { body, link, linkLabel, priority, tags, title };
+}
+
+export function sanitizeReplacements(value: unknown): Record<string, string> | undefined {
+    if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+        return undefined;
+    }
+
+    const entries = Object.entries(value as Record<string, unknown>)
+        .filter(([key, entry]) => key !== '' && typeof entry === 'string')
+        .slice(0, MAX_REPLACEMENT_ENTRIES) as [string, string][];
+
+    return entries.length ? Object.fromEntries(entries) : undefined;
 }
 
 function formatValue(value: unknown, emptyValue: string): string {
@@ -69,6 +127,19 @@ function formatValue(value: unknown, emptyValue: string): string {
     }
 
     return String(value);
+}
+
+function parseFilter(segment: string): null | TemplateFilter {
+    const [namePart = '', ...argParts] = splitUnquoted(segment, ':');
+    const name = namePart.trim();
+
+    if (!name) {
+        return null;
+    }
+
+    const rawArgs = argParts.join(':');
+
+    return { args: rawArgs.trim() ? splitUnquoted(rawArgs, ',').map(unquote) : [], name };
 }
 
 function resolvePath(value: unknown, segments: string[]): unknown {
@@ -87,4 +158,41 @@ function resolvePath(value: unknown, segments: string[]): unknown {
     }
 
     return undefined;
+}
+
+// An unterminated quote leaves the scanner "inside" it, so the remainder stays one literal part.
+function splitUnquoted(input: string, delimiter: string): string[] {
+    const parts: string[] = [];
+    let current = '';
+    let quoted = false;
+
+    for (const character of input) {
+        if (character === "'") {
+            quoted = !quoted;
+            current += character;
+            continue;
+        }
+
+        if (character === delimiter && !quoted) {
+            parts.push(current);
+            current = '';
+            continue;
+        }
+
+        current += character;
+    }
+
+    parts.push(current);
+
+    return parts;
+}
+
+function unquote(argument: string): string {
+    const trimmed = argument.trim();
+
+    if (trimmed.length >= 2 && trimmed.startsWith("'") && trimmed.endsWith("'")) {
+        return trimmed.slice(1, -1);
+    }
+
+    return trimmed;
 }

--- a/packages/emitsignal-shared/src/webhook-transforms.test.ts
+++ b/packages/emitsignal-shared/src/webhook-transforms.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'bun:test';
+
+import { applyTemplate, parsePlaceholder, renderTemplate } from './webhook-template.ts';
+
+// The Stripe customer.subscription.created delivery that motivated transforms.
+const stripePayload = {
+    created: 1787142663,
+    data: {
+        object: {
+            items: {
+                data: [{ price: { unit_amount: 500 } }],
+            },
+            status: 'active',
+        },
+    },
+    type: 'customer.subscription.created',
+};
+
+describe('parsePlaceholder', () => {
+    it('reads a bare path with no filters', () => {
+        expect(parsePlaceholder('data.object.status')).toEqual({
+            filters: [],
+            path: 'data.object.status',
+        });
+    });
+
+    it('keeps colons and spaces inside a quoted argument', () => {
+        expect(parsePlaceholder("created | date:'YYYY-MM-DD HH:mm'")).toEqual({
+            filters: [{ args: ['YYYY-MM-DD HH:mm'], name: 'date' }],
+            path: 'created',
+        });
+    });
+
+    it('keeps a pipe inside a quoted argument', () => {
+        expect(parsePlaceholder("status | default:' | '")).toEqual({
+            filters: [{ args: [' | '], name: 'default' }],
+            path: 'status',
+        });
+    });
+
+    it('splits multiple arguments on unquoted commas', () => {
+        expect(parsePlaceholder("amount | currency:'eur','de-DE'").filters[0]!.args).toEqual([
+            'eur',
+            'de-DE',
+        ]);
+    });
+
+    it('keeps a comma inside a quoted argument', () => {
+        expect(parsePlaceholder("status | default:'a,b'").filters[0]!.args).toEqual(['a,b']);
+    });
+
+    it('chains filters left to right', () => {
+        expect(parsePlaceholder('amount | divide:100 | number:2').filters).toEqual([
+            { args: ['100'], name: 'divide' },
+            { args: ['2'], name: 'number' },
+        ]);
+    });
+
+    it('treats the remainder of an unterminated quote as one literal argument', () => {
+        expect(parsePlaceholder("status | default:'oops | upper").filters).toEqual([
+            { args: ["'oops | upper"], name: 'default' },
+        ]);
+    });
+});
+
+describe('date filter', () => {
+    it('formats unix seconds with the default pattern', () => {
+        expect(applyTemplate('{{created | date}}', stripePayload)).toBe('2026-08-19 12:31');
+    });
+
+    it('formats unix milliseconds', () => {
+        expect(applyTemplate('{{at | date}}', { at: 1787142663000 })).toBe('2026-08-19 12:31');
+    });
+
+    it('formats an ISO string', () => {
+        expect(applyTemplate("{{at | date:'DD MMM YYYY'}}", { at: '2026-08-18T08:31:03Z' })).toBe(
+            '18 Aug 2026',
+        );
+    });
+
+    it('supports the iso pattern', () => {
+        expect(applyTemplate("{{created | date:'iso'}}", stripePayload)).toBe(
+            '2026-08-19T12:31:03.000Z',
+        );
+    });
+
+    it('passes a non-date value through untouched', () => {
+        expect(applyTemplate('{{type | date}}', stripePayload)).toBe(
+            'customer.subscription.created',
+        );
+    });
+});
+
+describe('number and currency filters', () => {
+    it('converts minor units element-wise across a wildcard', () => {
+        expect(
+            applyTemplate(
+                "{{data.object.items.data.*.price.unit_amount | divide:100 | currency:'usd'}}",
+                stripePayload,
+            ),
+        ).toBe('$5.00');
+    });
+
+    it('formats every element before joining them', () => {
+        const payload = { items: [{ amount: 500 }, { amount: 2500 }] };
+
+        expect(applyTemplate("{{items.*.amount | divide:100 | currency:'usd'}}", payload)).toBe(
+            '$5.00, $25.00',
+        );
+    });
+
+    it('falls back to a plain code for a malformed currency', () => {
+        expect(applyTemplate("{{amount | currency:'zz'}}", { amount: 5 })).toBe('ZZ 5');
+    });
+
+    it('ignores a zero divisor', () => {
+        expect(applyTemplate('{{amount | divide:0}}', { amount: 500 })).toBe('500');
+    });
+
+    it('applies fixed decimals', () => {
+        expect(applyTemplate('{{amount | number:2}}', { amount: 5 })).toBe('5.00');
+    });
+
+    it('multiplies', () => {
+        expect(applyTemplate('{{amount | multiply:100}}', { amount: 5 })).toBe('500');
+    });
+});
+
+describe('text filters', () => {
+    it('uppercases and lowercases', () => {
+        expect(applyTemplate('{{status | upper}}', { status: 'active' })).toBe('ACTIVE');
+        expect(applyTemplate('{{status | lower}}', { status: 'ACTIVE' })).toBe('active');
+    });
+
+    it('title-cases each word', () => {
+        expect(applyTemplate('{{name | title}}', { name: 'pulse monthly PLAN' })).toBe(
+            'Pulse Monthly Plan',
+        );
+    });
+
+    it('truncates with an ellipsis', () => {
+        expect(applyTemplate('{{type | truncate:8}}', stripePayload)).toBe('customer…');
+    });
+
+    it('leaves a short string untruncated', () => {
+        expect(applyTemplate('{{status | truncate:80}}', { status: 'active' })).toBe('active');
+    });
+
+    it('supplies a per-placeholder default for a missing path', () => {
+        expect(applyTemplate("{{nope | default:'unknown'}}", stripePayload)).toBe('unknown');
+    });
+
+    it('wins over the template-wide default value', () => {
+        expect(
+            applyTemplate("{{nope | default:'unknown'}}", stripePayload, { defaultValue: '—' }),
+        ).toBe('unknown');
+    });
+});
+
+describe('map filter', () => {
+    const replacements = { active: 'Ativa', 'customer.subscription.created': 'Assinatura criada' };
+
+    it('replaces a matching value', () => {
+        expect(applyTemplate('{{type | map}}', stripePayload, { replacements })).toBe(
+            'Assinatura criada',
+        );
+    });
+
+    it('passes an unmapped value through unchanged', () => {
+        expect(applyTemplate('{{data.object.status | map}}', stripePayload, {})).toBe('active');
+    });
+
+    it('uses an explicit fallback on a miss', () => {
+        expect(applyTemplate("{{nope | map:'other'}}", stripePayload, { replacements })).toBe('');
+    });
+
+    it('reads the dictionary off the template in renderTemplate', () => {
+        const rendered = renderTemplate(
+            { replacements, title: '{{type | map}} · {{data.object.status | map}}' },
+            stripePayload,
+        );
+
+        expect(rendered.title).toBe('Assinatura criada · Ativa');
+    });
+
+    it('ignores a replacements value that is not a flat string map', () => {
+        const rendered = renderTemplate(
+            {
+                replacements: { active: 3 } as unknown as Record<string, string>,
+                title: '{{data.object.status | map}}',
+            },
+            stripePayload,
+        );
+
+        expect(rendered.title).toBe('active');
+    });
+});
+
+describe('unknown filters', () => {
+    it('passes the value through without throwing', () => {
+        expect(applyTemplate('{{data.object.status | nope}}', stripePayload)).toBe('active');
+    });
+
+    it('still applies the known filters in the chain', () => {
+        expect(applyTemplate('{{data.object.status | nope | upper}}', stripePayload)).toBe(
+            'ACTIVE',
+        );
+    });
+});
+
+describe('link label cap', () => {
+    it('cannot be bypassed by truncate', () => {
+        const rendered = renderTemplate(
+            { link: 'https://status.dev', linkLabel: '{{label | truncate:200}}' },
+            { label: 'x'.repeat(200) },
+        );
+
+        expect(rendered.linkLabel.length).toBe(40);
+    });
+});

--- a/packages/emitsignal-shared/src/webhook-transforms.ts
+++ b/packages/emitsignal-shared/src/webhook-transforms.ts
@@ -1,0 +1,248 @@
+import { relativeTime } from './format.ts';
+
+export interface TemplateFilter {
+    args: string[];
+    name: string;
+}
+
+export interface TransformContext {
+    replacements?: Record<string, string>;
+}
+
+export type TransformFunction = (
+    value: unknown,
+    args: string[],
+    context: TransformContext,
+) => unknown;
+
+const DEFAULT_DATE_PATTERN = 'YYYY-MM-DD HH:mm';
+const DEFAULT_LOCALE = 'en-US';
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+// A timestamp below this is far more plausibly seconds than milliseconds:
+// 1e11 ms is 1973, while 1e11 s is the year 5138.
+const SECONDS_UPPER_BOUND = 1e11;
+
+export const TRANSFORMS: Record<string, TransformFunction> = {
+    currency: (value, args) => {
+        const number = toNumber(value);
+
+        if (number === null) {
+            return value;
+        }
+
+        const code = (args[0] ?? 'usd').toUpperCase();
+        const locale = args[1] ?? DEFAULT_LOCALE;
+
+        try {
+            return new Intl.NumberFormat(locale, { currency: code, style: 'currency' }).format(
+                number,
+            );
+        } catch {
+            return `${code} ${number}`;
+        }
+    },
+
+    date: (value, args) => {
+        const date = toDate(value);
+
+        if (date === null) {
+            return value;
+        }
+
+        const pattern = args[0] ?? DEFAULT_DATE_PATTERN;
+
+        if (pattern === 'iso') {
+            return date.toISOString();
+        }
+
+        if (pattern === 'relative') {
+            return relativeTime(date.getTime());
+        }
+
+        return formatDate(date, pattern);
+    },
+
+    default: (value, args) => {
+        const fallback = args[0] ?? '';
+
+        if (value == null || value === '') {
+            return fallback;
+        }
+
+        return value;
+    },
+
+    divide: (value, args) => {
+        const number = toNumber(value);
+        const divisor = toNumber(args[0]);
+
+        if (number === null || divisor === null || divisor === 0) {
+            return value;
+        }
+
+        return number / divisor;
+    },
+
+    lower: (value) => (typeof value === 'string' ? value.toLowerCase() : value),
+
+    map: (value, args, context) => {
+        if (value == null) {
+            return value;
+        }
+
+        const replacement = context.replacements?.[String(value)];
+
+        if (replacement !== undefined) {
+            return replacement;
+        }
+
+        return args[0] ?? value;
+    },
+
+    multiply: (value, args) => {
+        const number = toNumber(value);
+        const factor = toNumber(args[0]);
+
+        if (number === null || factor === null) {
+            return value;
+        }
+
+        return number * factor;
+    },
+
+    number: (value, args) => {
+        const number = toNumber(value);
+
+        if (number === null) {
+            return value;
+        }
+
+        const digits = toNumber(args[0]);
+
+        if (digits === null) {
+            return new Intl.NumberFormat(DEFAULT_LOCALE).format(number);
+        }
+
+        return new Intl.NumberFormat(DEFAULT_LOCALE, {
+            maximumFractionDigits: clampDigits(digits),
+            minimumFractionDigits: clampDigits(digits),
+        }).format(number);
+    },
+
+    title: (value) =>
+        typeof value === 'string'
+            ? value.replace(
+                  /\S+/g,
+                  (word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
+              )
+            : value,
+
+    trim: (value) => (typeof value === 'string' ? value.trim() : value),
+
+    truncate: (value, args) => {
+        if (typeof value !== 'string') {
+            return value;
+        }
+
+        const limit = toNumber(args[0]);
+
+        if (limit === null || limit < 1 || value.length <= limit) {
+            return value;
+        }
+
+        return `${value.slice(0, limit)}…`;
+    },
+
+    upper: (value) => (typeof value === 'string' ? value.toUpperCase() : value),
+};
+
+export const TRANSFORM_NAMES = Object.keys(TRANSFORMS);
+
+// Wildcard paths resolve to arrays, so every filter maps over elements rather than
+// over the joined string — `items.*.amount | divide:100` must divide each amount.
+export function applyFilters(
+    value: unknown,
+    filters: TemplateFilter[],
+    context: TransformContext,
+): unknown {
+    return filters.reduce((current, filter) => applyFilter(current, filter, context), value);
+}
+
+export function isKnownTransform(name: string): boolean {
+    return name in TRANSFORMS;
+}
+
+function applyFilter(value: unknown, filter: TemplateFilter, context: TransformContext): unknown {
+    const transform = TRANSFORMS[filter.name];
+
+    // An unknown filter passes through: a typo must never fail a live delivery.
+    if (!transform) {
+        return value;
+    }
+
+    if (Array.isArray(value)) {
+        return value.map((item) => applyFilter(item, filter, context));
+    }
+
+    return transform(value, filter.args, context);
+}
+
+function clampDigits(digits: number): number {
+    return Math.min(20, Math.max(0, Math.trunc(digits)));
+}
+
+function formatDate(date: Date, pattern: string): string {
+    const tokens: Record<string, string> = {
+        DD: pad(date.getUTCDate()),
+        HH: pad(date.getUTCHours()),
+        MM: pad(date.getUTCMonth() + 1),
+        mm: pad(date.getUTCMinutes()),
+        MMM: MONTHS[date.getUTCMonth()]!,
+        ss: pad(date.getUTCSeconds()),
+        YYYY: String(date.getUTCFullYear()),
+    };
+
+    return pattern.replace(/YYYY|MMM|MM|DD|HH|mm|ss/g, (token) => tokens[token] ?? token);
+}
+
+function pad(value: number): string {
+    return String(value).padStart(2, '0');
+}
+
+function toDate(value: unknown): Date | null {
+    const number = toNumber(value);
+
+    if (number !== null) {
+        const milliseconds = Math.abs(number) < SECONDS_UPPER_BOUND ? number * 1000 : number;
+        const fromNumber = new Date(milliseconds);
+
+        return Number.isNaN(fromNumber.getTime()) ? null : fromNumber;
+    }
+
+    if (value instanceof Date) {
+        return Number.isNaN(value.getTime()) ? null : value;
+    }
+
+    if (typeof value !== 'string' || !value.trim()) {
+        return null;
+    }
+
+    const parsed = new Date(value);
+
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function toNumber(value: unknown): null | number {
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : null;
+    }
+
+    if (typeof value !== 'string' || !value.trim()) {
+        return null;
+    }
+
+    const parsed = Number(value);
+
+    return Number.isFinite(parsed) ? parsed : null;
+}

--- a/packages/emitsignal-website/src/components/app/webhooks/deliveries-log.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/deliveries-log.tsx
@@ -1,4 +1,7 @@
-import { applyTemplate as applyTemplateExact } from '@emitsignal/shared/webhook-template';
+import {
+    applyTemplate as applyTemplateExact,
+    sanitizeReplacements,
+} from '@emitsignal/shared/webhook-template';
 import { useNavigate } from '@tanstack/react-router';
 import { Copy, Edit, RefreshCw } from 'lucide-react';
 import { useState } from 'react';
@@ -81,15 +84,18 @@ export function DeliveriesLog({ webhookId }: { webhookId: string }) {
 
         try {
             const template = JSON.parse(webhook.template) as WebhookTemplate;
+            const replacements = sanitizeReplacements(template.replacements);
 
             return {
-                body: applyTemplate(template.body ?? '', delivery.payload),
+                body: applyTemplate(template.body ?? '', delivery.payload, replacements),
                 channel: delivery.channel,
-                link: applyTemplate(template.link ?? '', delivery.payload).trim(),
-                linkLabel: applyTemplateExact(template.linkLabel ?? '', delivery.payload),
+                link: applyTemplate(template.link ?? '', delivery.payload, replacements).trim(),
+                linkLabel: applyTemplateExact(template.linkLabel ?? '', delivery.payload, {
+                    replacements,
+                }),
                 priority: Number(template.priority ?? '3'),
-                tags: applyTemplate(template.tags ?? '', delivery.payload),
-                title: applyTemplate(template.title ?? '', delivery.payload),
+                tags: applyTemplate(template.tags ?? '', delivery.payload, replacements),
+                title: applyTemplate(template.title ?? '', delivery.payload, replacements),
             };
         } catch {
             return null;

--- a/packages/emitsignal-website/src/components/app/webhooks/priority-chip.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/priority-chip.tsx
@@ -1,0 +1,30 @@
+import { withAlpha } from '#/lib/color';
+
+interface PriorityChipProps {
+    active: boolean;
+    onClick: () => void;
+    value: number;
+}
+
+export function PriorityChip({ active, onClick, value }: PriorityChipProps) {
+    const hex = `var(--color-p${value})`;
+
+    return (
+        <button
+            className="flex flex-1 cursor-pointer items-center justify-center rounded-md border py-1.5 font-mono text-[11.5px] font-semibold"
+            onClick={onClick}
+            style={
+                active
+                    ? { background: withAlpha(hex, 13), borderColor: hex, color: hex }
+                    : {
+                          background: 'var(--color-elev)',
+                          borderColor: 'var(--color-line)',
+                          color: 'var(--color-dim)',
+                      }
+            }
+            type="button"
+        >
+            {value}
+        </button>
+    );
+}

--- a/packages/emitsignal-website/src/components/app/webhooks/template-fields.ts
+++ b/packages/emitsignal-website/src/components/app/webhooks/template-fields.ts
@@ -1,0 +1,55 @@
+import { parsePlaceholder } from '@emitsignal/shared/webhook-template';
+import { isKnownTransform } from '@emitsignal/shared/webhook-transforms';
+
+import type { WebhookTemplate } from '#/lib/api';
+
+export interface ReplacementRow {
+    from: string;
+    to: string;
+}
+
+export type TemplateTextField = Exclude<keyof WebhookTemplate, 'replacements'>;
+
+export const TEMPLATE_FIELDS = ['title', 'body', 'tags', 'link'] as const;
+
+export const EMPTY_TEMPLATE: WebhookTemplate = {
+    body: '',
+    link: '',
+    linkLabel: '',
+    priority: '3',
+    replacements: {},
+    tags: '',
+    title: '',
+};
+
+const PLACEHOLDER_HINTS: Record<(typeof TEMPLATE_FIELDS)[number], string> = {
+    body: 'event.description',
+    link: 'event.url',
+    tags: 'source, tag',
+    title: 'event.type',
+};
+
+export function placeholderHintFor(field: (typeof TEMPLATE_FIELDS)[number]): string {
+    return `{{${PLACEHOLDER_HINTS[field]}}}`;
+}
+
+export function toReplacementMap(rows: ReplacementRow[]): Record<string, string> {
+    return Object.fromEntries(
+        rows.filter((row) => row.from.trim()).map((row) => [row.from, row.to]),
+    );
+}
+
+export function toReplacementRows(
+    replacements: Record<string, string> | undefined,
+): ReplacementRow[] {
+    return Object.entries(replacements ?? {}).map(([from, to]) => ({ from, to }));
+}
+
+// Filters are ignored at delivery time when misspelled, so the editor is where a typo surfaces.
+export function unknownFiltersIn(input: string): string[] {
+    const names = [...input.matchAll(/\{\{\s*([^}]+)\s*\}\}/g)].flatMap(([, raw]) =>
+        parsePlaceholder(raw!).filters.map((filter) => filter.name),
+    );
+
+    return [...new Set(names.filter((name) => !isKnownTransform(name)))];
+}

--- a/packages/emitsignal-website/src/components/app/webhooks/template-string.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/template-string.tsx
@@ -6,8 +6,12 @@ interface TemplateStringProps {
 }
 
 // Preview wrapper: renders missing values as an em dash so the UI shows a placeholder.
-export function applyTemplate(str: string, data: Record<string, unknown>): string {
-    return applyTemplateShared(str, data, '—');
+export function applyTemplate(
+    str: string,
+    data: Record<string, unknown>,
+    replacements?: Record<string, string>,
+): string {
+    return applyTemplateShared(str, data, { defaultValue: '—', replacements });
 }
 
 export function TemplateString({ size = 12.5, str }: TemplateStringProps) {

--- a/packages/emitsignal-website/src/components/app/webhooks/webhook-create.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/webhook-create.tsx
@@ -5,7 +5,12 @@ import {
     defaultVerificationForSource,
     schemeNeedsConfig,
 } from '@emitsignal/shared';
-import { applyTemplate as applyTemplateExact } from '@emitsignal/shared/webhook-template';
+import {
+    applyTemplate as applyTemplateExact,
+    parsePlaceholder,
+    sanitizeReplacements,
+} from '@emitsignal/shared/webhook-template';
+import { isKnownTransform, TRANSFORM_NAMES } from '@emitsignal/shared/webhook-transforms';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { ChevronDown, Copy } from 'lucide-react';
@@ -118,11 +123,19 @@ const EMPTY_TEMPLATE: WebhookTemplate = {
     link: '',
     linkLabel: '',
     priority: '3',
+    replacements: {},
     tags: '',
     title: '',
 };
 
-// ── Props ─────────────────────────────────────────────────────────────────────
+const TEMPLATE_FIELDS = ['title', 'body', 'tags', 'link'] as const;
+
+interface ReplacementRow {
+    from: string;
+    to: string;
+}
+
+type TemplateTextField = Exclude<keyof WebhookTemplate, 'replacements'>;
 
 interface WebhookCreateProps {
     initialData?: {
@@ -139,6 +152,27 @@ interface WebhookCreateProps {
         | 'verification'
         | 'verificationConfig'
     >;
+}
+
+function toReplacementMap(rows: ReplacementRow[]): Record<string, string> {
+    return Object.fromEntries(
+        rows.filter((row) => row.from.trim()).map((row) => [row.from, row.to]),
+    );
+}
+
+function toReplacementRows(replacements: Record<string, string> | undefined): ReplacementRow[] {
+    return Object.entries(replacements ?? {}).map(([from, to]) => ({ from, to }));
+}
+
+// ── Props ─────────────────────────────────────────────────────────────────────
+
+// Filters are ignored at delivery time when misspelled, so the editor is where a typo surfaces.
+function unknownFiltersIn(input: string): string[] {
+    const names = [...input.matchAll(/\{\{\s*([^}]+)\s*\}\}/g)].flatMap(([, raw]) =>
+        parsePlaceholder(raw!).filters.map((filter) => filter.name),
+    );
+
+    return [...new Set(names.filter((name) => !isKnownTransform(name)))];
 }
 
 const EMPTY_CONFIG: VerificationConfig = {
@@ -200,6 +234,9 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
     );
     const [topicName, setTopicName] = useState(initialData?.topicName ?? '');
     const [useTemplate, setUseTemplate] = useState(initialTemplate !== null);
+    const [replacementRows, setReplacementRows] = useState<ReplacementRow[]>(
+        toReplacementRows((initialTemplate ?? EMPTY_TEMPLATE).replacements),
+    );
     const templateDirtyRef = useRef(false);
 
     const [verificationConfig, setVerificationConfig] = useState<VerificationConfig>(
@@ -223,14 +260,18 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
 
     const showRaw = !useTemplate || previewMode === 'raw';
 
+    const replacements = sanitizeReplacements(templateFields.replacements);
+
     const rendered = {
-        body: applyTemplate(templateFields.body ?? '', activePayload),
+        body: applyTemplate(templateFields.body ?? '', activePayload, replacements),
         channel: topicName || `${source}/channel`,
-        link: applyTemplate(templateFields.link ?? '', activePayload).trim(),
-        linkLabel: applyTemplateExact(templateFields.linkLabel ?? '', activePayload),
+        link: applyTemplate(templateFields.link ?? '', activePayload, replacements).trim(),
+        linkLabel: applyTemplateExact(templateFields.linkLabel ?? '', activePayload, {
+            replacements,
+        }),
         priority: Number(templateFields.priority ?? '3'),
-        tags: applyTemplate(templateFields.tags ?? '', activePayload),
-        title: applyTemplate(templateFields.title ?? '', activePayload),
+        tags: applyTemplate(templateFields.tags ?? '', activePayload, replacements),
+        title: applyTemplate(templateFields.title ?? '', activePayload, replacements),
     };
 
     function handleSourceChange(source: Source) {
@@ -267,10 +308,17 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
         }
     }
 
-    function handleTemplateFieldChange(field: keyof WebhookTemplate, value: string) {
+    function handleTemplateFieldChange(field: TemplateTextField, value: string) {
         templateDirtyRef.current = true;
 
         setTemplateFields((prev) => ({ ...prev, [field]: value }));
+    }
+
+    function handleReplacementRowsChange(rows: ReplacementRow[]) {
+        templateDirtyRef.current = true;
+
+        setReplacementRows(rows);
+        setTemplateFields((prev) => ({ ...prev, replacements: toReplacementMap(rows) }));
     }
 
     function handleCustomPayloadChange(text: string) {
@@ -583,21 +631,31 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
                             pointerEvents: useTemplate ? 'auto' : 'none',
                         }}
                     >
-                        {(['title', 'body', 'tags', 'link'] as const).map((field) => (
-                            <div className="mb-2.5" key={field}>
-                                <div className="mb-1 font-mono text-[10px] uppercase tracking-[1px] text-dim">
-                                    {field}
+                        {TEMPLATE_FIELDS.map((field) => {
+                            const unknownFilters = unknownFiltersIn(templateFields[field] ?? '');
+
+                            return (
+                                <div className="mb-2.5" key={field}>
+                                    <div className="mb-1 font-mono text-[10px] uppercase tracking-[1px] text-dim">
+                                        {field}
+                                    </div>
+                                    <input
+                                        className="w-full rounded-lg border border-line bg-elev px-3 py-2 font-mono text-[12.5px] text-fg outline-none placeholder:text-faint focus:border-accent/50"
+                                        onChange={(e) =>
+                                            handleTemplateFieldChange(field, e.target.value)
+                                        }
+                                        placeholder={`{{${field === 'title' ? 'event.type' : field === 'body' ? 'event.description' : field === 'tags' ? 'source, tag' : 'event.url'}}}`}
+                                        value={templateFields[field] ?? ''}
+                                    />
+                                    {unknownFilters.length > 0 && (
+                                        <div className="mt-1 font-mono text-[10.5px] text-warn">
+                                            Unknown filter{unknownFilters.length > 1 ? 's' : ''}:{' '}
+                                            {unknownFilters.join(', ')} — ignored on delivery.
+                                        </div>
+                                    )}
                                 </div>
-                                <input
-                                    className="w-full rounded-lg border border-line bg-elev px-3 py-2 font-mono text-[12.5px] text-fg outline-none placeholder:text-faint focus:border-accent/50"
-                                    onChange={(e) =>
-                                        handleTemplateFieldChange(field, e.target.value)
-                                    }
-                                    placeholder={`{{${field === 'title' ? 'event.type' : field === 'body' ? 'event.description' : field === 'tags' ? 'source, tag' : 'event.url'}}}`}
-                                    value={templateFields[field] ?? ''}
-                                />
-                            </div>
-                        ))}
+                            );
+                        })}
 
                         {(templateFields.link ?? '') !== '' && (
                             <div className="mb-2.5">
@@ -638,6 +696,92 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
                                 ))}
                             </div>
                         </div>
+
+                        <div className="mb-2.5">
+                            <div className="mb-1 flex items-baseline gap-2 font-mono text-[10px] uppercase tracking-[1px] text-dim">
+                                Replacements
+                                <span className="normal-case tracking-normal text-faint">
+                                    optional · used by the {'{{ value | map }}'} filter
+                                </span>
+                            </div>
+
+                            {replacementRows.map((row, index) => (
+                                <div className="mb-1 flex gap-1" key={index}>
+                                    <input
+                                        className="w-full rounded-lg border border-line bg-elev px-3 py-2 font-mono text-[12.5px] text-fg outline-none placeholder:text-faint focus:border-accent/50"
+                                        onChange={(e) =>
+                                            handleReplacementRowsChange(
+                                                replacementRows.map((current, position) =>
+                                                    position === index
+                                                        ? { ...current, from: e.target.value }
+                                                        : current,
+                                                ),
+                                            )
+                                        }
+                                        placeholder="customer.subscription.created"
+                                        value={row.from}
+                                    />
+                                    <input
+                                        className="w-full rounded-lg border border-line bg-elev px-3 py-2 font-mono text-[12.5px] text-fg outline-none placeholder:text-faint focus:border-accent/50"
+                                        onChange={(e) =>
+                                            handleReplacementRowsChange(
+                                                replacementRows.map((current, position) =>
+                                                    position === index
+                                                        ? { ...current, to: e.target.value }
+                                                        : current,
+                                                ),
+                                            )
+                                        }
+                                        placeholder="Assinatura criada"
+                                        value={row.to}
+                                    />
+                                    <button
+                                        className="rounded-lg border border-line px-2.5 font-mono text-[12px] text-dim hover:text-fg"
+                                        onClick={() =>
+                                            handleReplacementRowsChange(
+                                                replacementRows.filter(
+                                                    (_, position) => position !== index,
+                                                ),
+                                            )
+                                        }
+                                        type="button"
+                                    >
+                                        ×
+                                    </button>
+                                </div>
+                            ))}
+
+                            <button
+                                className="rounded-lg border border-line px-2.5 py-1.5 font-mono text-[11px] text-dim hover:text-fg"
+                                onClick={() =>
+                                    handleReplacementRowsChange([
+                                        ...replacementRows,
+                                        { from: '', to: '' },
+                                    ])
+                                }
+                                type="button"
+                            >
+                                + Add replacement
+                            </button>
+                        </div>
+
+                        <details className="mb-3">
+                            <summary className="cursor-pointer font-mono text-[10px] uppercase tracking-[1px] text-dim">
+                                Available filters
+                            </summary>
+                            <div className="mt-1.5 font-mono text-[11px] leading-relaxed text-faint">
+                                {TRANSFORM_NAMES.join(' · ')}
+                                <div className="mt-1.5 text-dim">
+                                    {"{{ created | date:'YYYY-MM-DD HH:mm' }}"}
+                                </div>
+                                <div className="text-dim">
+                                    {
+                                        "{{ data.object.items.data.*.price.unit_amount | divide:100 | currency:'usd' }}"
+                                    }
+                                </div>
+                                <div className="text-dim">{'{{ type | map }}'}</div>
+                            </div>
+                        </details>
                     </div>
 
                     {/* preview */}

--- a/packages/emitsignal-website/src/components/app/webhooks/webhook-create.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/webhook-create.tsx
@@ -7,27 +7,29 @@ import {
 } from '@emitsignal/shared';
 import {
     applyTemplate as applyTemplateExact,
-    parsePlaceholder,
     sanitizeReplacements,
 } from '@emitsignal/shared/webhook-template';
-import { isKnownTransform, TRANSFORM_NAMES } from '@emitsignal/shared/webhook-transforms';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { ChevronDown, Copy } from 'lucide-react';
+import { Copy } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import type { Webhook, WebhookTemplate } from '#/lib/api';
 
-import { Dot } from '#/components/ui/dot';
-import { useSubscriptions } from '#/ctx/subscriptions';
 import { api, API_URL } from '#/lib/api';
-import { withAlpha } from '#/lib/color';
 import { queryKeys } from '#/lib/query-client';
+
+import type { ReplacementRow, TemplateTextField } from './template-fields';
+import type { WebhookTab } from './webhook-tab-bar';
 
 import { JsonView } from './json-view';
 import { NotifPreview } from './notif-preview';
+import { EMPTY_TEMPLATE, toReplacementMap, toReplacementRows } from './template-fields';
 import { applyTemplate } from './template-string';
 import { VerificationFields } from './verification-fields';
+import { WebhookSettingsTab } from './webhook-settings-tab';
+import { WebhookTabBar } from './webhook-tab-bar';
+import { WebhookTemplateTab } from './webhook-template-tab';
 
 const SOURCE_DATA: Record<
     string,
@@ -118,25 +120,6 @@ const GLYPH: Record<Source, string> = {
     vercel: 'VC',
 };
 
-const EMPTY_TEMPLATE: WebhookTemplate = {
-    body: '',
-    link: '',
-    linkLabel: '',
-    priority: '3',
-    replacements: {},
-    tags: '',
-    title: '',
-};
-
-const TEMPLATE_FIELDS = ['title', 'body', 'tags', 'link'] as const;
-
-interface ReplacementRow {
-    from: string;
-    to: string;
-}
-
-type TemplateTextField = Exclude<keyof WebhookTemplate, 'replacements'>;
-
 interface WebhookCreateProps {
     initialData?: {
         samplePayload?: null | string;
@@ -152,27 +135,6 @@ interface WebhookCreateProps {
         | 'verification'
         | 'verificationConfig'
     >;
-}
-
-function toReplacementMap(rows: ReplacementRow[]): Record<string, string> {
-    return Object.fromEntries(
-        rows.filter((row) => row.from.trim()).map((row) => [row.from, row.to]),
-    );
-}
-
-function toReplacementRows(replacements: Record<string, string> | undefined): ReplacementRow[] {
-    return Object.entries(replacements ?? {}).map(([from, to]) => ({ from, to }));
-}
-
-// ── Props ─────────────────────────────────────────────────────────────────────
-
-// Filters are ignored at delivery time when misspelled, so the editor is where a typo surfaces.
-function unknownFiltersIn(input: string): string[] {
-    const names = [...input.matchAll(/\{\{\s*([^}]+)\s*\}\}/g)].flatMap(([, raw]) =>
-        parsePlaceholder(raw!).filters.map((filter) => filter.name),
-    );
-
-    return [...new Set(names.filter((name) => !isKnownTransform(name)))];
 }
 
 const EMPTY_CONFIG: VerificationConfig = {
@@ -199,7 +161,6 @@ const EMPTY_PAYLOAD = '{\n  \n}';
 // ── Component ─────────────────────────────────────────────────────────────────
 
 export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
-    const { subscriptions } = useSubscriptions();
     const isEdit = !!initialData;
     const navigate = useNavigate();
     const queryClient = useQueryClient();
@@ -216,6 +177,7 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
         }
     })();
 
+    const [activeTab, setActiveTab] = useState<WebhookTab>(isEdit ? 'template' : 'settings');
     const [copied, setCopied] = useState(false);
     const [customPayloadText, setCustomPayloadText] = useState(
         initialData?.samplePayload ?? EMPTY_PAYLOAD,
@@ -259,6 +221,7 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
             : SOURCE_DATA[source]!.payload;
 
     const showRaw = !useTemplate || previewMode === 'raw';
+    const invalidTabs: WebhookTab[] = saveError && !topicName.trim() ? ['settings'] : [];
 
     const replacements = sanitizeReplacements(templateFields.replacements);
 
@@ -345,6 +308,8 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
 
     async function handleSave() {
         if (!topicName.trim()) {
+            setActiveTab('settings');
+
             return setSaveError('Channel name is required');
         }
 
@@ -440,7 +405,8 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
 
     return (
         <div className="flex min-h-0 flex-1 flex-col">
-            <div className="grid grid-cols-[1.1fr_1.6fr_1.1fr] gap-5 border-b border-line px-6 py-4">
+            {/* identity: source drives the sample payload, endpoint is the thing you copy */}
+            <div className="grid grid-cols-[auto_1fr] items-end gap-5 border-b border-line px-6 py-4">
                 <div>
                     <div className="mb-2 font-mono text-[10px] uppercase tracking-[1.3px] text-dim">
                         Source
@@ -467,6 +433,7 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
                                           }
                                 }
                                 title={s}
+                                type="button"
                             >
                                 {GLYPH[s]}
                             </button>
@@ -474,7 +441,6 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
                     </div>
                 </div>
 
-                {/* Endpoint URL */}
                 <div>
                     <div className="mb-2 font-mono text-[10px] uppercase tracking-[1.3px] text-dim">
                         Endpoint URL
@@ -491,6 +457,7 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
                             disabled={!isEdit}
                             onClick={handleCopyEndpoint}
                             title={copied ? 'Copied!' : 'Copy endpoint URL'}
+                            type="button"
                         >
                             {copied ? (
                                 <span className="font-mono text-[9px] text-success leading-none">
@@ -502,56 +469,7 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
                         </button>
                     </div>
                 </div>
-
-                {/* Channel */}
-                <div>
-                    <div className="mb-2 font-mono text-[10px] uppercase tracking-[1.3px] text-dim">
-                        Publish to channel
-                    </div>
-                    <div
-                        className="flex items-center gap-2 rounded-lg border bg-elev px-3 py-2"
-                        style={{
-                            borderColor:
-                                saveError && !topicName.trim()
-                                    ? 'var(--color-danger)'
-                                    : 'var(--color-line)',
-                        }}
-                    >
-                        <Dot level={2} size={6} />
-
-                        <select
-                            className="flex-1 bg-transparent font-mono text-[12px] text-fg outline-none"
-                            onChange={(e) => setTopicName(e.target.value)}
-                            value={topicName}
-                        >
-                            <option disabled value="">
-                                Select a channel…
-                            </option>
-
-                            {subscriptions.map((subscription) => (
-                                <option key={subscription.id} value={subscription.topic.name}>
-                                    {subscription.topic.displayName}
-                                </option>
-                            ))}
-                        </select>
-                        <ChevronDown className="pointer-events-none text-dim" size={13} />
-                    </div>
-
-                    {saveError && (
-                        <div className="mt-1 font-mono text-[10.5px] text-danger">{saveError}</div>
-                    )}
-                </div>
             </div>
-
-            <VerificationFields
-                config={verificationConfig}
-                hasStoredSecret={!!initialData?.hasSecret}
-                onConfigChange={setVerificationConfig}
-                onSchemeChange={handleSchemeChange}
-                onSecretChange={setSecret}
-                scheme={scheme}
-                secret={secret}
-            />
 
             {/* editor split */}
             <div className="flex min-h-0 flex-1">
@@ -587,205 +505,49 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
                     </div>
                 </div>
 
-                {/* template + preview pane */}
-                <div className="flex min-w-0 flex-1 flex-col overflow-auto">
-                    {/* template toggle */}
-                    <div className="flex items-center px-5 py-3.5">
-                        <span className="font-mono text-[10px] uppercase tracking-[1.5px] text-dim">
-                            Template
-                        </span>
+                {/* config pane: one tab at a time, preview pinned below */}
+                <div className="flex min-w-0 flex-1 flex-col">
+                    <WebhookTabBar
+                        active={activeTab}
+                        invalid={invalidTabs}
+                        onChange={setActiveTab}
+                    />
 
-                        <button
-                            className="ml-auto flex cursor-pointer items-center gap-2"
-                            onClick={() => setUseTemplate((v) => !v)}
-                        >
-                            <span
-                                className="font-mono text-[11px]"
-                                style={{
-                                    color: useTemplate ? 'var(--color-accent)' : 'var(--color-dim)',
-                                }}
-                            >
-                                {useTemplate ? 'Using template' : 'Raw passthrough'}
-                            </span>
-                            <div
-                                className="flex items-center rounded-full p-0.5 transition-colors"
-                                style={{
-                                    background: useTemplate
-                                        ? 'var(--color-accent)'
-                                        : 'var(--color-line)',
-                                    height: 21,
-                                    justifyContent: useTemplate ? 'flex-end' : 'flex-start',
-                                    width: 36,
-                                }}
-                            >
-                                <div className="h-[17px] w-[17px] rounded-full bg-fg" />
-                            </div>
-                        </button>
-                    </div>
-
-                    {/* template fields (editable) */}
-                    <div
-                        className="px-5 transition-opacity"
-                        style={{
-                            opacity: useTemplate ? 1 : 0.4,
-                            pointerEvents: useTemplate ? 'auto' : 'none',
-                        }}
-                    >
-                        {TEMPLATE_FIELDS.map((field) => {
-                            const unknownFilters = unknownFiltersIn(templateFields[field] ?? '');
-
-                            return (
-                                <div className="mb-2.5" key={field}>
-                                    <div className="mb-1 font-mono text-[10px] uppercase tracking-[1px] text-dim">
-                                        {field}
-                                    </div>
-                                    <input
-                                        className="w-full rounded-lg border border-line bg-elev px-3 py-2 font-mono text-[12.5px] text-fg outline-none placeholder:text-faint focus:border-accent/50"
-                                        onChange={(e) =>
-                                            handleTemplateFieldChange(field, e.target.value)
-                                        }
-                                        placeholder={`{{${field === 'title' ? 'event.type' : field === 'body' ? 'event.description' : field === 'tags' ? 'source, tag' : 'event.url'}}}`}
-                                        value={templateFields[field] ?? ''}
-                                    />
-                                    {unknownFilters.length > 0 && (
-                                        <div className="mt-1 font-mono text-[10.5px] text-warn">
-                                            Unknown filter{unknownFilters.length > 1 ? 's' : ''}:{' '}
-                                            {unknownFilters.join(', ')} — ignored on delivery.
-                                        </div>
-                                    )}
-                                </div>
-                            );
-                        })}
-
-                        {(templateFields.link ?? '') !== '' && (
-                            <div className="mb-2.5">
-                                <div className="mb-1 flex items-baseline gap-2 font-mono text-[10px] uppercase tracking-[1px] text-dim">
-                                    Button label
-                                    <span className="normal-case tracking-normal text-faint">
-                                        optional · defaults to “View”
-                                    </span>
-                                </div>
-                                <input
-                                    className="w-full rounded-lg border border-line bg-elev px-3 py-2 font-mono text-[12.5px] text-fg outline-none placeholder:text-faint focus:border-accent/50"
-                                    onChange={(e) =>
-                                        handleTemplateFieldChange('linkLabel', e.target.value)
-                                    }
-                                    placeholder="View"
-                                    value={templateFields.linkLabel ?? ''}
-                                />
-                            </div>
+                    <div className="min-h-0 flex-1 overflow-auto">
+                        {activeTab === 'settings' && (
+                            <WebhookSettingsTab
+                                error={saveError}
+                                onTopicNameChange={setTopicName}
+                                topicName={topicName}
+                            />
                         )}
 
-                        <div className="mb-2.5">
-                            <div className="mb-1 font-mono text-[10px] uppercase tracking-[1px] text-dim">
-                                Priority
-                            </div>
+                        {activeTab === 'signature' && (
+                            <VerificationFields
+                                config={verificationConfig}
+                                hasStoredSecret={!!initialData?.hasSecret}
+                                onConfigChange={setVerificationConfig}
+                                onSchemeChange={handleSchemeChange}
+                                onSecretChange={setSecret}
+                                scheme={scheme}
+                                secret={secret}
+                            />
+                        )}
 
-                            <div className="flex gap-1">
-                                {[1, 2, 3, 4, 5].map((priority) => (
-                                    <PriorityChip
-                                        active={
-                                            String(priority) === (templateFields.priority ?? '3')
-                                        }
-                                        key={priority}
-                                        onClick={() =>
-                                            handleTemplateFieldChange('priority', String(priority))
-                                        }
-                                        value={priority}
-                                    />
-                                ))}
-                            </div>
-                        </div>
-
-                        <div className="mb-2.5">
-                            <div className="mb-1 flex items-baseline gap-2 font-mono text-[10px] uppercase tracking-[1px] text-dim">
-                                Replacements
-                                <span className="normal-case tracking-normal text-faint">
-                                    optional · used by the {'{{ value | map }}'} filter
-                                </span>
-                            </div>
-
-                            {replacementRows.map((row, index) => (
-                                <div className="mb-1 flex gap-1" key={index}>
-                                    <input
-                                        className="w-full rounded-lg border border-line bg-elev px-3 py-2 font-mono text-[12.5px] text-fg outline-none placeholder:text-faint focus:border-accent/50"
-                                        onChange={(e) =>
-                                            handleReplacementRowsChange(
-                                                replacementRows.map((current, position) =>
-                                                    position === index
-                                                        ? { ...current, from: e.target.value }
-                                                        : current,
-                                                ),
-                                            )
-                                        }
-                                        placeholder="customer.subscription.created"
-                                        value={row.from}
-                                    />
-                                    <input
-                                        className="w-full rounded-lg border border-line bg-elev px-3 py-2 font-mono text-[12.5px] text-fg outline-none placeholder:text-faint focus:border-accent/50"
-                                        onChange={(e) =>
-                                            handleReplacementRowsChange(
-                                                replacementRows.map((current, position) =>
-                                                    position === index
-                                                        ? { ...current, to: e.target.value }
-                                                        : current,
-                                                ),
-                                            )
-                                        }
-                                        placeholder="Assinatura criada"
-                                        value={row.to}
-                                    />
-                                    <button
-                                        className="rounded-lg border border-line px-2.5 font-mono text-[12px] text-dim hover:text-fg"
-                                        onClick={() =>
-                                            handleReplacementRowsChange(
-                                                replacementRows.filter(
-                                                    (_, position) => position !== index,
-                                                ),
-                                            )
-                                        }
-                                        type="button"
-                                    >
-                                        ×
-                                    </button>
-                                </div>
-                            ))}
-
-                            <button
-                                className="rounded-lg border border-line px-2.5 py-1.5 font-mono text-[11px] text-dim hover:text-fg"
-                                onClick={() =>
-                                    handleReplacementRowsChange([
-                                        ...replacementRows,
-                                        { from: '', to: '' },
-                                    ])
-                                }
-                                type="button"
-                            >
-                                + Add replacement
-                            </button>
-                        </div>
-
-                        <details className="mb-3">
-                            <summary className="cursor-pointer font-mono text-[10px] uppercase tracking-[1px] text-dim">
-                                Available filters
-                            </summary>
-                            <div className="mt-1.5 font-mono text-[11px] leading-relaxed text-faint">
-                                {TRANSFORM_NAMES.join(' · ')}
-                                <div className="mt-1.5 text-dim">
-                                    {"{{ created | date:'YYYY-MM-DD HH:mm' }}"}
-                                </div>
-                                <div className="text-dim">
-                                    {
-                                        "{{ data.object.items.data.*.price.unit_amount | divide:100 | currency:'usd' }}"
-                                    }
-                                </div>
-                                <div className="text-dim">{'{{ type | map }}'}</div>
-                            </div>
-                        </details>
+                        {activeTab === 'template' && (
+                            <WebhookTemplateTab
+                                fields={templateFields}
+                                onFieldChange={handleTemplateFieldChange}
+                                onReplacementRowsChange={handleReplacementRowsChange}
+                                onUseTemplateChange={setUseTemplate}
+                                replacementRows={replacementRows}
+                                useTemplate={useTemplate}
+                            />
+                        )}
                     </div>
 
-                    {/* preview */}
-                    <div className="border-t border-line bg-deep px-5 py-4">
+                    {/* preview stays put so editing any tab shows its effect immediately */}
+                    <div className="shrink-0 border-t border-line bg-deep px-5 py-4">
                         <div className="mb-3 flex items-center">
                             <span className="font-mono text-[10px] uppercase tracking-[1.5px] text-dim">
                                 {showRaw ? 'Preview · Raw payload' : 'Preview · Notification'}
@@ -810,6 +572,7 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
                                                   }
                                                 : { color: 'var(--color-muted)' }
                                         }
+                                        type="button"
                                     >
                                         {option.charAt(0).toUpperCase() + option.slice(1)}
                                     </button>
@@ -842,45 +605,19 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
             </div>
 
             {/* save bar */}
-            <div className="flex justify-end gap-2 border-t border-line px-6 py-3">
+            <div className="flex items-center justify-end gap-3 border-t border-line px-6 py-3">
+                {saveError && (
+                    <span className="font-mono text-[11px] text-danger">{saveError}</span>
+                )}
                 <button
                     className="rounded-md bg-accent px-4 py-1.5 text-[12px] font-semibold text-bg hover:bg-accent-dim disabled:opacity-50"
                     disabled={saving || (source === 'custom' && !customPayloadValid)}
                     onClick={() => void handleSave()}
+                    type="button"
                 >
                     {saving ? 'Saving…' : isEdit ? 'Save changes' : 'Save webhook'}
                 </button>
             </div>
         </div>
-    );
-}
-
-function PriorityChip({
-    active,
-    onClick,
-    value,
-}: {
-    active: boolean;
-    onClick: () => void;
-    value: number;
-}) {
-    const hex = `var(--color-p${value})`;
-
-    return (
-        <button
-            className="flex flex-1 cursor-pointer items-center justify-center rounded-md border py-1.5 font-mono text-[11.5px] font-semibold"
-            onClick={onClick}
-            style={
-                active
-                    ? { background: withAlpha(hex, 13), borderColor: hex, color: hex }
-                    : {
-                          background: 'var(--color-elev)',
-                          borderColor: 'var(--color-line)',
-                          color: 'var(--color-dim)',
-                      }
-            }
-        >
-            {value}
-        </button>
     );
 }

--- a/packages/emitsignal-website/src/components/app/webhooks/webhook-settings-tab.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/webhook-settings-tab.tsx
@@ -1,0 +1,56 @@
+import { ChevronDown } from 'lucide-react';
+
+import { Dot } from '#/components/ui/dot';
+import { useSubscriptions } from '#/ctx/subscriptions';
+
+interface WebhookSettingsTabProps {
+    error: null | string;
+    onTopicNameChange: (topicName: string) => void;
+    topicName: string;
+}
+
+export function WebhookSettingsTab({
+    error,
+    onTopicNameChange,
+    topicName,
+}: WebhookSettingsTabProps) {
+    const { subscriptions } = useSubscriptions();
+    const missing = !!error && !topicName.trim();
+
+    return (
+        <div className="px-5 py-4">
+            <div className="mb-1 flex items-baseline gap-2 font-mono text-[10px] uppercase tracking-[1px] text-dim">
+                Publish to channel
+                <span className="normal-case tracking-normal text-faint">
+                    required · where deliveries land
+                </span>
+            </div>
+
+            <div
+                className="flex items-center gap-2 rounded-lg border bg-elev px-3 py-2"
+                style={{ borderColor: missing ? 'var(--color-danger)' : 'var(--color-line)' }}
+            >
+                <Dot level={2} size={6} />
+
+                <select
+                    className="flex-1 bg-transparent font-mono text-[12px] text-fg outline-none"
+                    onChange={(event) => onTopicNameChange(event.target.value)}
+                    value={topicName}
+                >
+                    <option disabled value="">
+                        Select a channel…
+                    </option>
+
+                    {subscriptions.map((subscription) => (
+                        <option key={subscription.id} value={subscription.topic.name}>
+                            {subscription.topic.displayName}
+                        </option>
+                    ))}
+                </select>
+                <ChevronDown className="pointer-events-none text-dim" size={13} />
+            </div>
+
+            {error && <div className="mt-1 font-mono text-[10.5px] text-danger">{error}</div>}
+        </div>
+    );
+}

--- a/packages/emitsignal-website/src/components/app/webhooks/webhook-tab-bar.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/webhook-tab-bar.tsx
@@ -1,0 +1,44 @@
+export type WebhookTab = 'settings' | 'signature' | 'template';
+
+interface WebhookTabBarProps {
+    active: WebhookTab;
+    // Tabs holding a validation error, marked so a problem is findable from any tab.
+    invalid?: WebhookTab[];
+    onChange: (tab: WebhookTab) => void;
+}
+
+const TABS: { id: WebhookTab; label: string }[] = [
+    { id: 'settings', label: 'Settings' },
+    { id: 'signature', label: 'Signature' },
+    { id: 'template', label: 'Template' },
+];
+
+export function WebhookTabBar({ active, invalid = [], onChange }: WebhookTabBarProps) {
+    return (
+        <div className="flex gap-4 border-b border-line px-5" role="tablist">
+            {TABS.map((tab) => {
+                const isActive = tab.id === active;
+
+                return (
+                    <button
+                        aria-selected={isActive}
+                        className="flex cursor-pointer items-center gap-1.5 border-b-2 py-3 font-mono text-[11px] uppercase tracking-[1.2px] transition-colors"
+                        key={tab.id}
+                        onClick={() => onChange(tab.id)}
+                        role="tab"
+                        style={{
+                            borderBottomColor: isActive ? 'var(--color-accent)' : 'transparent',
+                            color: isActive ? 'var(--color-accent)' : 'var(--color-dim)',
+                        }}
+                        type="button"
+                    >
+                        {tab.label}
+                        {invalid.includes(tab.id) && (
+                            <span className="h-1.5 w-1.5 rounded-full bg-danger" />
+                        )}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/packages/emitsignal-website/src/components/app/webhooks/webhook-template-tab.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/webhook-template-tab.tsx
@@ -1,0 +1,199 @@
+import { TRANSFORM_NAMES } from '@emitsignal/shared/webhook-transforms';
+
+import type { WebhookTemplate } from '#/lib/api';
+
+import type { ReplacementRow, TemplateTextField } from './template-fields';
+
+import { PriorityChip } from './priority-chip';
+import { placeholderHintFor, TEMPLATE_FIELDS, unknownFiltersIn } from './template-fields';
+
+interface WebhookTemplateTabProps {
+    fields: WebhookTemplate;
+    onFieldChange: (field: TemplateTextField, value: string) => void;
+    onReplacementRowsChange: (rows: ReplacementRow[]) => void;
+    onUseTemplateChange: (useTemplate: boolean) => void;
+    replacementRows: ReplacementRow[];
+    useTemplate: boolean;
+}
+
+export function WebhookTemplateTab({
+    fields,
+    onFieldChange,
+    onReplacementRowsChange,
+    onUseTemplateChange,
+    replacementRows,
+    useTemplate,
+}: WebhookTemplateTabProps) {
+    function updateRow(index: number, patch: Partial<ReplacementRow>) {
+        onReplacementRowsChange(
+            replacementRows.map((row, position) =>
+                position === index ? { ...row, ...patch } : row,
+            ),
+        );
+    }
+
+    return (
+        <div className="px-5 py-4">
+            <button
+                className="mb-3 flex w-full cursor-pointer items-center"
+                onClick={() => onUseTemplateChange(!useTemplate)}
+                type="button"
+            >
+                <span
+                    className="font-mono text-[11px]"
+                    style={{ color: useTemplate ? 'var(--color-accent)' : 'var(--color-dim)' }}
+                >
+                    {useTemplate ? 'Using template' : 'Raw passthrough'}
+                </span>
+                <div
+                    className="ml-auto flex items-center rounded-full p-0.5 transition-colors"
+                    style={{
+                        background: useTemplate ? 'var(--color-accent)' : 'var(--color-line)',
+                        height: 21,
+                        justifyContent: useTemplate ? 'flex-end' : 'flex-start',
+                        width: 36,
+                    }}
+                >
+                    <div className="h-[17px] w-[17px] rounded-full bg-fg" />
+                </div>
+            </button>
+
+            <div
+                className="transition-opacity"
+                style={{
+                    opacity: useTemplate ? 1 : 0.4,
+                    pointerEvents: useTemplate ? 'auto' : 'none',
+                }}
+            >
+                {TEMPLATE_FIELDS.map((field) => {
+                    const unknownFilters = unknownFiltersIn(fields[field] ?? '');
+
+                    return (
+                        <div className="mb-2.5" key={field}>
+                            <div className="mb-1 font-mono text-[10px] uppercase tracking-[1px] text-dim">
+                                {field}
+                            </div>
+                            <input
+                                className="w-full rounded-lg border border-line bg-elev px-3 py-2 font-mono text-[12.5px] text-fg outline-none placeholder:text-faint focus:border-accent/50"
+                                onChange={(event) => onFieldChange(field, event.target.value)}
+                                placeholder={placeholderHintFor(field)}
+                                value={fields[field] ?? ''}
+                            />
+                            {unknownFilters.length > 0 && (
+                                <div className="mt-1 font-mono text-[10.5px] text-warn">
+                                    Unknown filter{unknownFilters.length > 1 ? 's' : ''}:{' '}
+                                    {unknownFilters.join(', ')}, ignored on delivery.
+                                </div>
+                            )}
+                        </div>
+                    );
+                })}
+
+                {(fields.link ?? '') !== '' && (
+                    <div className="mb-2.5">
+                        <div className="mb-1 flex items-baseline gap-2 font-mono text-[10px] uppercase tracking-[1px] text-dim">
+                            Button label
+                            <span className="normal-case tracking-normal text-faint">
+                                optional · defaults to “View”
+                            </span>
+                        </div>
+                        <input
+                            className="w-full rounded-lg border border-line bg-elev px-3 py-2 font-mono text-[12.5px] text-fg outline-none placeholder:text-faint focus:border-accent/50"
+                            onChange={(event) => onFieldChange('linkLabel', event.target.value)}
+                            placeholder="View"
+                            value={fields.linkLabel ?? ''}
+                        />
+                    </div>
+                )}
+
+                <div className="mb-2.5">
+                    <div className="mb-1 font-mono text-[10px] uppercase tracking-[1px] text-dim">
+                        Priority
+                    </div>
+
+                    <div className="flex gap-1">
+                        {[1, 2, 3, 4, 5].map((priority) => (
+                            <PriorityChip
+                                active={String(priority) === (fields.priority ?? '3')}
+                                key={priority}
+                                onClick={() => onFieldChange('priority', String(priority))}
+                                value={priority}
+                            />
+                        ))}
+                    </div>
+                </div>
+
+                <details className="mb-2.5">
+                    <summary className="cursor-pointer font-mono text-[10px] uppercase tracking-[1px] text-dim">
+                        Replacements
+                        <span className="ml-2 normal-case tracking-normal text-faint">
+                            {replacementRows.length || 'none'} · used by {'{{ value | map }}'}
+                        </span>
+                    </summary>
+
+                    <div className="mt-1.5">
+                        {replacementRows.map((row, index) => (
+                            <div className="mb-1 flex gap-1" key={index}>
+                                <input
+                                    className="w-full rounded-lg border border-line bg-elev px-3 py-2 font-mono text-[12.5px] text-fg outline-none placeholder:text-faint focus:border-accent/50"
+                                    onChange={(event) =>
+                                        updateRow(index, { from: event.target.value })
+                                    }
+                                    placeholder="customer.subscription.created"
+                                    value={row.from}
+                                />
+                                <input
+                                    className="w-full rounded-lg border border-line bg-elev px-3 py-2 font-mono text-[12.5px] text-fg outline-none placeholder:text-faint focus:border-accent/50"
+                                    onChange={(event) =>
+                                        updateRow(index, { to: event.target.value })
+                                    }
+                                    placeholder="Assinatura criada"
+                                    value={row.to}
+                                />
+                                <button
+                                    className="rounded-lg border border-line px-2.5 font-mono text-[12px] text-dim hover:text-fg"
+                                    onClick={() =>
+                                        onReplacementRowsChange(
+                                            replacementRows.filter(
+                                                (_, position) => position !== index,
+                                            ),
+                                        )
+                                    }
+                                    type="button"
+                                >
+                                    ×
+                                </button>
+                            </div>
+                        ))}
+
+                        <button
+                            className="rounded-lg border border-line px-2.5 py-1.5 font-mono text-[11px] text-dim hover:text-fg"
+                            onClick={() =>
+                                onReplacementRowsChange([...replacementRows, { from: '', to: '' }])
+                            }
+                            type="button"
+                        >
+                            + Add replacement
+                        </button>
+                    </div>
+                </details>
+
+                <details>
+                    <summary className="cursor-pointer font-mono text-[10px] uppercase tracking-[1px] text-dim">
+                        Available filters
+                    </summary>
+                    <div className="mt-1.5 font-mono text-[11px] leading-relaxed text-faint">
+                        {TRANSFORM_NAMES.join(' · ')}
+                        <div className="mt-1.5 text-dim">
+                            {"{{ created | date:'YYYY-MM-DD HH:mm' }}"}
+                        </div>
+                        <div className="text-dim">
+                            {"{{ items.data.*.price.unit_amount | divide:100 | currency:'usd' }}"}
+                        </div>
+                        <div className="text-dim">{'{{ type | map }}'}</div>
+                    </div>
+                </details>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
Webhook templates could only interpolate raw payload values, which reads badly for
anything that needs formatting. A Stripe `customer.subscription.created` payload showed
the gap: `{{created}}` renders `1787142663`, and `{{data.object.items.data.*.price.unit_amount}}`
renders `500` when it means $5.00.

Placeholders can now chain filters after a pipe:

```
{{ created | date:'YYYY-MM-DD HH:mm' }}                                        → 2026-08-19 12:31
{{ data.object.items.data.*.price.unit_amount | divide:100 | currency:'usd' }} → $5.00
{{ type | map }}                                                               → Assinatura criada
```

Filters: `date`, `divide`, `multiply`, `number`, `currency`, `upper`, `lower`, `title`,
`trim`, `truncate`, `default`, `map`. The `map` filter looks values up in a new
`replacements` dictionary on the template, for translating or normalizing text.

Notes:

- Filters apply to each element of a wildcard match, so `items.*.amount | divide:100 | currency:'usd'`
  gives `$5.00, $25.00` rather than formatting the joined string.
- An unknown filter, or a value a filter cannot handle, passes through untouched — a
  template typo can never fail a live delivery. The website editor flags unknown filter
  names instead.
- No migration: `replacements` lives inside the JSON already stored in `Webhook.template`.

The engine is shared, so the server receiver, the create/edit form preview, and the
delivery log all pick this up together. The website form gains a replacements editor and
a collapsible filter reference.

Not a breaking change for templates — a placeholder with no pipe renders byte-for-byte as
before, and the existing test suite passes untouched. `applyTemplate`'s third parameter
does change from `defaultValue: string` to an options object; all four call sites are in
this repo and are updated.