### PR TITLE
docs: add Getting Started walkthrough to the docs site

### DIFF
--- a/packages/emitsignal-docs/api/index.mdx
+++ b/packages/emitsignal-docs/api/index.mdx
@@ -54,7 +54,8 @@ curl https://emitsignal.com/publish/deploy/prod \
 </CodeGroup>
 
 <Note>
-    Prefer the terminal? The [CLI](/cli/index) wraps these endpoints in a single static binary.
+    Prefer the terminal? The [CLI](/cli/index) wraps these endpoints in a single static binary. New
+    to EmitSignal? Start with the [Getting started walkthrough](/start/index).
 </Note>
 
 ## Conventions

--- a/packages/emitsignal-docs/api/rate-limits.mdx
+++ b/packages/emitsignal-docs/api/rate-limits.mdx
@@ -39,7 +39,7 @@ Authenticated publishing counts against a per-day message quota that depends on 
 
 | Plan  | Messages / day | Owned topics | Webhooks | Max attachment | Emails / day |
 | ----- | -------------- | ------------ | -------- | -------------- | ------------ |
-| Free  | 100            | 5            | 2        | 5 MB           | 5            |
+| Free  | 100            | 0            | 2        | 5 MB           | 5            |
 | Pulse | 2,500          | 15           | 10       | 25 MB          | 50           |
 | Beam  | 20,000         | 50           | 30       | 100 MB         | 250          |
 

--- a/packages/emitsignal-docs/cli/index.mdx
+++ b/packages/emitsignal-docs/cli/index.mdx
@@ -20,6 +20,11 @@ import { Arrow, Caret, Cmd, Cmt, Ok, Out, Sp, Term } from '../snippets/terminal.
     </Card>
 </CardGroup>
 
+<Note>
+    Never used EmitSignal before? The [Getting started walkthrough](/start/index) covers the whole
+    journey — first `curl`, the phone apps, then the CLI.
+</Note>
+
 ## Why a CLI?
 
 Every service you run can publish signals. Every machine you own can listen to them.

--- a/packages/emitsignal-docs/cli/index.mdx
+++ b/packages/emitsignal-docs/cli/index.mdx
@@ -22,7 +22,7 @@ import { Arrow, Caret, Cmd, Cmt, Ok, Out, Sp, Term } from '../snippets/terminal.
 
 <Note>
     Never used EmitSignal before? The [Getting started walkthrough](/start/index) covers the whole
-    journey — first `curl`, the phone apps, then the CLI.
+    journey: first `curl`, the phone apps, then the CLI.
 </Note>
 
 ## Why a CLI?

--- a/packages/emitsignal-docs/cli/quickstart.mdx
+++ b/packages/emitsignal-docs/cli/quickstart.mdx
@@ -4,13 +4,11 @@ description: 'From zero to a notification on your phone in four commands.'
 ---
 
 import { Arrow, Caret, Cmd, Ok, Out, Sp, Term } from '../snippets/terminal.jsx';
-import { Terminal } from '../snippets/hi.jsx';
 
 <Steps>
     <Step title="Install and log in">
-    <Terminal>Oi</Terminal>
         <Term title="emitsignal — zsh">
-            <Cmd>brew install emitsignal</Cmd>
+            <Cmd>brew install emitsignal/tap/emitsignal</Cmd>
             <Ok>emitsignal 1.0.0 installed</Ok>
             <Sp />
             <Cmd>emitsignal login</Cmd>

--- a/packages/emitsignal-docs/docs.json
+++ b/packages/emitsignal-docs/docs.json
@@ -30,7 +30,7 @@
     },
     "logo": {
         "dark": "/logo/dark.svg",
-        "href": "/api/index",
+        "href": "/start/index",
         "light": "/logo/light.svg"
     },
     "name": "EmitSignal",
