### PR TITLE
Forward published messages to email

### DIFF
--- a/packages/emitsignal-docs/api/publish.mdx
+++ b/packages/emitsignal-docs/api/publish.mdx
@@ -94,21 +94,57 @@ curl https://emitsignal.com/publish/alerts/prod \
 
 | Field       | Headers (first non-empty wins)                          |
 | ----------- | ------------------------------------------------------- |
-| Title       | `x-title`, `title`, `t`                                 |
-| Body        | `x-message`, `message`, `m` (else the raw request body) |
-| Priority    | `x-priority`, `priority`, `prio`, `p`                   |
-| Tags        | `x-tags`, `tags`, `ta` (comma-separated)                |
-| Schedule    | `x-delay`, `delay`, `x-at`, `at`, `x-in`, `in`          |
 | Actions     | `x-actions`, `actions` (JSON)                           |
-| Banner      | `x-banner`, `banner`                                    |
-| Inline imgs | `x-inline-images`, `inline-images`                      |
 | Attachments | `x-inline-attachments`, `inline-attachments`            |
+| Banner      | `x-banner`, `banner`                                    |
+| Body        | `x-message`, `message`, `m` (else the raw request body) |
+| Email       | `x-email`, `x-e-mail`, `email`, `e-mail`, `mail`, `e`   |
+| Inline imgs | `x-inline-images`, `inline-images`                      |
+| Priority    | `x-priority`, `priority`, `prio`, `p`                   |
+| Schedule    | `x-delay`, `delay`, `x-at`, `at`, `x-in`, `in`          |
+| Tags        | `x-tags`, `tags`, `ta` (comma-separated)                |
+| Title       | `x-title`, `title`, `t`                                 |
 
 **Priority values** accept names or numbers: `min`/`1`, `low`/`2`,
 `none`/`default`/`3`, `high`/`4`, `urgent`/`max`/`5`.
 
 **Delay/schedule values** accept a duration string — `30s`, `5m`, `2h`, `1d`, `1w`
 — or an integer (a unix timestamp if it's `>= now`, otherwise seconds from now).
+
+## Email notifications
+
+Pass an email header (or `"email"` in a JSON body) to also forward the message to an
+inbox — useful when a signal should outlive its retention window, or to blast-notify
+yourself on every channel at once. Only one address is supported.
+
+```bash
+curl https://emitsignal.com/publish/alerts \
+  -H "Authorization: Bearer es_xxx" \
+  -H "Email: you@example.com" \
+  -H "Tags: warning,ssh-login" \
+  -H "Priority: high" \
+  -d "Unknown login from 5.31.23.83 to backups.example.com"
+```
+
+Pass `yes`, `true`, or `1` instead of an address to send to your own account address:
+
+```bash
+curl -H "Authorization: Bearer es_xxx" -H "Email: yes" \
+  -d "You've got mail" https://emitsignal.com/publish/alerts
+```
+
+Rules:
+
+- **Authentication is required.** Anonymous publishes are rejected with `403
+anonymous_email_forbidden` — this keeps the platform from being used as an open relay.
+- **`yes`/`true`/`1` requires a verified account email**, otherwise `403 email_not_verified`.
+- **Emailing an address other than your own requires a paid plan** (Pulse or Beam);
+  free accounts get `403 plan_required`. Mailing your own address is free.
+- **A daily quota applies per account** — 5/day on Free, 50/day on Pulse, 250/day on Beam.
+  Exceeding it returns `429 daily_quota_exceeded` with `metric: "emails"` and the usual
+  `x-quota-*` headers. Current usage is reported by `GET /billing` as `usage.emailsToday`.
+- **Email cannot be combined with a delay.** A scheduled publish plus an email header
+  returns `400 email_not_schedulable`.
 
 ## Priority
 

--- a/packages/emitsignal-server/src/http/topic/__tests__/publish-email.spec.ts
+++ b/packages/emitsignal-server/src/http/topic/__tests__/publish-email.spec.ts
@@ -30,6 +30,16 @@ import { getDailyUsage, resetUsageForTests } from '#/services/billing/usage';
 
 const SENDER_EMAIL = 'owner@example.com';
 
+const TOPIC = {
+    accessMode: 'public',
+    createdAt: new Date(1700000000000),
+    description: '',
+    displayName: 'alerts',
+    id: 'topic-alerts',
+    name: 'alerts',
+    ownerId: null,
+};
+
 describe('POST /publish/<topic> — email notifications', () => {
     const app = new Elysia().use(publish);
 
@@ -56,13 +66,12 @@ describe('POST /publish/<topic> — email notifications', () => {
         resetUsageForTests();
         resetUserPlansForTests();
         mockSend.mockClear();
-        // prismaMock and the topic cache are module singletons shared by every spec in
-        // the process, so an earlier file can leave a queued `once` row or a cached
-        // topic behind. Reset both so the asserted topic name is ours.
+        // prismaMock is a module singleton shared by every spec in the process, so an
+        // earlier file can leave a topic row behind and getOrCreateTopic would resolve
+        // a name this file never chose. Seeding the cache keeps the topic ours no
+        // matter what the shared mock currently returns.
         topicNameCache.clear();
-        prismaMock.topic.findUnique = mock(() =>
-            Promise.resolve(null),
-        ) as typeof prismaMock.topic.findUnique;
+        topicNameCache.set(TOPIC.name, TOPIC as never);
         // The shared mock returns `tags` as a JSON string; the real column is String[],
         // and the alert template maps over it.
         prismaMock.message.create = mock(() =>
@@ -135,7 +144,7 @@ describe('POST /publish/<topic> — email notifications', () => {
         expect(res.status).toBe(200);
         expect(mockSend).toHaveBeenCalledTimes(1);
         expect(mockSend.mock.calls[0][0]).toMatchObject({
-            subject: '[test] Disk almost full',
+            subject: `[${TOPIC.name}] Disk almost full`,
             to: SENDER_EMAIL,
         });
     });

--- a/packages/emitsignal-server/src/http/topic/__tests__/publish-email.spec.ts
+++ b/packages/emitsignal-server/src/http/topic/__tests__/publish-email.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, mock } from 'bun:test';
 import { Elysia } from 'elysia';
 
 import { prismaMock } from '#/__tests__/mocks';
+import { topicNameCache } from '#/lib/cache';
 
 const mockBus = { publish: mock(), subscribe: mock() };
 const mockPushQueue = { add: mock(() => Promise.resolve()) };
@@ -55,6 +56,13 @@ describe('POST /publish/<topic> — email notifications', () => {
         resetUsageForTests();
         resetUserPlansForTests();
         mockSend.mockClear();
+        // prismaMock and the topic cache are module singletons shared by every spec in
+        // the process, so an earlier file can leave a queued `once` row or a cached
+        // topic behind. Reset both so the asserted topic name is ours.
+        topicNameCache.clear();
+        prismaMock.topic.findUnique = mock(() =>
+            Promise.resolve(null),
+        ) as typeof prismaMock.topic.findUnique;
         // The shared mock returns `tags` as a JSON string; the real column is String[],
         // and the alert template maps over it.
         prismaMock.message.create = mock(() =>

--- a/packages/emitsignal-server/src/http/topic/__tests__/publish-email.spec.ts
+++ b/packages/emitsignal-server/src/http/topic/__tests__/publish-email.spec.ts
@@ -1,0 +1,253 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { Elysia } from 'elysia';
+
+import { prismaMock } from '#/__tests__/mocks';
+
+const mockBus = { publish: mock(), subscribe: mock() };
+const mockPushQueue = { add: mock(() => Promise.resolve()) };
+const mockScheduleQueue = { add: mock(() => Promise.resolve()) };
+const mockSend = mock<(options: { subject: string; to: string }) => Promise<void>>(() =>
+    Promise.resolve(),
+);
+
+mock.module('#/lib/prisma', () => ({ prisma: prismaMock }));
+mock.module('#/lib/event-bus', () => ({ bus: mockBus }));
+mock.module('#/lib/queue', () => ({
+    pushQueue: mockPushQueue,
+    scheduleQueue: mockScheduleQueue,
+}));
+mock.module('#/lib/email-service', () => ({ EmailService: { send: mockSend } }));
+mock.module('#/http/auth/plugin', () => ({
+    resolveUserId: ({ headers }: { headers: Record<string, string | undefined> }) =>
+        Promise.resolve(headers['x-test-user-id'] ?? null),
+}));
+
+import { publish } from '#/http/topic/publish';
+import { resetUserPlansForTests, setUserPlanForTests } from '#/services/billing/get-user-plan';
+import { PLANS } from '#/services/billing/plans';
+import { getDailyUsage, resetUsageForTests } from '#/services/billing/usage';
+
+const SENDER_EMAIL = 'owner@example.com';
+
+describe('POST /publish/<topic> — email notifications', () => {
+    const app = new Elysia().use(publish);
+
+    function jsonRequest(payload: Record<string, unknown>, userId?: string) {
+        return new Request('http://localhost/publish/alerts', {
+            body: JSON.stringify({ body: 'Disk almost full', priority: 3, ...payload }),
+            headers: {
+                'Content-Type': 'application/json',
+                ...(userId ? { 'x-test-user-id': userId } : {}),
+            },
+            method: 'POST',
+        });
+    }
+
+    function headerRequest(headers: Record<string, string>, userId?: string) {
+        return new Request('http://localhost/publish/alerts', {
+            body: 'Disk almost full',
+            headers: { ...headers, ...(userId ? { 'x-test-user-id': userId } : {}) },
+            method: 'POST',
+        });
+    }
+
+    beforeEach(() => {
+        resetUsageForTests();
+        resetUserPlansForTests();
+        mockSend.mockClear();
+        // The shared mock returns `tags` as a JSON string; the real column is String[],
+        // and the alert template maps over it.
+        prismaMock.message.create = mock(() =>
+            Promise.resolve({
+                actions: '[]',
+                body: 'Disk almost full',
+                createdAt: new Date(),
+                id: 'msg-1',
+                priority: 3,
+                scheduledAt: null,
+                tags: [],
+                title: '',
+                topicId: 'topic-1',
+            }),
+        ) as typeof prismaMock.message.create;
+        prismaMock.user.findUnique = mock(() =>
+            Promise.resolve({ email: SENDER_EMAIL, emailVerified: true }),
+        ) as typeof prismaMock.user.findUnique;
+    });
+
+    it('rejects anonymous senders without creating the message', async () => {
+        const res = await app.handle(headerRequest({ Email: 'you@example.com' }));
+
+        expect(res.status).toBe(403);
+        expect(await res.json()).toMatchObject({ error: 'anonymous_email_forbidden' });
+        expect(prismaMock.message.create).not.toHaveBeenCalled();
+        expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('rejects email combined with a delay', async () => {
+        setUserPlanForTests('email-user', 'free');
+
+        const res = await app.handle(
+            headerRequest({ Email: 'yes', 'X-Delay': '1h' }, 'email-user'),
+        );
+
+        expect(res.status).toBe(400);
+        expect(await res.json()).toMatchObject({ error: 'email_not_schedulable' });
+        expect(prismaMock.message.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects a malformed address', async () => {
+        setUserPlanForTests('email-user', 'free');
+
+        const res = await app.handle(headerRequest({ Email: 'nope' }, 'email-user'));
+
+        expect(res.status).toBe(400);
+        expect(await res.json()).toMatchObject({ error: 'invalid_email' });
+    });
+
+    it('rejects more than one address', async () => {
+        setUserPlanForTests('email-user', 'free');
+
+        const res = await app.handle(
+            headerRequest({ Email: 'a@example.com,b@example.com' }, 'email-user'),
+        );
+
+        expect(res.status).toBe(400);
+        expect(await res.json()).toMatchObject({
+            error: 'invalid_email',
+            message: 'only one email address is supported',
+        });
+    });
+
+    it('lets a free user email their own verified address via the self token', async () => {
+        setUserPlanForTests('email-user', 'free');
+
+        const res = await app.handle(headerRequest({ Email: 'yes' }, 'email-user'));
+
+        expect(res.status).toBe(200);
+        expect(mockSend).toHaveBeenCalledTimes(1);
+        expect(mockSend.mock.calls[0][0]).toMatchObject({
+            subject: '[test] Disk almost full',
+            to: SENDER_EMAIL,
+        });
+    });
+
+    it('refuses an unverified account address', async () => {
+        setUserPlanForTests('email-user', 'free');
+
+        prismaMock.user.findUnique = mock(() =>
+            Promise.resolve({ email: SENDER_EMAIL, emailVerified: false }),
+        ) as typeof prismaMock.user.findUnique;
+
+        const res = await app.handle(headerRequest({ Email: 'yes' }, 'email-user'));
+
+        expect(res.status).toBe(403);
+        expect(await res.json()).toMatchObject({ error: 'email_not_verified' });
+    });
+
+    it('requires a paid plan to email a third-party address', async () => {
+        setUserPlanForTests('email-user', 'free');
+
+        const res = await app.handle(headerRequest({ Email: 'you@example.com' }, 'email-user'));
+
+        expect(res.status).toBe(403);
+        expect(await res.json()).toMatchObject({
+            error: 'plan_required',
+            requiredPlans: ['pulse', 'beam'],
+        });
+        expect(prismaMock.message.create).not.toHaveBeenCalled();
+    });
+
+    it('allows a paid plan to email a third-party address', async () => {
+        setUserPlanForTests('paid-user', 'pulse');
+
+        const res = await app.handle(headerRequest({ Email: 'you@example.com' }, 'paid-user'));
+
+        expect(res.status).toBe(200);
+        expect(mockSend.mock.calls[0][0]).toMatchObject({ to: 'you@example.com' });
+    });
+
+    it('accepts the address through the JSON body', async () => {
+        setUserPlanForTests('email-user', 'free');
+
+        const res = await app.handle(jsonRequest({ email: SENDER_EMAIL }, 'email-user'));
+
+        expect(res.status).toBe(200);
+        expect(mockSend.mock.calls[0][0]).toMatchObject({ to: SENDER_EMAIL });
+    });
+
+    // Six aliases against the free tier's five-a-day would trip the quota, so this
+    // uses a paid plan to keep the assertion about aliases only.
+    it('accepts every ntfy header alias', async () => {
+        setUserPlanForTests('paid-user', 'pulse');
+
+        for (const alias of ['X-Email', 'X-E-mail', 'Email', 'E-mail', 'Mail', 'e']) {
+            mockSend.mockClear();
+
+            const res = await app.handle(headerRequest({ [alias]: 'yes' }, 'paid-user'));
+
+            expect(res.status).toBe(200);
+            expect(mockSend).toHaveBeenCalledTimes(1);
+        }
+    });
+
+    it('returns 429 with quota headers once the daily email limit is exhausted', async () => {
+        setUserPlanForTests('email-user', 'free');
+
+        const limit = PLANS.free.limits.emailsPerDay;
+
+        for (let index = 0; index < limit; index++) {
+            const res = await app.handle(headerRequest({ Email: 'yes' }, 'email-user'));
+
+            expect(res.status).toBe(200);
+        }
+
+        const rejected = await app.handle(headerRequest({ Email: 'yes' }, 'email-user'));
+
+        expect(rejected.status).toBe(429);
+        expect(rejected.headers.get('x-quota-limit')).toBe(String(limit));
+        expect(await rejected.json()).toMatchObject({
+            error: 'daily_quota_exceeded',
+            metric: 'emails',
+        });
+    });
+
+    it('does not consume the message quota when the email gate rejects', async () => {
+        setUserPlanForTests('email-user', 'free');
+
+        const res = await app.handle(headerRequest({ Email: 'phil@example.com' }, 'email-user'));
+
+        expect(res.status).toBe(403);
+        expect(await getDailyUsage('email-user', 'messages')).toBe(0);
+        expect(await getDailyUsage('email-user', 'emails')).toBe(0);
+    });
+
+    it('refunds the message quota when the email quota is exhausted', async () => {
+        setUserPlanForTests('email-user', 'free');
+
+        const limit = PLANS.free.limits.emailsPerDay;
+
+        for (let index = 0; index < limit; index++) {
+            await app.handle(headerRequest({ Email: 'yes' }, 'email-user'));
+        }
+
+        expect(await getDailyUsage('email-user', 'messages')).toBe(limit);
+
+        const rejected = await app.handle(headerRequest({ Email: 'yes' }, 'email-user'));
+
+        expect(rejected.status).toBe(429);
+        // The rejected publish created no message, so neither counter may move.
+        expect(await getDailyUsage('email-user', 'messages')).toBe(limit);
+        expect(await getDailyUsage('email-user', 'emails')).toBe(limit);
+    });
+
+    it('leaves publishes without an email address untouched', async () => {
+        setUserPlanForTests('email-user', 'free');
+
+        const res = await app.handle(jsonRequest({}, 'email-user'));
+
+        expect(res.status).toBe(200);
+        expect(mockSend).not.toHaveBeenCalled();
+        expect(prismaMock.user.findUnique).not.toHaveBeenCalled();
+    });
+});

--- a/packages/emitsignal-server/src/http/topic/header-publish.ts
+++ b/packages/emitsignal-server/src/http/topic/header-publish.ts
@@ -28,6 +28,7 @@ export function parsePublishHeaders(
     actions?: unknown;
     bannerImage?: unknown;
     body: string;
+    email?: string;
     inlineAttachments?: unknown;
     inlineImages?: unknown;
     priority: number;
@@ -40,6 +41,7 @@ export function parsePublishHeaders(
     const rawBanner = firstHeader(headers, 'x-banner', 'banner');
     const rawInlineAttachments = firstHeader(headers, 'x-inline-attachments', 'inline-attachments');
     const rawInlineImages = firstHeader(headers, 'x-inline-images', 'inline-images');
+    const rawEmail = firstHeader(headers, 'x-email', 'x-e-mail', 'email', 'e-mail', 'mail', 'e');
     const rawDelay = firstHeader(headers, 'x-delay', 'delay', 'x-at', 'at', 'x-in', 'in');
     const rawPriority = firstHeader(headers, 'x-priority', 'priority', 'prio', 'p');
     const rawTags = firstHeader(headers, 'x-tags', 'tags', 'ta');
@@ -59,6 +61,7 @@ export function parsePublishHeaders(
         actions,
         bannerImage: rawBanner ? parseMediaHeader(rawBanner) : undefined,
         body: messageOverride || rawBody,
+        email: rawEmail || undefined,
         inlineAttachments: rawInlineAttachments
             ? parseMediaHeader(rawInlineAttachments)
             : undefined,

--- a/packages/emitsignal-server/src/http/topic/publish.ts
+++ b/packages/emitsignal-server/src/http/topic/publish.ts
@@ -1,3 +1,4 @@
+import { PAID_PLAN_NAMES } from '@emitsignal/shared';
 import Elysia, { t } from 'elysia';
 
 import { resolveUserId } from '#/http/auth/plugin';
@@ -10,13 +11,21 @@ import { publishAnonLimiter, publishAuthLimiter } from '#/lib/rate-limit';
 import { captureTraceContext } from '#/lib/trace-context';
 import { getUserLimits, getUserPlan } from '#/services/billing/get-user-plan';
 import { messageExpiresAt, messageRetentionDays } from '#/services/billing/retention';
-import { consumeDailyQuota, quotaExceededHeaders } from '#/services/billing/usage';
+import {
+    consumeDailyQuota,
+    quotaExceededHeaders,
+    type QuotaResult,
+    refundDailyQuota,
+    type UsageMetric,
+} from '#/services/billing/usage';
+import { sendMessageAlertEmail } from '#/services/emails/message-alert';
 import { serializeMessage } from '#/services/message';
 import { incrementMessageCounter } from '#/services/stats/message-counter';
 import { getOrCreateTopic, TopicNameError } from '#/services/topic';
 import { resolveTopicCapabilities } from '#/services/topic-access';
 import { validateActions } from '#/utils/actions';
 import { duration } from '#/utils/duration';
+import { parseEmailTarget } from '#/utils/email-target';
 import { ANON_INLINE_MAX, validateMessageMedia } from '#/utils/media-refs';
 
 import { parsePublishHeaders } from './header-publish';
@@ -36,6 +45,12 @@ const mediaInputSchema = t.Union([mediaItemSchema, t.Array(mediaItemSchema)]);
  */
 const DEPRECATED_AT = '@1786320000';
 const SUCCESSOR_LINK = '</publish/*>; rel="successor-version"';
+
+interface SetLike {
+    headers: Record<string, number | string | undefined>;
+}
+
+type StatusFn = (code: number, body: Record<string, unknown>) => unknown;
 
 function publishRoute(path: string, deprecated: boolean) {
     return new Elysia({ name: `publish${path}` }).post(
@@ -93,28 +108,15 @@ function publishRoute(path: string, deprecated: boolean) {
             const userId = await resolveUserId({ headers });
 
             let inlineMax = ANON_INLINE_MAX;
+            let emailsPerDay = 0;
+            let messagesPerDay = 0;
 
             if (userId) {
                 const limits = await getUserLimits(userId);
-                const quota = await consumeDailyQuota(userId, 'messages', limits.messagesPerDay);
-
-                if (!quota.allowed) {
-                    logger.warn(
-                        { limit: quota.limit, metric: 'messages', userId },
-                        'daily quota exceeded',
-                    );
-
-                    Object.assign(set.headers, quotaExceededHeaders(quota));
-
-                    return status(429, {
-                        error: 'daily_quota_exceeded',
-                        limit: quota.limit,
-                        metric: 'messages',
-                        resetAt: quota.resetAt,
-                    });
-                }
 
                 inlineMax = limits.inlineMaxPerArray;
+                emailsPerDay = limits.emailsPerDay;
+                messagesPerDay = limits.messagesPerDay;
             }
 
             const media = validateMessageMedia(
@@ -161,6 +163,91 @@ function publishRoute(path: string, deprecated: boolean) {
             }
 
             const actions = validation.actions;
+
+            let emailAddress: null | string = null;
+
+            if (body.email) {
+                if (!userId) {
+                    return status(403, {
+                        error: 'anonymous_email_forbidden',
+                        message: 'email notifications require an authenticated account',
+                    });
+                }
+
+                if (isScheduled) {
+                    return status(400, {
+                        error: 'email_not_schedulable',
+                        message: 'email notifications cannot be combined with a delay',
+                    });
+                }
+
+                const target = parseEmailTarget(body.email);
+
+                if ('error' in target) {
+                    return status(400, { error: 'invalid_email', message: target.error });
+                }
+
+                const sender = await prisma.user.findUnique({
+                    select: { email: true, emailVerified: true },
+                    where: { id: userId },
+                });
+
+                if (!sender) {
+                    return status(403, {
+                        error: 'anonymous_email_forbidden',
+                        message: 'email notifications require an authenticated account',
+                    });
+                }
+
+                if (target.kind === 'self') {
+                    if (!sender.emailVerified) {
+                        return status(403, {
+                            error: 'email_not_verified',
+                            message: 'verify your account email before sending email notifications',
+                        });
+                    }
+
+                    emailAddress = sender.email;
+                } else {
+                    emailAddress = target.address;
+                }
+
+                // Mailing a third party is the abusable path, so it is paid-plan only;
+                // mailing the account's own verified address stays free.
+                if (emailAddress.toLowerCase() !== sender.email.toLowerCase()) {
+                    const plan = await getUserPlan(userId);
+
+                    if (!PAID_PLAN_NAMES.includes(plan)) {
+                        return status(403, {
+                            error: 'plan_required',
+                            message:
+                                'Emailing an address other than your own requires a paid plan (Pulse or Beam).',
+                            requiredPlans: PAID_PLAN_NAMES,
+                        });
+                    }
+                }
+            }
+
+            // Quotas are consumed last: every rejection above must leave the day's
+            // counters untouched, since none of them produce a message or an email.
+            if (userId) {
+                const quota = await consumeDailyQuota(userId, 'messages', messagesPerDay);
+
+                if (!quota.allowed) {
+                    return quotaExceeded(quota, 'messages', userId, set, status);
+                }
+
+                if (emailAddress) {
+                    const emailQuota = await consumeDailyQuota(userId, 'emails', emailsPerDay);
+
+                    if (!emailQuota.allowed) {
+                        await refundDailyQuota(userId, 'messages');
+
+                        return quotaExceeded(emailQuota, 'emails', userId, set, status);
+                    }
+                }
+            }
+
             const deliveredAt = isScheduled ? null : new Date();
 
             const message = await prisma.message.create({
@@ -219,6 +306,19 @@ function publishRoute(path: string, deprecated: boolean) {
                 traceContext: captureTraceContext(),
             });
 
+            if (emailAddress) {
+                await sendMessageAlertEmail({
+                    body: messageBody,
+                    createdAt: message.createdAt,
+                    emailAddress,
+                    messageId: message.id,
+                    priority: message.priority,
+                    tags: message.tags,
+                    title,
+                    topicName: topic.name,
+                });
+            }
+
             return { message: 'posted', messageId: message.id };
         },
         {
@@ -238,6 +338,7 @@ function publishRoute(path: string, deprecated: boolean) {
                 ),
                 bannerImage: t.Optional(mediaItemSchema),
                 body: t.Optional(t.String({ maxLength: 32_768 })),
+                email: t.Optional(t.String({ maxLength: 128 })),
                 inlineAttachments: t.Optional(mediaInputSchema),
                 inlineImages: t.Optional(mediaInputSchema),
                 priority: t.Integer({ default: 3, maximum: 5, minimum: 1 }),
@@ -256,6 +357,25 @@ function publishRoute(path: string, deprecated: boolean) {
             ],
         },
     );
+}
+
+function quotaExceeded(
+    quota: QuotaResult,
+    metric: UsageMetric,
+    userId: string,
+    set: SetLike,
+    status: StatusFn,
+) {
+    logger.warn({ limit: quota.limit, metric, userId }, 'daily quota exceeded');
+
+    Object.assign(set.headers, quotaExceededHeaders(quota));
+
+    return status(429, {
+        error: 'daily_quota_exceeded',
+        limit: quota.limit,
+        metric,
+        resetAt: quota.resetAt,
+    });
 }
 
 export const publish = new Elysia()

--- a/packages/emitsignal-server/src/services/billing/__tests__/usage.spec.ts
+++ b/packages/emitsignal-server/src/services/billing/__tests__/usage.spec.ts
@@ -4,6 +4,7 @@ import {
     consumeDailyQuota,
     getDailyUsage,
     quotaExceededHeaders,
+    refundDailyQuota,
     resetUsageForTests,
 } from '#/services/billing/usage';
 
@@ -28,6 +29,14 @@ describe('consumeDailyQuota', () => {
 
         expect(third.allowed).toBe(false);
         expect(third.remaining).toBe(0);
+    });
+
+    it('does not let reported usage run past the limit', async () => {
+        for (let index = 0; index < 5; index++) {
+            await consumeDailyQuota('user-1', 'emails', 2);
+        }
+
+        expect(await getDailyUsage('user-1', 'emails')).toBe(2);
     });
 
     it('allows exactly the limit', async () => {
@@ -86,5 +95,21 @@ describe('quotaExceededHeaders', () => {
         expect(headers['x-quota-limit']).toBe('1');
         expect(headers['x-quota-remaining']).toBe('0');
         expect(headers['x-quota-reset']).toBe(String(quota.resetAt));
+    });
+});
+
+describe('refundDailyQuota', () => {
+    it('gives back a consumed point', async () => {
+        await consumeDailyQuota('user-1', 'messages', 3);
+        await consumeDailyQuota('user-1', 'messages', 3);
+        await refundDailyQuota('user-1', 'messages');
+
+        expect(await getDailyUsage('user-1', 'messages')).toBe(1);
+    });
+
+    it('never drives a counter below zero', async () => {
+        await refundDailyQuota('user-1', 'messages');
+
+        expect(await getDailyUsage('user-1', 'messages')).toBe(0);
     });
 });

--- a/packages/emitsignal-server/src/services/billing/usage.ts
+++ b/packages/emitsignal-server/src/services/billing/usage.ts
@@ -29,9 +29,13 @@ export async function consumeDailyQuota(
         const key = usageKey(userId, metric);
         const used = (testCounters.get(key) ?? 0) + 1;
 
+        if (used > limit) {
+            return { allowed: false, limit, remaining: 0, resetAt };
+        }
+
         testCounters.set(key, used);
 
-        return { allowed: used <= limit, limit, remaining: Math.max(0, limit - used), resetAt };
+        return { allowed: true, limit, remaining: limit - used, resetAt };
     }
 
     try {
@@ -42,7 +46,13 @@ export async function consumeDailyQuota(
             await redis.expire(key, KEY_TTL_SECONDS);
         }
 
-        return { allowed: used <= limit, limit, remaining: Math.max(0, limit - used), resetAt };
+        if (used > limit) {
+            await redis.decr(key);
+
+            return { allowed: false, limit, remaining: 0, resetAt };
+        }
+
+        return { allowed: true, limit, remaining: limit - used, resetAt };
     } catch (error) {
         logger.error({ error, metric }, 'daily quota check failed, allowing request');
 
@@ -73,6 +83,26 @@ export function quotaExceededHeaders(quota: QuotaResult): Record<string, string>
         'x-quota-remaining': String(quota.remaining),
         'x-quota-reset': String(quota.resetAt),
     };
+}
+
+export async function refundDailyQuota(userId: string, metric: UsageMetric): Promise<void> {
+    const key = usageKey(userId, metric);
+
+    if (Bun.env.NODE_ENV === 'test') {
+        testCounters.set(key, Math.max(0, (testCounters.get(key) ?? 0) - 1));
+
+        return;
+    }
+
+    try {
+        const used = await redis.decr(key);
+
+        if (used < 0) {
+            await redis.set(key, '0');
+        }
+    } catch (error) {
+        logger.error({ error, metric }, 'daily quota refund failed');
+    }
 }
 
 export function resetUsageForTests(): void {

--- a/packages/emitsignal-server/src/services/emails/message-alert.ts
+++ b/packages/emitsignal-server/src/services/emails/message-alert.ts
@@ -1,0 +1,54 @@
+import { MessageAlertEmail, render } from '@emitsignal/emails';
+import { createElement } from 'react';
+
+import { EmailService } from '#/lib/email-service';
+import { logger } from '#/lib/logger';
+import { environment } from '#/schema/environment';
+
+interface MessageAlert {
+    body: string;
+    createdAt: Date;
+    emailAddress: string;
+    messageId: string;
+    priority: number;
+    tags: string[];
+    title: string;
+    topicName: string;
+}
+
+const SUBJECT_MAX_LENGTH = 120;
+
+export async function sendMessageAlertEmail(alert: MessageAlert): Promise<void> {
+    try {
+        const html = await render(
+            createElement(MessageAlertEmail, {
+                body: alert.body,
+                createdAt: alert.createdAt,
+                messageUrl: `${environment.APP_URL}/app/inbox/${alert.messageId}`,
+                priority: alert.priority,
+                tags: alert.tags,
+                title: alert.title,
+                topicName: alert.topicName,
+            }),
+        );
+
+        await EmailService.send({
+            from: environment.EMAIL_FROM,
+            html,
+            subject: `[${alert.topicName}] ${subjectLine(alert)}`,
+            to: alert.emailAddress,
+        });
+    } catch (error) {
+        logger.error({ error, messageId: alert.messageId }, 'failed to send message-alert email');
+    }
+}
+
+function subjectLine({ body, title }: MessageAlert): string {
+    const source = title || body;
+
+    if (source.length <= SUBJECT_MAX_LENGTH) {
+        return source;
+    }
+
+    return `${source.slice(0, SUBJECT_MAX_LENGTH - 1).trimEnd()}…`;
+}

--- a/packages/emitsignal-server/src/utils/__tests__/email-target.spec.ts
+++ b/packages/emitsignal-server/src/utils/__tests__/email-target.spec.ts
@@ -34,11 +34,11 @@ describe('parseEmailTarget', () => {
         }
     });
 
-    it('rejects an address longer than 128 characters', () => {
-        const raw = `${'a'.repeat(124)}@example.com`;
+    it('rejects an address longer than 254 characters', () => {
+        const raw = `${'a'.repeat(250)}@example.com`;
 
         expect(parseEmailTarget(raw)).toEqual({
-            error: 'an email address cannot exceed 128 characters',
+            error: 'an email address cannot exceed 254 characters',
         });
     });
 });

--- a/packages/emitsignal-server/src/utils/__tests__/email-target.spec.ts
+++ b/packages/emitsignal-server/src/utils/__tests__/email-target.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'bun:test';
+
+import { parseEmailTarget } from '#/utils/email-target';
+
+describe('parseEmailTarget', () => {
+    it('treats the ntfy self tokens as the account address', () => {
+        for (const token of ['1', 'true', 'yes', 'YES', ' True ']) {
+            expect(parseEmailTarget(token)).toEqual({ kind: 'self' });
+        }
+    });
+
+    it('accepts a single address and normalizes its case', () => {
+        expect(parseEmailTarget(' you@example.com ')).toEqual({
+            address: 'you@example.com',
+            kind: 'address',
+        });
+    });
+
+    it('rejects more than one address', () => {
+        for (const raw of ['a@b.com,c@d.com', 'a@b.com; c@d.com', 'a@b.com c@d.com']) {
+            expect(parseEmailTarget(raw)).toEqual({
+                error: 'only one email address is supported',
+            });
+        }
+    });
+
+    it('rejects an empty value', () => {
+        expect(parseEmailTarget('   ')).toEqual({ error: 'an email address is required' });
+    });
+
+    it('rejects malformed addresses', () => {
+        for (const raw of ['nope', 'a@b', '@example.com', 'phil@', 'phil@example.']) {
+            expect(parseEmailTarget(raw)).toEqual({ error: 'not a valid email address' });
+        }
+    });
+
+    it('rejects an address longer than 128 characters', () => {
+        const raw = `${'a'.repeat(124)}@example.com`;
+
+        expect(parseEmailTarget(raw)).toEqual({
+            error: 'an email address cannot exceed 128 characters',
+        });
+    });
+});

--- a/packages/emitsignal-server/src/utils/email-target.ts
+++ b/packages/emitsignal-server/src/utils/email-target.ts
@@ -1,0 +1,35 @@
+export type EmailTarget = { address: string; kind: 'address' } | { kind: 'self' };
+
+const SELF_TOKENS = new Set(['1', 'true', 'yes']);
+
+// Deliberately permissive: the goal is to reject obvious junk and multi-recipient
+// values before they reach the queue, not to re-implement RFC 5321.
+const ADDRESS_PATTERN = /^[^\s@,;]+@[^\s@,;.]+(\.[^\s@,;.]+)+$/;
+
+const MAX_ADDRESS_LENGTH = 128;
+
+export function parseEmailTarget(raw: string): { error: string } | EmailTarget {
+    const trimmed = raw.trim();
+
+    if (trimmed === '') {
+        return { error: 'an email address is required' };
+    }
+
+    if (SELF_TOKENS.has(trimmed.toLowerCase())) {
+        return { kind: 'self' };
+    }
+
+    if (/[,;]/.test(trimmed) || /\s/.test(trimmed)) {
+        return { error: 'only one email address is supported' };
+    }
+
+    if (trimmed.length > MAX_ADDRESS_LENGTH) {
+        return { error: `an email address cannot exceed ${MAX_ADDRESS_LENGTH} characters` };
+    }
+
+    if (!ADDRESS_PATTERN.test(trimmed)) {
+        return { error: 'not a valid email address' };
+    }
+
+    return { address: trimmed.toLowerCase(), kind: 'address' };
+}

--- a/packages/emitsignal-server/src/utils/email-target.ts
+++ b/packages/emitsignal-server/src/utils/email-target.ts
@@ -6,7 +6,8 @@ const SELF_TOKENS = new Set(['1', 'true', 'yes']);
 // values before they reach the queue, not to re-implement RFC 5321.
 const ADDRESS_PATTERN = /^[^\s@,;]+@[^\s@,;.]+(\.[^\s@,;.]+)+$/;
 
-const MAX_ADDRESS_LENGTH = 128;
+// RFC 5321 caps a reversible path at 254 characters; the route schema matches.
+const MAX_ADDRESS_LENGTH = 254;
 
 export function parseEmailTarget(raw: string): { error: string } | EmailTarget {
     const trimmed = raw.trim();


### PR DESCRIPTION
Publishers can now also deliver a message to an inbox, ntfy-style, via an email header (`x-email`, `x-e-mail`, `email`, `e-mail`, `mail`, `e`) or an `email` field in the JSON body. This wires up the `MessageAlertEmail` template that was already in the repo but had no call site.

Passing `yes`/`true`/`1` sends to the sender's own verified account address. Anonymous publishes are rejected, and emailing any other address requires a paid plan — mailing yourself stays free. Sending is capped by the existing per-account daily `emails` quota (5 / 50 / 250), so no new limiter or IP keying was needed.

Also fixes two quota bugs found while testing this, both of which predate the feature:

- `consumeDailyQuota` incremented before comparing, so denied requests still counted and reported usage climbed past its own limit (e.g. `10 / 5`).
- The messages quota was consumed right after auth, before media validation, topic resolution, the permission check, and action validation — so a `403` or `400` burned a message that was never created. Quotas are now consumed after all validation, immediately before the insert.

Not breaking: the request field is optional and existing publishes are unaffected. Worth flagging that daily counters now stop at their limit instead of growing past it, so any dashboard reading raw usage will report differently.

Verified with 517 server tests passing, plus lint, format, and tsc. Not exercised against a live stack — email delivery itself is covered by unit tests only.