### PR TITLE
docs: default docs site to API Reference tab

### DIFF
--- a/packages/emitsignal-docs/docs.json
+++ b/packages/emitsignal-docs/docs.json
@@ -30,7 +30,7 @@
     },
     "logo": {
         "dark": "/logo/dark.svg",
-        "href": "/cli/index",
+        "href": "/api/index",
         "light": "/logo/light.svg"
     },
     "name": "EmitSignal",
@@ -49,6 +49,34 @@
     },
     "navigation": {
         "tabs": [
+            {
+                "groups": [
+                    {
+                        "group": "Overview",
+                        "pages": ["api/index", "api/authentication"]
+                    },
+                    {
+                        "group": "Publish & stream",
+                        "pages": ["api/publish", "api/listen"]
+                    },
+                    {
+                        "group": "Resources",
+                        "pages": [
+                            "api/topics",
+                            "api/subscriptions",
+                            "api/messages",
+                            "api/push-tokens",
+                            "api/webhooks",
+                            "api/billing"
+                        ]
+                    },
+                    {
+                        "group": "Reference",
+                        "pages": ["api/errors", "api/rate-limits"]
+                    }
+                ],
+                "tab": "API Reference"
+            },
             {
                 "groups": [
                     {
@@ -81,34 +109,6 @@
                     }
                 ],
                 "tab": "CLI Reference"
-            },
-            {
-                "groups": [
-                    {
-                        "group": "Overview",
-                        "pages": ["api/index", "api/authentication"]
-                    },
-                    {
-                        "group": "Publish & stream",
-                        "pages": ["api/publish", "api/listen"]
-                    },
-                    {
-                        "group": "Resources",
-                        "pages": [
-                            "api/topics",
-                            "api/subscriptions",
-                            "api/messages",
-                            "api/push-tokens",
-                            "api/webhooks",
-                            "api/billing"
-                        ]
-                    },
-                    {
-                        "group": "Reference",
-                        "pages": ["api/errors", "api/rate-limits"]
-                    }
-                ],
-                "tab": "API Reference"
             }
         ]
     },


### PR DESCRIPTION
## Summary
- Reorders the `docs.json` navigation tabs so **API Reference** loads first instead of **CLI Reference**
- Updates the logo link target from `/cli/index` to `/api/index`

Requested in #blog-and-docs: the API reference is more useful for integrations than the CLI, so it should be the default landing section on docs.emitsignal.com.

## Test plan
- [ ] `mintlify dev` locally and confirm `/` lands on the API Reference tab
- [ ] Confirm logo click routes to `/api/index`
- [ ] Confirm CLI Reference tab still works and its pages are unchanged