@@ -49,6 +49,23 @@
     },
     "navigation": {
         "tabs": [
+            {
+                "groups": [
+                    {
+                        "group": "Start here",
+                        "pages": ["start/index"]
+                    },
+                    {
+                        "group": "Your first journey",
+                        "pages": ["start/first-signal", "start/mobile", "start/terminal"]
+                    },
+                    {
+                        "group": "Going further",
+                        "pages": ["start/automate", "start/accounts", "start/self-hosting"]
+                    }
+                ],
+                "tab": "Getting Started"
+            },
             {
                 "groups": [
                     {

--- a/packages/emitsignal-docs/start/accounts.mdx
+++ b/packages/emitsignal-docs/start/accounts.mdx
@@ -1,0 +1,100 @@
+---
+title: 'Accounts and API keys'
+description: 'What signing in unlocks, how to mint a scoped key for CI, and how to reserve a topic name.'
+---
+
+Nearly everything works anonymously — publishing, subscribing, and listening are all
+device-scoped and usable without an account. Signing in raises limits, syncs across
+devices, and unlocks ownership.
+
+## Anonymous vs signed in
+
+|                      | Anonymous    | Signed in             |
+| -------------------- | ------------ | --------------------- |
+| Publish              | 10 / min     | 60 / min              |
+| Reads                | 30 / min     | 120 / min             |
+| Live SSE connections | 3 concurrent | 10 concurrent         |
+| Subscriptions        | Per device   | Synced across devices |
+| Attachment uploads   | 5 / hour     | 20 / hour             |
+| Topic ownership      | —            | On a paid plan        |
+
+Rate limits are keyed by user when authenticated, by IP otherwise. When Redis is
+unavailable, limiting **fails open**. Full detail in
+[Rate limits](/api/rate-limits).
+
+## Sign in
+
+Three equivalent routes to the same account:
+
+- **CLI** — `emitsignal login`, an email one-time code; the token lands in
+  `~/.emitsignalrc`.
+- **Apps and web** — magic link, passkey (WebAuthn), or GitHub / Apple sign-in.
+- **Directly against the API** — the Better Auth routes under `/api/auth/*`, documented
+  in [Authentication](/api/authentication).
+
+Already been using the app anonymously? Sign in and
+[claim your device's subscriptions](/api/subscriptions#claim-device-subscriptions) so
+they carry over.
+
+## API keys
+
+Use an API key for anything unattended — CI, cron, a server. Keys are prefixed `es_`
+and go in the `Authorization` header:
+
+```bash
+curl https://api.emitsignal.com/publish/ci/web \
+  -H "Authorization: Bearer es_xxxxxxxxxxxx" \
+  -d "build finished"
+```
+
+Create, list, and revoke them from the CLI:
+
+```bash
+emitsignal keys create --name ci-prod --expires 90d
+emitsignal keys list
+emitsignal keys revoke <id>
+```
+
+<Warning>
+    A new key's secret is shown **once**, at creation. Store it in your secret manager immediately —
+    it cannot be retrieved again.
+</Warning>
+
+`x-api-key: <key>` works as a dedicated header if `Authorization` is already taken by
+something else in your stack.
+
+## Reserving a topic name
+
+By default a topic is created on first publish, is owned by nobody, and is readable and
+writable by anyone who knows its name. Reserving one binds it to your account:
+
+```
+POST /topics/:name/claim   { "accessMode": "public" | "readonly" | "private" }
+```
+
+- `public` — anyone can read and publish.
+- `readonly` — anyone can read; only you and the users you grant access can publish.
+- `private` — only you and the users you grant access can read or publish.
+
+Reserving requires a **paid plan** (Pulse or Beam) and returns `403 plan_required`
+otherwise. An already-owned name returns `409 already_claimed`. `DELETE` on the same
+path releases the topic back to public and ownerless.
+
+## Plan quotas
+
+Authenticated publishing counts against a per-day quota:
+
+| Plan  | Messages / day | Owned topics | Webhooks | Max attachment | Emails / day |
+| ----- | -------------- | ------------ | -------- | -------------- | ------------ |
+| Free  | 100            | 0            | 2        | 5 MB           | 5            |
+| Pulse | 2,500          | 15           | 10       | 25 MB          | 50           |
+| Beam  | 20,000         | 50           | 30       | 100 MB         | 250          |
+
+Over the daily quota returns `429 daily_quota_exceeded` with a `resetAt`. Topic and
+webhook caps are enforced at create time with `403 plan_limit_reached`. Current usage
+is on [`GET /billing`](/api/billing).
+
+<Note>
+    Running out of quota is also a reason to [self-host](/start/self-hosting) — the limits are yours
+    to set.
+</Note>

--- a/packages/emitsignal-docs/start/accounts.mdx
+++ b/packages/emitsignal-docs/start/accounts.mdx
@@ -3,20 +3,20 @@ title: 'Accounts and API keys'
 description: 'What signing in unlocks, how to mint a scoped key for CI, and how to reserve a topic name.'
 ---
 
-Nearly everything works anonymously — publishing, subscribing, and listening are all
+Nearly everything works anonymously: publishing, subscribing, and listening are all
 device-scoped and usable without an account. Signing in raises limits, syncs across
 devices, and unlocks ownership.
 
 ## Anonymous vs signed in
 
-|                      | Anonymous    | Signed in             |
-| -------------------- | ------------ | --------------------- |
-| Publish              | 10 / min     | 60 / min              |
-| Reads                | 30 / min     | 120 / min             |
-| Live SSE connections | 3 concurrent | 10 concurrent         |
-| Subscriptions        | Per device   | Synced across devices |
-| Attachment uploads   | 5 / hour     | 20 / hour             |
-| Topic ownership      | —            | On a paid plan        |
+|                      | Anonymous     | Signed in             |
+| -------------------- | ------------- | --------------------- |
+| Publish              | 10 / min      | 60 / min              |
+| Reads                | 30 / min      | 120 / min             |
+| Live SSE connections | 3 concurrent  | 10 concurrent         |
+| Subscriptions        | Per device    | Synced across devices |
+| Attachment uploads   | 5 / hour      | 20 / hour             |
+| Topic ownership      | Not available | On a paid plan        |
 
 Rate limits are keyed by user when authenticated, by IP otherwise. When Redis is
 unavailable, limiting **fails open**. Full detail in
@@ -26,10 +26,10 @@ unavailable, limiting **fails open**. Full detail in
 
 Three equivalent routes to the same account:
 
-- **CLI** — `emitsignal login`, an email one-time code; the token lands in
+- **CLI**: `emitsignal login`, an email one-time code; the token lands in
   `~/.emitsignalrc`.
-- **Apps and web** — magic link, passkey (WebAuthn), or GitHub / Apple sign-in.
-- **Directly against the API** — the Better Auth routes under `/api/auth/*`, documented
+- **Apps and web**: magic link, passkey (WebAuthn), or GitHub / Apple sign-in.
+- **Directly against the API**: the Better Auth routes under `/api/auth/*`, documented
   in [Authentication](/api/authentication).
 
 Already been using the app anonymously? Sign in and
@@ -38,7 +38,7 @@ they carry over.
 
 ## API keys
 
-Use an API key for anything unattended — CI, cron, a server. Keys are prefixed `es_`
+Use an API key for anything unattended: CI, cron, a server. Keys are prefixed `es_`
 and go in the `Authorization` header:
 
 ```bash
@@ -56,8 +56,8 @@ emitsignal keys revoke <id>
 ```
 
 <Warning>
-    A new key's secret is shown **once**, at creation. Store it in your secret manager immediately —
-    it cannot be retrieved again.
+    A new key's secret is shown **once**, at creation. Store it in your secret manager immediately,
+    because it cannot be retrieved again.
 </Warning>
 
 `x-api-key: <key>` works as a dedicated header if `Authorization` is already taken by
@@ -72,9 +72,9 @@ writable by anyone who knows its name. Reserving one binds it to your account:
 POST /topics/:name/claim   { "accessMode": "public" | "readonly" | "private" }
 ```
 
-- `public` — anyone can read and publish.
-- `readonly` — anyone can read; only you and the users you grant access can publish.
-- `private` — only you and the users you grant access can read or publish.
+- `public`: anyone can read and publish.
+- `readonly`: anyone can read; only you and the users you grant access can publish.
+- `private`: only you and the users you grant access can read or publish.
 
 Reserving requires a **paid plan** (Pulse or Beam) and returns `403 plan_required`
 otherwise. An already-owned name returns `409 already_claimed`. `DELETE` on the same
@@ -95,6 +95,6 @@ webhook caps are enforced at create time with `403 plan_limit_reached`. Current 
 is on [`GET /billing`](/api/billing).
 
 <Note>
-    Running out of quota is also a reason to [self-host](/start/self-hosting) — the limits are yours
-    to set.
+    Running out of quota is also a reason to [self-host](/start/self-hosting), where the limits are
+    yours to set.
 </Note>

--- a/packages/emitsignal-docs/start/automate.mdx
+++ b/packages/emitsignal-docs/start/automate.mdx
@@ -1,0 +1,124 @@
+---
+title: 'Wire it into your stack'
+description: 'Real recipes — CI, cron, monitoring, and inbound webhooks from GitHub, Grafana, Stripe, and Vercel.'
+---
+
+Anything that can make an HTTP request can emit a signal. Here is what that looks like
+in the places you'd actually use it.
+
+## CI: notify on failure
+
+A single step at the end of a job. This one uses the header format so nothing needs
+JSON-encoding:
+
+```yaml
+- name: Notify EmitSignal
+  if: always()
+  run: |
+      curl -X POST https://api.emitsignal.com/publish/ci/web \
+        -H "Authorization: Bearer ${{ secrets.EMITSIGNAL_API_KEY }}" \
+        -H "X-Title: ${{ job.status == 'success' && 'Build passed' || 'Build failed' }}" \
+        -H "X-Priority: ${{ job.status == 'success' && 'low' || 'high' }}" \
+        -H "X-Tags: ci,${{ github.ref_name }}" \
+        -d "${{ github.repository }} · ${{ github.sha }}"
+```
+
+Mint a key scoped to CI rather than reusing your personal token — see
+[Accounts and API keys](/start/accounts).
+
+## Cron: report a nightly job
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ./nightly-backup.sh > /tmp/backup.log 2>&1; then
+  emitsignal publish cron/backup -p2 -T "Backup ok" -m "$(tail -1 /tmp/backup.log)"
+else
+  emitsignal publish cron/backup -p5 -T "Backup FAILED" < /tmp/backup.log
+fi
+```
+
+`publish` reads stdin when no body is given, so piping a log file in is enough.
+
+## Long-running commands
+
+Fire a signal the moment something finishes, however long it takes:
+
+```bash
+make deploy && emitsignal publish deploy/prod -p4 -m "deploy done"
+```
+
+## Inbound webhooks from other services
+
+Instead of writing glue code, give the sending service an EmitSignal URL. Each webhook
+has a public receiver at `/h/:slug` that turns an inbound POST into a signal on a
+topic. Built-in sources: `github`, `grafana`, `stripe`, `vercel`, and `custom`.
+
+```bash
+emitsignal webhooks create \
+  --channel github/acme \
+  --source github \
+  --name "acme repo" \
+  --verification github \
+  --secret "$GITHUB_WEBHOOK_SECRET"
+```
+
+Paste the returned URL into the provider's webhook settings. Always configure a
+verification scheme and secret — the receiver is public, and verification is what stops
+anyone else from posting to it.
+
+Watch deliveries while you wire it up:
+
+```bash
+emitsignal webhooks tail github
+```
+
+Full options — templates, `hmac`/`token` verification, and the delivery stream — are in
+the [webhooks reference](/api/webhooks).
+
+## React to signals with a script
+
+`listen -x` runs a command per event, with the message exposed as `$ES_*` environment
+variables:
+
+```bash
+emitsignal listen alerts/prod --priority '>=5' -x 'say "$ES_TITLE"'
+```
+
+## Schedule a reminder
+
+```bash
+emitsignal publish reminders -T "Stand-up" -m "Daily in 30" --priority 3
+curl -H "X-Delay: 30m" -H "X-Title: Stand-up" \
+  -d "Daily in 30" https://api.emitsignal.com/publish/reminders
+```
+
+`X-Delay` takes `30s`, `5m`, `2h`, `1d`, `1w`, or a unix timestamp, up to a year out.
+
+## Consume signals in your own app
+
+Subscribe over SSE from any language. In the browser:
+
+```js
+const source = new EventSource('https://api.emitsignal.com/listen?topics=alerts/prod,deploy/prod');
+
+source.addEventListener('message', (event) => {
+    const signal = JSON.parse(event.data);
+    console.log(signal.priority, signal.title);
+});
+```
+
+Reuse one multi-topic stream rather than opening one per topic — the connection cap is
+3 anonymous, 10 authenticated.
+
+## Next
+
+<CardGroup cols={2}>
+    <Card title="Accounts and API keys" icon="key" href="/start/accounts">
+        Scoped keys, higher limits, and plan quotas.
+    </Card>
+    <Card title="Webhooks reference" icon="webhook" href="/api/webhooks">
+        Templates, signature verification, delivery history.
+    </Card>
+</CardGroup>

--- a/packages/emitsignal-docs/start/automate.mdx
+++ b/packages/emitsignal-docs/start/automate.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Wire it into your stack'
-description: 'Real recipes — CI, cron, monitoring, and inbound webhooks from GitHub, Grafana, Stripe, and Vercel.'
+description: 'Real recipes for CI, cron, monitoring, and inbound webhooks from GitHub, Grafana, Stripe, and Vercel.'
 ---
 
 Anything that can make an HTTP request can emit a signal. Here is what that looks like
@@ -23,7 +23,7 @@ JSON-encoding:
         -d "${{ github.repository }} · ${{ github.sha }}"
 ```
 
-Mint a key scoped to CI rather than reusing your personal token — see
+Mint a key scoped to CI rather than reusing your personal token. See
 [Accounts and API keys](/start/accounts).
 
 ## Cron: report a nightly job
@@ -65,7 +65,7 @@ emitsignal webhooks create \
 ```
 
 Paste the returned URL into the provider's webhook settings. Always configure a
-verification scheme and secret — the receiver is public, and verification is what stops
+verification scheme and secret: the receiver is public, and verification is what stops
 anyone else from posting to it.
 
 Watch deliveries while you wire it up:
@@ -74,7 +74,7 @@ Watch deliveries while you wire it up:
 emitsignal webhooks tail github
 ```
 
-Full options — templates, `hmac`/`token` verification, and the delivery stream — are in
+Full options, including templates, `hmac`/`token` verification, and the delivery stream, are in
 the [webhooks reference](/api/webhooks).
 
 ## React to signals with a script
@@ -109,7 +109,7 @@ source.addEventListener('message', (event) => {
 });
 ```
 
-Reuse one multi-topic stream rather than opening one per topic — the connection cap is
+Reuse one multi-topic stream rather than opening one per topic. The connection cap is
 3 anonymous, 10 authenticated.
 
 ## Next

--- a/packages/emitsignal-docs/start/first-signal.mdx
+++ b/packages/emitsignal-docs/start/first-signal.mdx
@@ -1,0 +1,115 @@
+---
+title: 'Send your first signal'
+description: 'Everything a message can carry — title, priority, tags, links, scheduling — using nothing but curl.'
+---
+
+Publishing is one `POST` to `/publish/<topic>`. No account, no SDK, no
+pre-registration: the topic is created the first time you write to it.
+
+```bash
+curl -d "Deploy finished" https://api.emitsignal.com/publish/mytopic-8f2a
+```
+
+Topic names are up to 38 characters of `a-z`, `0-9`, `-`, `_`, and `/`, and must start
+and end with a letter or digit. The slashes are just part of the name, so `alerts/prod`
+and `ci/web` group naturally.
+
+The response tells you the message landed:
+
+```json
+{ "message": "posted", "messageId": "cly..." }
+```
+
+## Add a title, priority, and tags
+
+When the request `Content-Type` is **not** `application/json`, the raw body becomes the
+message and the metadata comes from headers. That's exactly what `curl -d` does by
+default, so this is the shortest path:
+
+```bash
+curl -X POST https://api.emitsignal.com/publish/alerts \
+  -H "X-Title: Deploy finished" \
+  -H "X-Priority: high" \
+  -H "X-Tags: ci,prod" \
+  -d "v2.4.0 shipped to production"
+```
+
+Priority accepts a name or a number:
+
+| Priority | Names             | Typical use                       |
+| -------- | ----------------- | --------------------------------- |
+| `5`      | `urgent`, `max`   | Page someone. Wake them up.       |
+| `4`      | `high`            | Deploys, failed builds.           |
+| `3`      | `default`, `none` | Ordinary events.                  |
+| `2`      | `low`             | Chatty background activity.       |
+| `1`      | `min`             | Log-level noise you want to skim. |
+
+<Tip>
+    Short header aliases work too — `t` for title, `p` for priority, `ta` for tags. Handy when
+    you're hand-writing a curl inside a CI YAML file.
+</Tip>
+
+## Or send JSON
+
+If you'd rather build a payload in code, set `Content-Type: application/json`:
+
+```bash
+curl -X POST https://api.emitsignal.com/publish/alerts \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Latency alert",
+    "body": "p99 over 800ms",
+    "priority": 5,
+    "tags": ["prod", "oncall"]
+  }'
+```
+
+At least one of `title` or `body` must be non-empty. `body` renders as Markdown.
+The full field list is in the [Publish reference](/api/publish).
+
+## Deliver it later
+
+`X-Delay` takes a relative duration (`30s`, `5m`, `2h`, `1d`, `1w`) or a unix
+timestamp, up to a year out:
+
+```bash
+curl -X POST https://api.emitsignal.com/publish/reminders \
+  -H "X-Title: Stand-up in 30 minutes" \
+  -H "X-Delay: 30m" \
+  -d "Don't forget the daily"
+```
+
+Scheduled messages skip the live stream and go to the schedule queue, then deliver at
+their time like any other signal.
+
+## Watch it arrive
+
+Open a second terminal and stream the topic over
+[Server-Sent Events](/api/listen) before you publish:
+
+```bash
+# one topic
+curl -N https://api.emitsignal.com/topics/alerts/listen
+
+# several at once, replaying the last 10 minutes first
+curl -N "https://api.emitsignal.com/listen?topics=alerts,ci,deploys&since=$(($(date +%s000) - 600000))"
+```
+
+The stream emits named `message` events plus a `: ping` heartbeat every 25 seconds, so
+proxies don't hang up on an idle connection.
+
+<Warning>
+    Anonymous callers get **10 publishes per minute** and **3 concurrent SSE connections**. Signing
+    in raises both — see [Accounts and API keys](/start/accounts).
+</Warning>
+
+## Next
+
+<CardGroup cols={2}>
+    <Card title="Get it on your phone" icon="mobile" href="/start/mobile">
+        Turn that signal into a real push notification.
+    </Card>
+    <Card title="Publish reference" icon="paper-plane" href="/api/publish">
+        Every field, header, and response shape.
+    </Card>
+</CardGroup>

--- a/packages/emitsignal-docs/start/first-signal.mdx
+++ b/packages/emitsignal-docs/start/first-signal.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Send your first signal'
-description: 'Everything a message can carry — title, priority, tags, links, scheduling — using nothing but curl.'
+description: 'Everything a message can carry (title, priority, tags, links, scheduling) using nothing but curl.'
 ---
 
 Publishing is one `POST` to `/publish/<topic>`. No account, no SDK, no
@@ -45,8 +45,8 @@ Priority accepts a name or a number:
 | `1`      | `min`             | Log-level noise you want to skim. |
 
 <Tip>
-    Short header aliases work too — `t` for title, `p` for priority, `ta` for tags. Handy when
-    you're hand-writing a curl inside a CI YAML file.
+    Short header aliases work too: `t` for title, `p` for priority, `ta` for tags. Handy when you're
+    hand-writing a curl inside a CI YAML file.
 </Tip>
 
 ## Or send JSON
@@ -100,7 +100,7 @@ proxies don't hang up on an idle connection.
 
 <Warning>
     Anonymous callers get **10 publishes per minute** and **3 concurrent SSE connections**. Signing
-    in raises both — see [Accounts and API keys](/start/accounts).
+    in raises both. See [Accounts and API keys](/start/accounts).
 </Warning>
 
 ## Next

--- a/packages/emitsignal-docs/start/index.mdx
+++ b/packages/emitsignal-docs/start/index.mdx
@@ -4,7 +4,7 @@ description: 'From your first curl to a push notification on your phone. No SDK,
 ---
 
 EmitSignal is a real-time notification platform for developers. You `POST` a message to
-a named **topic**; anyone subscribed to that topic gets it **live** — as a push
+a named **topic**, and anyone subscribed to that topic gets it **live**: as a push
 notification on their phone, as a line in their terminal, and in the web inbox.
 
 There is nothing to install to send. If it can make an HTTP request, it can emit a
@@ -12,7 +12,7 @@ signal.
 
 ## The 30-second version
 
-Pick a topic name — anything, it's created on first publish — and send to it:
+Pick a topic name. Anything works, since the topic is created on first publish:
 
 ```bash
 curl -d "Deploy finished" https://api.emitsignal.com/publish/mytopic-8f2a
@@ -37,7 +37,7 @@ that same loop with better ergonomics.
 
 <CardGroup cols={2}>
     <Card title="1 · Send your first signal" icon="paper-plane" href="/start/first-signal">
-        Titles, priorities, tags, and scheduling — all from `curl`.
+        Titles, priorities, tags, and scheduling, all from `curl`.
     </Card>
     <Card title="2 · Get it on your phone" icon="mobile" href="/start/mobile">
         Install the app, subscribe to your topic, receive real push.
@@ -68,6 +68,6 @@ that same loop with better ergonomics.
 | Read from your own code         | [`GET /listen`](/api/listen) over Server-Sent Events              |
 
 <Note>
-    Prefer to run it yourself? Every part of EmitSignal is AGPL-3.0 and self-hostable — see
+    Prefer to run it yourself? Every part of EmitSignal is AGPL-3.0 and self-hostable. See
     [Self-hosting](/start/self-hosting).
 </Note>

--- a/packages/emitsignal-docs/start/index.mdx
+++ b/packages/emitsignal-docs/start/index.mdx
@@ -1,0 +1,73 @@
+---
+title: 'Getting started'
+description: 'From your first curl to a push notification on your phone. No SDK, no account required.'
+---
+
+EmitSignal is a real-time notification platform for developers. You `POST` a message to
+a named **topic**; anyone subscribed to that topic gets it **live** — as a push
+notification on their phone, as a line in their terminal, and in the web inbox.
+
+There is nothing to install to send. If it can make an HTTP request, it can emit a
+signal.
+
+## The 30-second version
+
+Pick a topic name — anything, it's created on first publish — and send to it:
+
+```bash
+curl -d "Deploy finished" https://api.emitsignal.com/publish/mytopic-8f2a
+```
+
+<Note>
+    Topics are public by default and created on first use, so choose a name nobody would guess
+    (`mytopic-8f2a`, not `test`). Anyone who knows the name can read and write it until it is
+    [reserved by an owner](/start/accounts#reserving-a-topic-name).
+</Note>
+
+To see that message arrive, open a second terminal **before** publishing:
+
+```bash
+curl -N https://api.emitsignal.com/topics/mytopic-8f2a/listen
+```
+
+That's the whole model: publish to a topic, listen on a topic. Everything below is
+that same loop with better ergonomics.
+
+## Follow the journey
+
+<CardGroup cols={2}>
+    <Card title="1 · Send your first signal" icon="paper-plane" href="/start/first-signal">
+        Titles, priorities, tags, and scheduling — all from `curl`.
+    </Card>
+    <Card title="2 · Get it on your phone" icon="mobile" href="/start/mobile">
+        Install the app, subscribe to your topic, receive real push.
+    </Card>
+    <Card title="3 · Live in your terminal" icon="terminal" href="/start/terminal">
+        Install the CLI, log in, and tail your topics like logs.
+    </Card>
+    <Card title="4 · Wire it into your stack" icon="gear" href="/start/automate">
+        CI, cron, inbound webhooks from GitHub, Grafana, Stripe, and Vercel.
+    </Card>
+    <Card title="5 · Accounts and API keys" icon="key" href="/start/accounts">
+        What an account unlocks, and how to mint a scoped key for CI.
+    </Card>
+    <Card title="6 · Self-host it" icon="server" href="/start/self-hosting">
+        The whole stack on your own machine with one Docker Compose file.
+    </Card>
+</CardGroup>
+
+## How the pieces fit
+
+| You want to…                    | Use                                                               |
+| ------------------------------- | ----------------------------------------------------------------- |
+| Send from a script, CI, or cron | `curl` → [`POST /publish/<topic>`](/api/publish)                  |
+| Send from your terminal         | [`emitsignal publish`](/cli/publish)                              |
+| Read on your phone              | The [iOS and Android apps](/start/mobile)                         |
+| Read in your terminal           | [`emitsignal listen`](/cli/listen) or [`tui`](/cli/tui)           |
+| Read in a browser               | The web inbox at [emitsignal.com/app](https://emitsignal.com/app) |
+| Read from your own code         | [`GET /listen`](/api/listen) over Server-Sent Events              |
+
+<Note>
+    Prefer to run it yourself? Every part of EmitSignal is AGPL-3.0 and self-hostable — see
+    [Self-hosting](/start/self-hosting).
+</Note>

--- a/packages/emitsignal-docs/start/mobile.mdx
+++ b/packages/emitsignal-docs/start/mobile.mdx
@@ -4,20 +4,20 @@ description: 'Install the app, subscribe to a topic, and receive native push on 
 ---
 
 The apps are the other half of EmitSignal: the inbox you actually carry. Push is
-native on both platforms — no polling, no companion service.
+native on both platforms, with no polling and no companion service.
 
 ## Install
 
 <CardGroup cols={2}>
     <Card
-        title="iOS — App Store"
+        title="iOS · App Store"
         icon="apple"
         href="https://apps.apple.com/us/app/emitsignal/id6782717233"
     >
         Download EmitSignal for iPhone and iPad.
     </Card>
     <Card title="Android" icon="android" href="https://emitsignal.com/mobile">
-        Not on Google Play yet — build it from source. Instructions on the mobile page.
+        Not on Google Play yet, so build it from source. Instructions on the mobile page.
     </Card>
 </CardGroup>
 
@@ -26,7 +26,7 @@ same topics on more than one device.
 
 ## Subscribe to a topic
 
-1. Open the app and allow notifications when prompted — without permission there is no
+1. Open the app and allow notifications when prompted. Without permission there is no
    push, only the in-app inbox.
 2. Add the topic name you published to in [step 1](/start/first-signal), for example
    `mytopic-8f2a`.
@@ -53,7 +53,7 @@ to see how the alert is presented differently.
 
 ## What the app can do
 
-- **Read and publish.** Sending isn't terminal-only — you can publish from the app.
+- **Read and publish.** Sending isn't terminal-only. You can publish from the app.
 - **Per-topic control.** Subscribe per topic and mute the noisy ones individually.
 - **Widgets.** Home Screen and Lock Screen widgets for your latest signals.
 - **Actions.** Messages published with `X-Actions` render tappable buttons
@@ -61,7 +61,7 @@ to see how the alert is presented differently.
 
 ## Prefer a browser?
 
-The same inbox runs at [emitsignal.com/app](https://emitsignal.com/app) — searchable
+The same inbox runs at [emitsignal.com/app](https://emitsignal.com/app), with searchable
 history, attachments, and live updates over SSE.
 
 ## Next

--- a/packages/emitsignal-docs/start/mobile.mdx
+++ b/packages/emitsignal-docs/start/mobile.mdx
@@ -1,0 +1,76 @@
+---
+title: 'Get it on your phone'
+description: 'Install the app, subscribe to a topic, and receive native push on iOS and Android.'
+---
+
+The apps are the other half of EmitSignal: the inbox you actually carry. Push is
+native on both platforms — no polling, no companion service.
+
+## Install
+
+<CardGroup cols={2}>
+    <Card
+        title="iOS — App Store"
+        icon="apple"
+        href="https://apps.apple.com/us/app/emitsignal/id6782717233"
+    >
+        Download EmitSignal for iPhone and iPad.
+    </Card>
+    <Card title="Android" icon="android" href="https://emitsignal.com/mobile">
+        Not on Google Play yet — build it from source. Instructions on the mobile page.
+    </Card>
+</CardGroup>
+
+The app is free and usable straight away. An account only matters once you want the
+same topics on more than one device.
+
+## Subscribe to a topic
+
+1. Open the app and allow notifications when prompted — without permission there is no
+   push, only the in-app inbox.
+2. Add the topic name you published to in [step 1](/start/first-signal), for example
+   `mytopic-8f2a`.
+3. Leave push enabled for that subscription. You can mute individual topics later
+   without unsubscribing.
+
+A subscription links a **device** to a topic. It works anonymously; signing in lets you
+[claim your device's subscriptions](/api/subscriptions#claim-device-subscriptions) so
+they follow you to your other devices.
+
+## Send yourself a real push
+
+Back in your terminal:
+
+```bash
+curl -X POST https://api.emitsignal.com/publish/mytopic-8f2a \
+  -H "X-Title: It works" \
+  -H "X-Priority: high" \
+  -d "Sent from my shell"
+```
+
+The notification lands within about a second. Try priority `4` (high) and `5` (urgent)
+to see how the alert is presented differently.
+
+## What the app can do
+
+- **Read and publish.** Sending isn't terminal-only — you can publish from the app.
+- **Per-topic control.** Subscribe per topic and mute the noisy ones individually.
+- **Widgets.** Home Screen and Lock Screen widgets for your latest signals.
+- **Actions.** Messages published with `X-Actions` render tappable buttons
+  (`acknowledge` or `view`); `-l, --link` from the CLI attaches a tap-through URL.
+
+## Prefer a browser?
+
+The same inbox runs at [emitsignal.com/app](https://emitsignal.com/app) — searchable
+history, attachments, and live updates over SSE.
+
+## Next
+
+<CardGroup cols={2}>
+    <Card title="Live in your terminal" icon="terminal" href="/start/terminal">
+        The CLI, the filters, and the full-screen TUI inbox.
+    </Card>
+    <Card title="Push tokens API" icon="bell" href="/api/push-tokens">
+        How devices register for push, if you're building your own client.
+    </Card>
+</CardGroup>

--- a/packages/emitsignal-docs/start/self-hosting.mdx
+++ b/packages/emitsignal-docs/start/self-hosting.mdx
@@ -1,0 +1,107 @@
+---
+title: 'Self-host EmitSignal'
+description: 'Run the whole stack on your own machine with one Docker Compose file.'
+---
+
+EmitSignal is AGPL-3.0 and self-hostable end to end — API, workers, database, queue,
+and web dashboard. The fastest path is the bundled Compose stack.
+
+## Requirements
+
+- [Bun](https://bun.com) `>= 1.3`
+- [Docker](https://docs.docker.com/get-docker/)
+
+## Bring up the stack
+
+```bash
+git clone https://github.com/emitsignal/emitsignal.git
+cd emitsignal
+bun install
+docker compose -f packages/emitsignal-docker/docker-compose.dev.yml up
+```
+
+That runs everything with hot reload:
+
+| Service                           | Where                                   |
+| --------------------------------- | --------------------------------------- |
+| API server                        | [localhost:5100](http://localhost:5100) |
+| Web dashboard                     | [localhost:5173](http://localhost:5173) |
+| SMTP inbox                        | [localhost:3134](http://localhost:3134) |
+| PostgreSQL, Redis, BullMQ workers | in the same stack                       |
+
+Point the CLI at it:
+
+```bash
+emitsignal config set-url http://localhost:5100
+```
+
+## Running the pieces by hand
+
+<CodeGroup>
+
+```bash API + workers
+cd packages/emitsignal-server
+cp .env.example .env          # edit DATABASE_URL, REDIS_URL, etc.
+bun run db:migrate && bun run db:seed
+bun run dev:worker            # all workers (separate terminal)
+bun run dev                   # API server
+```
+
+```bash Web dashboard
+cd packages/emitsignal-website
+bun run dev
+```
+
+```bash Mobile app
+cd packages/emitsignal-mobile
+bun run start
+```
+
+</CodeGroup>
+
+Workspace-wide scripts run from the repo root: `bun format`, `bun lint`, `bun test`,
+and `bun dev` (runs `dev` in every package).
+
+## How it fits together
+
+```
+┌─────────────┐              ┌─────────────┐              ┌─────────────┐
+│   Website   │  SSE/HTTP    │   Server    │   BullMQ     │   Workers   │
+│  (TanStack) │ ◄──────────► │  (Elysia)   │ ───────────► │ email/push/ │
+└─────────────┘              └──────┬──────┘              │  schedule   │
+                                    │                     └──────┬──────┘
+┌─────────────┐              ┌──────┴──────┐                     │
+│   Mobile    │  SSE/HTTP    │ PostgreSQL  │              ┌──────┴──────┐
+│  (Expo/RN)  │ ◄──────────► │   + Redis   │              │   Email     │
+└─────────────┘              └─────────────┘              │  Provider   │
+                                                          │ smtp/resend │
+                                                          └─────────────┘
+```
+
+A publish immediately fires an in-process event bus — that's what powers live SSE — and
+enqueues a push job. Scheduled messages skip the bus and go straight to the schedule
+queue. Dedicated workers drain the `email`, `push`, and `schedule` queues, so the
+publish path never blocks on delivery.
+
+## What to configure
+
+- **Email** — a pluggable provider: `log` (default in dev), `smtp`, or
+  [Resend](https://resend.com).
+- **Attachments** — stored locally or on S3.
+- **Redis** — backs rate limiting and BullMQ. Rate limiting fails open if Redis is down.
+- **Auth** — magic link, passkey, and API keys work out of the box; GitHub and Apple
+  sign-in are optional.
+
+Start from `packages/emitsignal-server/.env.example`; every variable is documented
+there.
+
+## Next
+
+<CardGroup cols={2}>
+    <Card title="API reference" icon="code" href="/api/index">
+        The endpoints your instance exposes.
+    </Card>
+    <Card title="Source on GitHub" icon="github" href="https://github.com/emitsignal/emitsignal">
+        Issues, releases, and the Compose files.
+    </Card>
+</CardGroup>

--- a/packages/emitsignal-docs/start/self-hosting.mdx
+++ b/packages/emitsignal-docs/start/self-hosting.mdx
@@ -3,7 +3,7 @@ title: 'Self-host EmitSignal'
 description: 'Run the whole stack on your own machine with one Docker Compose file.'
 ---
 
-EmitSignal is AGPL-3.0 and self-hostable end to end — API, workers, database, queue,
+EmitSignal is AGPL-3.0 and self-hostable end to end: API, workers, database, queue,
 and web dashboard. The fastest path is the bundled Compose stack.
 
 ## Requirements
@@ -78,18 +78,18 @@ and `bun dev` (runs `dev` in every package).
                                                           └─────────────┘
 ```
 
-A publish immediately fires an in-process event bus — that's what powers live SSE — and
+A publish immediately fires an in-process event bus, which is what powers live SSE, and
 enqueues a push job. Scheduled messages skip the bus and go straight to the schedule
 queue. Dedicated workers drain the `email`, `push`, and `schedule` queues, so the
 publish path never blocks on delivery.
 
 ## What to configure
 
-- **Email** — a pluggable provider: `log` (default in dev), `smtp`, or
+- **Email**: a pluggable provider, either `log` (default in dev), `smtp`, or
   [Resend](https://resend.com).
-- **Attachments** — stored locally or on S3.
-- **Redis** — backs rate limiting and BullMQ. Rate limiting fails open if Redis is down.
-- **Auth** — magic link, passkey, and API keys work out of the box; GitHub and Apple
+- **Attachments**: stored locally or on S3.
+- **Redis**: backs rate limiting and BullMQ. Rate limiting fails open if Redis is down.
+- **Auth**: magic link, passkey, and API keys work out of the box; GitHub and Apple
   sign-in are optional.
 
 Start from `packages/emitsignal-server/.env.example`; every variable is documented

--- a/packages/emitsignal-docs/start/terminal.mdx
+++ b/packages/emitsignal-docs/start/terminal.mdx
@@ -26,9 +26,9 @@ npm i -g @emitsignal/cli
 
 </CodeGroup>
 
-The short alias `es` is symlinked automatically — both names always work.
+The short alias `es` is symlinked automatically, so both names always work.
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd>emitsignal --version</Cmd>
     <Ok>emitsignal 1.0.0 (darwin/arm64)</Ok>
 </Term>
@@ -37,7 +37,7 @@ The short alias `es` is symlinked automatically — both names always work.
 
 Sign-in is an email one-time code. The token is written to `~/.emitsignalrc`.
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd>emitsignal login</Cmd>
     <Arrow>check you@acme.io for your sign-in code</Arrow>
     <Ok>authorized as you@acme.io · token written to ~/.emitsignalrc</Ok>
@@ -47,13 +47,13 @@ Sign-in is an email one-time code. The token is written to `~/.emitsignalrc`.
 </Term>
 
 <Note>
-    You can skip this. Publishing and listening work anonymously — logging in raises your rate
-    limits and syncs subscriptions across devices.
+    You can skip this. Publishing and listening work anonymously. Logging in raises your rate limits
+    and syncs subscriptions across devices.
 </Note>
 
 ## Subscribe, publish, listen
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd>emitsignal subscribe deploy/prod</Cmd>
     <Ok>subscribed → deploy/prod · p≥1 · push</Ok>
     <Sp />
@@ -70,7 +70,7 @@ Sign-in is an email one-time code. The token is written to `~/.emitsignalrc`.
 Then tail your subscriptions. With no topic argument, `listen` streams everything you
 are subscribed to:
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd>emitsignal listen --priority &gt;=2</Cmd>
     <Arrow>connected · 1 subscription · filter priority&gt;=2 · ctrl-c to quit</Arrow>
     <Out color="#f7f7f8">
@@ -82,11 +82,11 @@ Useful `listen` flags:
 
 | Flag                    | Does                                                      |
 | ----------------------- | --------------------------------------------------------- |
-| `-p, --priority <expr>` | Filter by priority — `>=2`, `<5`, `=4`.                   |
+| `-p, --priority <expr>` | Filter by priority: `>=2`, `<5`, `=4`.                    |
 | `-t, --tag <tags>`      | Only events carrying these tags (comma-separated).        |
 | `-c, --channel <glob>`  | Restrict to topics matching a glob, e.g. `alerts/*`.      |
 | `-f, --format <mode>`   | `pretty` (default), `json`, `compact`, or `tsv`.          |
-| `--since <dur>`         | Replay history first, then go live — `30m`, `1h`.         |
+| `--since <dur>`         | Replay history first, then go live: `30m`, `1h`.          |
 | `-x, --exec <cmd>`      | Run a shell command per event, with `$ES_*` env vars set. |
 | `-s, --sound`           | Play a sound on each message.                             |
 
@@ -98,12 +98,12 @@ emitsignal listen --format json | jq 'select(.priority >= 4) | .title'
 
 ## The full-screen inbox
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd>emitsignal tui</Cmd>
     <Arrow>launching full-screen inbox…</Arrow>
 </Term>
 
-Keyboard-driven, built with React Ink — see the [TUI reference](/cli/tui).
+Keyboard-driven, built with React Ink. See the [TUI reference](/cli/tui).
 
 ## Point it somewhere else
 

--- a/packages/emitsignal-docs/start/terminal.mdx
+++ b/packages/emitsignal-docs/start/terminal.mdx
@@ -1,0 +1,128 @@
+---
+title: 'Live in your terminal'
+description: 'Install the CLI, log in, and tail your topics the way you tail logs.'
+---
+
+import { Arrow, Cmd, Ok, Out, Sp, Term } from '../snippets/terminal.jsx';
+
+The CLI is a single static binary with no runtime dependencies. It wraps the same HTTP
+API you used with `curl`, and adds filtering, formatting, and a full-screen inbox.
+
+## Install
+
+<CodeGroup>
+
+```bash Homebrew
+brew install emitsignal/tap/emitsignal
+```
+
+```bash Shell
+curl -fsSL https://github.com/emitsignal/emitsignal/releases/latest/download/install.sh | sh
+```
+
+```bash npm
+npm i -g @emitsignal/cli
+```
+
+</CodeGroup>
+
+The short alias `es` is symlinked automatically — both names always work.
+
+<Term title="emitsignal — zsh">
+    <Cmd>emitsignal --version</Cmd>
+    <Ok>emitsignal 1.0.0 (darwin/arm64)</Ok>
+</Term>
+
+## Log in
+
+Sign-in is an email one-time code. The token is written to `~/.emitsignalrc`.
+
+<Term title="emitsignal — zsh">
+    <Cmd>emitsignal login</Cmd>
+    <Arrow>check you@acme.io for your sign-in code</Arrow>
+    <Ok>authorized as you@acme.io · token written to ~/.emitsignalrc</Ok>
+    <Sp />
+    <Cmd>emitsignal whoami</Cmd>
+    <Out>Alex Rivera &lt;you@acme.io&gt;</Out>
+</Term>
+
+<Note>
+    You can skip this. Publishing and listening work anonymously — logging in raises your rate
+    limits and syncs subscriptions across devices.
+</Note>
+
+## Subscribe, publish, listen
+
+<Term title="emitsignal — zsh">
+    <Cmd>emitsignal subscribe deploy/prod</Cmd>
+    <Ok>subscribed → deploy/prod · p≥1 · push</Ok>
+    <Sp />
+    <Cmd>emitsignal publish deploy/prod -p4 -m "shipped v2.14.3"</Cmd>
+    <Ok>published → deploy/prod · 1 subscriber · 96ms</Ok>
+</Term>
+
+`publish` reads stdin when you don't pass a body, so it pipes like any other unix tool:
+
+```bash
+./deploy.sh 2>&1 | emitsignal publish deploy/prod -T "Deploy log" -p4
+```
+
+Then tail your subscriptions. With no topic argument, `listen` streams everything you
+are subscribed to:
+
+<Term title="emitsignal — zsh">
+    <Cmd>emitsignal listen --priority &gt;=2</Cmd>
+    <Arrow>connected · 1 subscription · filter priority&gt;=2 · ctrl-c to quit</Arrow>
+    <Out color="#f7f7f8">
+        21:52 <span style={{ color: '#a78bfa' }}>●</span> deploy/prod p4&nbsp; shipped v2.14.3
+    </Out>
+</Term>
+
+Useful `listen` flags:
+
+| Flag                    | Does                                                      |
+| ----------------------- | --------------------------------------------------------- |
+| `-p, --priority <expr>` | Filter by priority — `>=2`, `<5`, `=4`.                   |
+| `-t, --tag <tags>`      | Only events carrying these tags (comma-separated).        |
+| `-c, --channel <glob>`  | Restrict to topics matching a glob, e.g. `alerts/*`.      |
+| `-f, --format <mode>`   | `pretty` (default), `json`, `compact`, or `tsv`.          |
+| `--since <dur>`         | Replay history first, then go live — `30m`, `1h`.         |
+| `-x, --exec <cmd>`      | Run a shell command per event, with `$ES_*` env vars set. |
+| `-s, --sound`           | Play a sound on each message.                             |
+
+`--format json` makes the stream pipeable:
+
+```bash
+emitsignal listen --format json | jq 'select(.priority >= 4) | .title'
+```
+
+## The full-screen inbox
+
+<Term title="emitsignal — zsh">
+    <Cmd>emitsignal tui</Cmd>
+    <Arrow>launching full-screen inbox…</Arrow>
+</Term>
+
+Keyboard-driven, built with React Ink — see the [TUI reference](/cli/tui).
+
+## Point it somewhere else
+
+Self-hosting, or testing against a local server:
+
+```bash
+emitsignal config set-url http://localhost:5100
+emitsignal config get-url
+```
+
+`ES_BASE_URL` overrides it per-command.
+
+## Next
+
+<CardGroup cols={2}>
+    <Card title="Wire it into your stack" icon="gear" href="/start/automate">
+        CI, cron, and inbound webhooks from the services you already run.
+    </Card>
+    <Card title="Filter expressions" icon="filter" href="/cli/filters">
+        `priority>=4 AND tag:prod AND NOT tag:resolved`
+    </Card>
+</CardGroup>


### PR DESCRIPTION
## What

A **Getting Started** tab in `packages/emitsignal-docs` that walks a reader end to end — first `curl` → push on their phone → terminal → wiring it into their stack — the way [docs.ntfy.sh](https://docs.ntfy.sh) does. Until now the docs opened straight into reference material with no on-ramp.

Six pages under `start/`:

| Page | Covers |
| --- | --- |
| `start/index` | What EmitSignal is, the 30-second publish/listen loop, a map of the journey |
| `start/first-signal` | Headers vs JSON, priorities, tags, scheduling, watching over SSE — all `curl` |
| `start/mobile` | App Store link, Android from source, subscribing, sending yourself a real push |
| `start/terminal` | CLI install, `login`, `subscribe`/`publish`/`listen`, filter flags, the TUI |
| `start/automate` | GitHub Actions, cron, inbound webhooks, `listen -x`, consuming SSE from your own code |
| `start/accounts` | Anonymous vs signed in, API keys, reserving a topic name, plan quotas |
| `start/self-hosting` | The Compose stack, running pieces by hand, the architecture diagram |

## Sources

Every example is lifted from the root `README.md`, the landing page sections (`hero`, `mock-publish`, `cli-section`, `mobile-section`), or verified against the CLI (`packages/emitsignal-cli/src/commands/*`) and server (`packages/emitsignal-server`). Nothing invented.

## Also fixed along the way

- `cli/quickstart.mdx` imported `../snippets/hi.jsx`, which does not exist — that import and its stray `<Terminal>Oi</Terminal>` are removed. It would break the Mintlify build.
- `cli/quickstart.mdx` said `brew install emitsignal`; `cli/install.mdx` says `brew install emitsignal/tap/emitsignal`. Now consistent.
- `api/rate-limits.mdx` listed Free as 5 owned topics. `PLANS.free.limits.maxOwnedTopics` is `0` (topic reservation is Pulse/Beam only, per `src/http/topic/claim.ts`). Corrected.

## Worth a look

The new tab is **first**, so the docs site now lands on Getting Started rather than the API Reference — this reverses the intent of c2cdfb5. Say the word if you would rather keep API Reference as the landing tab and I will reorder.

`bunx mintlify broken-links` fails locally on an unrelated `ajv/dist/core` resolution error, so links and nav entries were validated with a script instead: no broken internal links, every nav entry resolves to a file, every file is in the nav. `prettier --check` passes.
