### PR TITLE
docs: drop em-dashes across the docs site

### DIFF
--- a/packages/emitsignal-docs/api/authentication.mdx
+++ b/packages/emitsignal-docs/api/authentication.mdx
@@ -6,17 +6,17 @@ description: 'How the API resolves your identity: session tokens, API keys, and 
 Every endpoint that needs a caller identity resolves it from one of three sources, in
 order:
 
-1. **`Authorization: Bearer <token>`** — a session token (mobile/CLI) **or** an
+1. **`Authorization: Bearer <token>`**: a session token (mobile/CLI) **or** an
    `es_`-prefixed API key.
-2. **`x-api-key: <key>`** — an API key as a dedicated header.
-3. **Session cookie** — set automatically for the web dashboard.
+2. **`x-api-key: <key>`**: an API key as a dedicated header.
+3. **Session cookie**: set automatically for the web dashboard.
 
 ```http
 Authorization: Bearer es_xxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
 <Note>
-    Many endpoints work **without** any credential — publishing, subscribing, and listening all
+    Many endpoints work **without** any credential. Publishing, subscribing, and listening all
     support anonymous, device-scoped use. Authentication raises your rate limits and syncs
     subscriptions across devices. Endpoints that strictly require a token return [`401
     missing_token`](/api/errors).
@@ -34,7 +34,7 @@ emitsignal keys revoke <id>
 ```
 
 See the [`keys` command](/cli/keys) for the full reference. A newly created key's
-secret is shown **once** — store it immediately.
+secret is shown **once**, so store it immediately.
 
 ## Sign-in flow
 

--- a/packages/emitsignal-docs/api/errors.mdx
+++ b/packages/emitsignal-docs/api/errors.mdx
@@ -33,16 +33,16 @@ Individual endpoints return their own machine-readable `error` codes (usually
 | `400`  | `invalid_verification_config` | `hmac`/`token` webhook without a usable header config. |
 | `401`  | `missing_token`               | Endpoint requires auth and none was resolved.          |
 | `401`  | `unauthorized`                | Avatar endpoints without auth.                         |
-| `401`  | `invalid_signature`           | `{ error, reason }` — webhook signature check failed.  |
+| `401`  | `invalid_signature`           | `{ error, reason }`; webhook signature check failed.   |
 | `403`  | `forbidden`                   | Authenticated but not the owner of the resource.       |
-| `403`  | `plan_limit_reached`          | `{ error, limit, metric, plan }` — topics or webhooks. |
+| `403`  | `plan_limit_reached`          | `{ error, limit, metric, plan }`; topics or webhooks.  |
 | `404`  | `topic_not_found`             | Topic doesn't exist.                                   |
 | `404`  | `message_not_found`           | Message doesn't exist.                                 |
 | `404`  | `not_found`                   | Subscription / push token / webhook doesn't exist.     |
 | `409`  | `attachment_already_exists`   | Message already has an attachment.                     |
 | `413`  | `payload_too_large`           | Webhook receiver body over 64 KB.                      |
 | `429`  | `daily_quota_exceeded`        | `{ error, limit, metric: "messages", resetAt }`.       |
-| `429`  | `too_many_sse_connections`    | `{ error, max, retryAfter: 60 }` — SSE connection cap. |
+| `429`  | `too_many_sse_connections`    | `{ error, max, retryAfter: 60 }`; SSE connection cap.  |
 | `503`  | `webhook_paused`              | Posting to a paused webhook receiver.                  |
 
 See [Rate limits](/api/rate-limits) for the `429` cases.

--- a/packages/emitsignal-docs/api/index.mdx
+++ b/packages/emitsignal-docs/api/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'API Reference'
-description: 'A simple HTTP API. No SDK required — if it can make an HTTP request, it can publish a signal.'
+description: 'A simple HTTP API. No SDK required. If it can make an HTTP request, it can publish a signal.'
 ---
 
 The EmitSignal HTTP API is JSON over HTTPS. There is no SDK to install: curl works,
@@ -11,7 +11,7 @@ and every language works.
         Session tokens and API keys via the `Authorization` header.
     </Card>
     <Card title="Publish" icon="paper-plane" href="/api/publish">
-        Send a signal to a topic — JSON body or header-based format.
+        Send a signal to a topic, with a JSON body or the header-based format.
     </Card>
     <Card title="Listen" icon="radio" href="/api/listen">
         Stream signals in real time with Server-Sent Events.
@@ -28,7 +28,7 @@ https://api.emitsignal.com
 ```
 
 Publishing also accepts the shorter `https://emitsignal.com/publish/<topic>`, which is what the
-examples below use. That alias covers `POST /publish/*` only — listening, webhooks, auth and every
+examples below use. That alias covers `POST /publish/*` only. Listening, webhooks, auth and every
 other endpoint require the API host above.
 
 Self-hosting? Point the CLI at your own instance with `emitsignal config set-url`, or
@@ -39,7 +39,7 @@ root.
 
 <CodeGroup>
 
-```bash No auth — public publish
+```bash No auth · public publish
 # Publish to any topic. The topic is created on first publish.
 curl -d "hello from curl" https://emitsignal.com/publish/welcome
 ```

--- a/packages/emitsignal-docs/api/listen.mdx
+++ b/packages/emitsignal-docs/api/listen.mdx
@@ -29,7 +29,7 @@ curl -N \
 # data: {"id":"...","title":"High memory","priority":5,"createdAt":1790000000000, ...}
 ```
 
-Listening to a topic that doesn't exist yet is allowed — publishing creates the topic on first
+Listening to a topic that doesn't exist yet is allowed, since publishing creates the topic on first
 use, so you can connect ahead of the first signal. A topic that exists but that you're not
 allowed to read returns `404 topic_not_found`.
 
@@ -40,9 +40,8 @@ GET /listen
 ```
 
 <ParamField query="topics" type="string">
-    Comma-separated topic names. If omitted, subscribes to every topic you own or are subscribed to
-    — authentication is required in that case, otherwise the request fails with `400
-    topics_required`.
+    Comma-separated topic names. If omitted, subscribes to every topic you own or are subscribed to.
+    Authentication is required in that case, otherwise the request fails with `400 topics_required`.
 </ParamField>
 
 <ParamField query="since" type="integer (unix ms)">
@@ -66,4 +65,4 @@ rest of the stream. If none of the requested topics are readable, the request re
     one per topic.
 </Warning>
 
-Each event's `data` is a serialized message — see the [message object](/api/messages#message-object).
+Each event's `data` is a serialized message. See the [message object](/api/messages#message-object).

--- a/packages/emitsignal-docs/api/messages.mdx
+++ b/packages/emitsignal-docs/api/messages.mdx
@@ -43,7 +43,7 @@ Public. Returns the message object above (with `attachments` resolved) plus
 POST /messages/:id/acknowledge
 ```
 
-Public — identity comes from the body.
+Public: identity comes from the body.
 
 <ParamField body="deviceId" type="string" required />
 <ParamField body="userId" type="string" />
@@ -58,7 +58,7 @@ Public — identity comes from the body.
 POST /messages/:id/attachments
 ```
 
-Multipart upload of a **single** file. Auth optional — anonymous uploads are allowed
+Multipart upload of a **single** file. Auth optional; anonymous uploads are allowed
 with free-tier size limits and a shorter retention (3 hours vs. 15 days for
 authenticated).
 

--- a/packages/emitsignal-docs/api/publish.mdx
+++ b/packages/emitsignal-docs/api/publish.mdx
@@ -114,8 +114,8 @@ or an integer (a unix timestamp if it's `>= now`, otherwise seconds from now).
 ## Email notifications
 
 Pass an email header (or `"email"` in a JSON body) to also forward the message to an
-inbox — useful when a signal should outlive its retention window, or to blast-notify
-yourself on every channel at once. Only one address is supported.
+inbox. This is useful when a signal should outlive its retention window, or to
+blast-notify yourself on every channel at once. Only one address is supported.
 
 ```bash
 curl https://emitsignal.com/publish/alerts \
@@ -136,11 +136,11 @@ curl -H "Authorization: Bearer es_xxx" -H "Email: yes" \
 Rules:
 
 - **Authentication is required.** Anonymous publishes are rejected with `403
-anonymous_email_forbidden` — this keeps the platform from being used as an open relay.
+anonymous_email_forbidden`, which keeps the platform from being used as an open relay.
 - **`yes`/`true`/`1` requires a verified account email**, otherwise `403 email_not_verified`.
 - **Emailing an address other than your own requires a paid plan** (Pulse or Beam);
   free accounts get `403 plan_required`. Mailing your own address is free.
-- **A daily quota applies per account** — 5/day on Free, 50/day on Pulse, 250/day on Beam.
+- **A daily quota applies per account**: 5/day on Free, 50/day on Pulse, 250/day on Beam.
   Exceeding it returns `429 daily_quota_exceeded` with `metric: "emails"` and the usual
   `x-quota-*` headers. Current usage is reported by `GET /billing` as `usage.emailsToday`.
 - **Email cannot be combined with a delay.** A scheduled publish plus an email header

--- a/packages/emitsignal-docs/api/publish.mdx
+++ b/packages/emitsignal-docs/api/publish.mdx
@@ -8,14 +8,14 @@ POST /publish/<topic>
 ```
 
 Publishes a message to a topic. The topic is created automatically on first publish.
-**Auth is optional** — anonymous publishes are allowed (per-IP rate limited); an
+**Auth is optional**: anonymous publishes are allowed (per-IP rate limited); an
 authenticated publish applies your plan's daily message quota and attributes the
 sender.
 
 <Note>
     Publishing answers on two hosts: `https://emitsignal.com/publish/<topic>` (shorter, used in the
     examples here) and `https://api.emitsignal.com/publish/<topic>`. They hit the same endpoint with the
-    same limits. Only publishing is aliased — every other endpoint requires the API host.
+    same limits. Only publishing is aliased; every other endpoint requires the API host.
 </Note>
 
 <Note>
@@ -55,7 +55,7 @@ Send `Content-Type: application/json` with any of these fields. At least one of
 </ParamField>
 
 <ParamField body="bannerImage" type="string | { href, title? }">
-    A single banner image — a URL string or an object.
+    A single banner image, either a URL string or an object.
 </ParamField>
 
 <ParamField body="inlineImages" type="media | media[]">
@@ -108,8 +108,8 @@ curl https://emitsignal.com/publish/alerts/prod \
 **Priority values** accept names or numbers: `min`/`1`, `low`/`2`,
 `none`/`default`/`3`, `high`/`4`, `urgent`/`max`/`5`.
 
-**Delay/schedule values** accept a duration string — `30s`, `5m`, `2h`, `1d`, `1w`
-— or an integer (a unix timestamp if it's `>= now`, otherwise seconds from now).
+**Delay/schedule values** accept a duration string (`30s`, `5m`, `2h`, `1d`, `1w`)
+or an integer (a unix timestamp if it's `>= now`, otherwise seconds from now).
 
 ## Email notifications
 
@@ -159,16 +159,16 @@ anonymous_email_forbidden` — this keeps the platform from being used as an ope
 ## Responses
 
 ```json
-// Immediate publish — 200
+// Immediate publish · 200
 { "message": "posted", "messageId": "..." }
 ```
 
 ```json
-// Scheduled publish — 200
+// Scheduled publish · 200
 { "message": "scheduled", "messageId": "...", "scheduledAt": 1790000000 }
 ```
 
 Common errors: `400 missing_content` (no title or body), `400 invalid_media`,
 `400 invalid_topic_name`, `403 plan_limit_reached` (topic count), and
-`429 daily_quota_exceeded` (authenticated users over the daily message limit — see
+`429 daily_quota_exceeded` (authenticated users over the daily message limit, see
 [Rate limits](/api/rate-limits)).

--- a/packages/emitsignal-docs/api/push-tokens.mdx
+++ b/packages/emitsignal-docs/api/push-tokens.mdx
@@ -12,7 +12,7 @@ are under `/push-tokens`.
 POST /push-tokens
 ```
 
-Upserts a push token for a device. **Auth optional** — the owning user is derived
+Upserts a push token for a device. **Auth optional**: the owning user is derived
 from the auth token (bearer or session cookie), so an authenticated call links the
 token to your account and an unauthenticated call registers it anonymously. Sign in
 and re-register the same device to link an existing anonymous token.
@@ -24,7 +24,7 @@ and re-register the same device to link an existing anonymous token.
 </ParamField>
 
 <Note>
-    You cannot set the owning user from the body — it always comes from the authenticated session.
+    You cannot set the owning user from the body. It always comes from the authenticated session.
     This prevents a caller from binding their device to someone else's account.
 </Note>
 

--- a/packages/emitsignal-docs/api/subscriptions.mdx
+++ b/packages/emitsignal-docs/api/subscriptions.mdx
@@ -15,7 +15,7 @@ All routes are under `/subscriptions`.
 POST /subscriptions
 ```
 
-Upserts a subscription. Auth optional — an authenticated call records your `userId` on
+Upserts a subscription. Auth optional; an authenticated call records your `userId` on
 the row.
 
 <ParamField body="topicName" type="string" required>
@@ -68,7 +68,7 @@ otherwise only this device's anonymous row is removed. Always returns `{ "ok": t
 GET /subscriptions
 ```
 
-Returns the authenticated user's subscriptions, or — when anonymous — the device's
+Returns the authenticated user's subscriptions, or, when anonymous, the device's
 subscriptions, or `[]`.
 
 <ParamField query="deviceId" type="string" />
@@ -97,7 +97,7 @@ subscriptions, or `[]`.
 PATCH /subscriptions/:id
 ```
 
-Ownership-gated: must belong to the authenticated user, or — when anonymous — the
+Ownership-gated: must belong to the authenticated user, or, when anonymous, the
 body's `deviceId` must match the row. Otherwise `403 forbidden`.
 
 <ParamField body="pushEnabled" type="boolean" />
@@ -114,7 +114,7 @@ body's `deviceId` must match the row. Otherwise `403 forbidden`.
 POST /subscriptions/claim
 ```
 
-Reassigns a device's anonymous subscriptions to the signed-in user — call this right
+Reassigns a device's anonymous subscriptions to the signed-in user. Call this right
 after sign-in. Returns `{ "claimed": 0 }` (no error) if unauthenticated.
 
 <ParamField body="deviceId" type="string" required />

--- a/packages/emitsignal-docs/api/topics.mdx
+++ b/packages/emitsignal-docs/api/topics.mdx
@@ -4,7 +4,7 @@ description: 'Read topics, their messages, and their activity metrics.'
 ---
 
 Topics are slash-delimited names (e.g. `deploy/prod`). They are created implicitly on
-first [publish](/api/publish) or [subscribe](/api/subscriptions) — there is no
+first [publish](/api/publish) or [subscribe](/api/subscriptions), so there is no
 create/delete endpoint. The endpoints below are for reading.
 
 ## Get a topic

--- a/packages/emitsignal-docs/api/webhooks.mdx
+++ b/packages/emitsignal-docs/api/webhooks.mdx
@@ -3,8 +3,8 @@ title: 'Webhooks'
 description: 'Turn inbound HTTP from third parties into signals, and stream deliveries live.'
 ---
 
-A webhook gives you a public URL (`/h/:slug`) that turns an inbound HTTP POST — from
-Slack, GitHub, Grafana, Stripe, Vercel, or anything custom — into a signal on a topic.
+A webhook gives you a public URL (`/h/:slug`) that turns an inbound HTTP POST, from
+Slack, GitHub, Grafana, Stripe, Vercel, or anything custom, into a signal on a topic.
 Management endpoints require authentication; the receiver is public, and should be
 given a signing secret so only your provider can post to it.
 
@@ -32,8 +32,8 @@ POST /webhooks
     a `secret`. See [Verifying the sender](#verifying-the-sender).
 </ParamField>
 <ParamField body="secret" type="string | null">
-    The signing secret issued by the sending provider. Write-only — it is encrypted at rest and
-    never returned by any endpoint.
+    The signing secret issued by the sending provider. Write-only: it is encrypted at rest and never
+    returned by any endpoint.
 </ParamField>
 <ParamField body="verificationConfig" type="string | null">
     JSON string describing the header to check. Required for `hmac` and `token`, ignored otherwise.
@@ -99,7 +99,7 @@ All **auth required** and ownership-gated (`404 not_found`, `403 forbidden`). `P
 accepts any of `name`, `status`, `template`, `topicName`, `verification`, `secret`,
 `verificationConfig`. `DELETE` returns `204`.
 
-The secret is never readable — `GET` and `PATCH` return `hasSecret` and `verification`
+The secret is never readable. `GET` and `PATCH` return `hasSecret` and `verification`
 instead. On `PATCH`, omitting `secret` keeps the stored one, sending a new string
 rotates it, and sending `null` clears it (which also requires `verification: "none"`,
 otherwise the request fails with `400 missing_secret`).
@@ -164,11 +164,11 @@ title/body/priority/tags, otherwise a default message is built (title
 `"<source> delivery"`, body = pretty JSON, priority 3, tag `[source]`). The message
 fires the live bus and enqueues push.
 
-- `400 invalid_json` — body is not a JSON object
-- `401 invalid_signature` — `{ error, reason }`; see below
-- `404 not_found` — unknown slug
-- `413 payload_too_large` — body over 64 KB
-- `503 webhook_paused` — the webhook's `status` is `paused`
+- `400 invalid_json`: body is not a JSON object
+- `401 invalid_signature`: `{ error, reason }`; see below
+- `404 not_found`: unknown slug
+- `413 payload_too_large`: body over 64 KB
+- `503 webhook_paused`: the webhook's `status` is `paused`
 
 ```json
 { "messageId": "...", "ok": true }
@@ -179,7 +179,7 @@ fires the live bus and enqueues push.
 Because the receiver is public, the slug is the only thing standing between your topic
 and anyone who has seen the URL in a log or a screenshot. Setting a `secret` makes
 EmitSignal check each delivery's signature against the **raw request bytes** before
-anything is published — no message, no push, no live fanout on a failed check.
+anything is published: no message, no push, no live fanout on a failed check.
 
 | `verification` | Header(s) checked                             | Secret to paste                   |
 | -------------- | --------------------------------------------- | --------------------------------- |
@@ -205,7 +205,7 @@ For `hmac` and `token`, `verificationConfig` is a JSON **string**:
 
 `algorithm` is one of `sha1`, `sha256` (default), `sha512`; `encoding` is `hex`
 (default) or `base64`; `prefix` is stripped from the header value before comparison
-(e.g. `"sha256="` or `"Bearer "`). `token` uses only `header` and `prefix` — the header
+(e.g. `"sha256="` or `"Bearer "`). `token` uses only `header` and `prefix`, so the header
 carries the secret itself rather than a signature.
 
 A rejected delivery returns `401` with a `reason` of `missing_signature`,

--- a/packages/emitsignal-docs/cli/auth.mdx
+++ b/packages/emitsignal-docs/cli/auth.mdx
@@ -1,16 +1,16 @@
 ---
 title: 'Authentication'
-description: 'Browser device-flow login. No key to paste — the token lands in ~/.emitsignalrc.'
+description: 'Browser device-flow login. No key to paste, and the token lands in ~/.emitsignalrc.'
 ---
 
 import { Arrow, Cmd, Ok, Out, Sp, Term } from '../snippets/terminal.jsx';
 
 ## Login
 
-Run `emitsignal login` and follow the URL. The CLI handles the OAuth device flow —
+Run `emitsignal login` and follow the URL. The CLI handles the OAuth device flow,
 you confirm a short code in the browser, and the token is written to `~/.emitsignalrc`.
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd>emitsignal login</Cmd>
     <Arrow>
         open this URL:{' '}
@@ -35,7 +35,7 @@ For non-interactive environments, set the `ES_TOKEN` environment variable instea
 of using `login`. Create a scoped key with `emitsignal keys create` (see [Keys](/cli/keys)),
 then pass it via env:
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd>ES_TOKEN=es_live_c8f4_... emitsignal publish deploy/prod -p4</Cmd>
     <Ok>published → deploy/prod · 3 subscribers · 142ms</Ok>
 </Term>

--- a/packages/emitsignal-docs/cli/config.mdx
+++ b/packages/emitsignal-docs/cli/config.mdx
@@ -22,7 +22,7 @@ Settings resolve in this order: **flags → `ES_*` env vars → `~/.emitsignalrc
 
 ## Examples
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd>emitsignal config set default.format pretty</Cmd>
     <Ok>default.format = pretty</Ok>
     <Cmd>emitsignal config set default.priority 3</Cmd>

--- a/packages/emitsignal-docs/cli/exits.mdx
+++ b/packages/emitsignal-docs/cli/exits.mdx
@@ -10,18 +10,18 @@ import { Arrow, Cmd, Cmt, Ok, Out, Sp, Term } from '../snippets/terminal.jsx';
 `emitsignal` is safe to use in `set -e` scripts and CI gates.
 All exit codes are stable across versions.
 
-| Code  | Meaning                                         |
-| ----- | ----------------------------------------------- |
-| `0`   | Success — published, or stream closed cleanly   |
-| `1`   | Generic error (network, server 5xx)             |
-| `2`   | Usage error — bad flags or expression           |
-| `3`   | Auth error — no token, expired, or out of scope |
-| `4`   | Not found — topic or channel does not exist     |
-| `130` | Interrupted (`ctrl-c`)                          |
+| Code  | Meaning                                        |
+| ----- | ---------------------------------------------- |
+| `0`   | Success: published, or stream closed cleanly   |
+| `1`   | Generic error (network, server 5xx)            |
+| `2`   | Usage error: bad flags or expression           |
+| `3`   | Auth error: no token, expired, or out of scope |
+| `4`   | Not found: topic or channel does not exist     |
+| `130` | Interrupted (`ctrl-c`)                         |
 
 ### CI gate example
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmt># notify on success or failure</Cmt>
     <Cmd wrap>emitsignal publish ci/web -p2 -m "tests passed" &amp;&amp; exit 0</Cmd>
     <Ok>published → ci/web · 1 subscriber · 88ms</Ok>
@@ -57,7 +57,7 @@ When `listen --exec` runs a subprocess per event, these variables are injected:
 | `ES_TOPIC`    | Topic path               |
 | `ES_ID`       | Event ID                 |
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd wrap>
         {'emitsignal listen --priority >=5 --exec \'notify-send "$ES_TITLE" "$ES_BODY"\''}
     </Cmd>

--- a/packages/emitsignal-docs/cli/filters.mdx
+++ b/packages/emitsignal-docs/cli/filters.mdx
@@ -7,7 +7,7 @@ import { Arrow, Caret, Cmd, Term } from '../snippets/terminal.jsx';
 
 All three forms compile to the same internal filter. Use whichever fits the context:
 
-<Term title="emitsignal — zsh" dense>
+<Term dense>
     <div style={{ marginBottom: 16 }}>
         <div
             style={{
@@ -35,7 +35,7 @@ All three forms compile to the same internal filter. Use whichever fits the cont
                 textTransform: 'uppercase',
             }}
         >
-            long flags — AND-ed automatically
+            long flags · AND-ed automatically
         </div>
         <Cmd>emitsignal listen --priority "&gt;=2"</Cmd>
         <Cmd>emitsignal listen --tag prod</Cmd>
@@ -70,13 +70,13 @@ All three forms compile to the same internal filter. Use whichever fits the cont
 | `tag`      | `tag:sev2`         | Membership test against the event tag set       |
 | `channel`  | `channel:alerts/*` | Glob match on the topic path                    |
 | `title`    | `title~"memory"`   | Substring (`~`) or regex (`=~`) on the headline |
-| `age`      | `age<5m`           | Relative time window — `30s`, `5m`, `1h`, `2d`  |
+| `age`      | `age<5m`           | Relative time window: `30s`, `5m`, `1h`, `2d`   |
 
 ## Boolean operators
 
 Combine any fields with `AND`, `OR`, `NOT`, and parentheses:
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd wrap>
         emitsignal listen 'priority&gt;=4 AND (tag:prod OR tag:staging) AND NOT tag:resolved'
     </Cmd>
@@ -97,7 +97,7 @@ Combine any fields with `AND`, `OR`, `NOT`, and parentheses:
 
 ## Using expressions in `subscribe`
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd wrap>emitsignal subscribe alerts/* --filter 'priority&gt;=4 AND NOT tag:maintenance'</Cmd>
     <Arrow>subscribed → alerts/* · filter active · push</Arrow>
 </Term>

--- a/packages/emitsignal-docs/cli/formats.mdx
+++ b/packages/emitsignal-docs/cli/formats.mdx
@@ -12,7 +12,7 @@ Color is automatically disabled when stdout isn't a TTY.
 
 Human-readable, color-coded by priority. One event per block.
 
-<Term title="emitsignal — zsh">
+<Term>
     <div style={{ display: 'flex', gap: 9 }}>
         <span style={{ color: '#3f3f46' }}>21:52:14</span>
         <span style={{ color: '#f87171' }}>●</span>
@@ -27,7 +27,7 @@ Human-readable, color-coded by priority. One event per block.
 
 One line per event. Good for tailing in a tmux pane.
 
-<Term title="emitsignal — zsh">
+<Term>
     <Out color="#f7f7f8">21:52:14 p5 alerts/prod</Out>
     <Out color="#a1a1a6">&nbsp;&nbsp;High memory on api-02 #sev2</Out>
     <div style={{ height: 6 }} />
@@ -60,7 +60,7 @@ Tab-separated: `ts\ttopic\tpriority\ttitle`. Pipe to `awk`, `cut`, or `sort`.
 
 ## Pipe patterns
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd>emitsignal listen -f json | jq -r '.title'</Cmd>
     <Out color="#f7f7f8">High memory on api-02</Out>
     <Out color="#f7f7f8">TypeError spike</Out>
@@ -71,17 +71,17 @@ Tab-separated: `ts\ttopic\tpriority\ttitle`. Pipe to `awk`, `cut`, or `sort`.
     </div>
 </Term>
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd>{"emitsignal listen -f tsv | awk -F'\\t' '{ print $3, $2 }'"}</Cmd>
     <Out color="#f7f7f8">5 alerts/prod</Out>
     <Out color="#f7f7f8">3 ci/web</Out>
 </Term>
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd>emitsignal listen -f json --no-color &gt;&gt; /var/log/signals.ndjson</Cmd>
 </Term>
 
 <Tip>
-    When piping, you never need `--no-color` — it's implied automatically. The flag exists only for
-    cases where you're writing to a TTY but want plain text anyway.
+    When piping, you never need `--no-color`, since it's implied automatically. The flag exists only
+    for cases where you're writing to a TTY but want plain text anyway.
 </Tip>

--- a/packages/emitsignal-docs/cli/index.mdx
+++ b/packages/emitsignal-docs/cli/index.mdx
@@ -29,9 +29,9 @@ import { Arrow, Caret, Cmd, Cmt, Ok, Out, Sp, Term } from '../snippets/terminal.
 
 Every service you run can publish signals. Every machine you own can listen to them.
 `emitsignal` is the glue between your shell scripts, CI pipelines, cron jobs, and your
-phone — no SDK required.
+phone, with no SDK required.
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmt># deploy finished? tell your phone.</Cmt>
     <Cmd>emitsignal publish deploy/prod -p4 -m "api-gateway → v2.14.3"</Cmd>
     <Ok>published → deploy/prod · 3 subscribers · 142ms</Ok>
@@ -46,9 +46,9 @@ phone — no SDK required.
 
 ## The short alias
 
-Every invocation can use the `es` alias — symlinked automatically at install time.
+Every invocation can use the `es` alias, symlinked automatically at install time.
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd>es publish alerts/prod -p5 -m "High memory on api-02"</Cmd>
     <Ok>published → alerts/prod · push+sms+slack · 4 subscribers · 96ms</Ok>
     <Sp />

--- a/packages/emitsignal-docs/cli/install.mdx
+++ b/packages/emitsignal-docs/cli/install.mdx
@@ -23,12 +23,12 @@ npm i -g @emitsignal/cli
 
 Verify the install:
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd>emitsignal --version</Cmd>
     <Ok>emitsignal 1.0.0 (darwin/arm64)</Ok>
 </Term>
 
-The short alias `es` is symlinked automatically — both names are always available.
+The short alias `es` is symlinked automatically, so both names are always available.
 
 ## What gets installed
 
@@ -55,5 +55,5 @@ npm update -g @emitsignal/cli
 
 <Note>
     If you installed via Homebrew, run `brew upgrade emitsignal`. Installing via the shell script
-    again also works — it's idempotent.
+    again also works, since it's idempotent.
 </Note>

--- a/packages/emitsignal-docs/cli/keys.mdx
+++ b/packages/emitsignal-docs/cli/keys.mdx
@@ -9,7 +9,7 @@ import { Cmd, Cmt, Ok, Out, Sp, Term } from '../snippets/terminal.jsx';
 emitsignal keys <list | create | revoke> [flags]
 ```
 
-Keys are scoped — a CI key that can only write to `ci/*` can never read your inbox,
+Keys are scoped: a CI key that can only write to `ci/*` can never read your inbox,
 subscribe to topics, or touch anything outside its scope.
 
 ## Subcommands
@@ -46,8 +46,8 @@ can no longer authenticate, and a second call on the now-deactivated key
 
 ## Examples
 
-<Term title="emitsignal — zsh">
-    <Cmt># mint a key for CI — the full secret is shown exactly once</Cmt>
+<Term>
+    <Cmt># mint a key for CI; the full secret is shown exactly once</Cmt>
     <Cmd wrap>emitsignal keys create -n ci-runner -e 90d</Cmd>
     <Out color="#f7f7f8">
         &nbsp;&nbsp;id&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; hK3n8QpZ2mVx9rLd0a99
@@ -58,9 +58,9 @@ can no longer authenticate, and a second call on the now-deactivated key
         &nbsp;&nbsp;secret&nbsp;&nbsp;{' '}
         <span style={{ color: '#fbbf24' }}>es_live_c8f4_9Qk2Lr7vN3pXa1Ze6Bd0Yw</span>
     </Out>
-    <Ok>store this now — it will not be shown again</Ok>
+    <Ok>store this now · it will not be shown again</Ok>
     <Sp />
-    <Cmt># list shows the id (first column) — that is what revoke takes</Cmt>
+    <Cmt># list shows the id (first column), which is what revoke takes</Cmt>
     <Cmd>emitsignal keys list</Cmd>
     <Out color="#f7f7f8">
         {'p9k2Lm4vX8nQr1Td0Zs  prod-write    es_live_p9k2_••••   4m ago     active'}
@@ -75,7 +75,7 @@ can no longer authenticate, and a second call on the now-deactivated key
     <Cmt># first revoke deactivates; a second revoke permanently deletes</Cmt>
     <Cmd>emitsignal keys revoke hK3n8QpZ2mVx9rLd0a99</Cmd>
     <Ok wrap>
-        deactivated key hK3n8QpZ2mVx9rLd0a99 — run revoke again (or pass --force) to delete it
+        deactivated key hK3n8QpZ2mVx9rLd0a99 · run revoke again (or pass --force) to delete it
     </Ok>
     <Cmd>emitsignal keys revoke hK3n8QpZ2mVx9rLd0a99</Cmd>
     <Ok>permanently deleted key hK3n8QpZ2mVx9rLd0a99</Ok>
@@ -87,7 +87,7 @@ can no longer authenticate, and a second call on the now-deactivated key
 
 **Pipe to a secrets manager:**
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd wrap>
         emitsignal keys create -n ci-runner --json | jq -r '.key' | gh secret set ES_TOKEN
     </Cmd>
@@ -96,7 +96,7 @@ can no longer authenticate, and a second call on the now-deactivated key
 
 <Warning>
     The secret is shown **once**, immediately after creation. Store it in a secrets manager before
-    closing your terminal. If you lose it, revoke the key and create a new one — there is no way to
+    closing your terminal. If you lose it, revoke the key and create a new one. There is no way to
     retrieve a secret after the first display.
 </Warning>
 

--- a/packages/emitsignal-docs/cli/listen.mdx
+++ b/packages/emitsignal-docs/cli/listen.mdx
@@ -44,7 +44,7 @@ emitsignal listen [topic|expression] [flags]
 
 **Stream events at priority 2 or above:**
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd>emitsignal listen --priority &gt;=2 --format pretty</Cmd>
     <Arrow>connected · 8 subscriptions · filter priority&gt;=2 · ctrl-c to quit</Arrow>
     <div style={{ borderBottom: '1px dashed #232427', height: 8, margin: '8px 0' }} />
@@ -60,7 +60,7 @@ emitsignal listen [topic|expression] [flags]
         <Dot level={5} />
         <span style={{ color: '#71717a', width: 110 }}>alerts/prod</span>
         <span style={{ color: '#3f3f46' }}>p5</span>
-        <span style={{ color: '#f7f7f8' }}>High memory on api-02 — mem.used &gt; 92%</span>
+        <span style={{ color: '#f7f7f8' }}>High memory on api-02 · mem.used &gt; 92%</span>
     </div>
     <div style={{ display: 'flex', gap: 10, padding: '1px 0' }}>
         <span style={{ color: '#3f3f46' }}>21:52:22</span>
@@ -74,7 +74,7 @@ emitsignal listen [topic|expression] [flags]
         <Dot level={2} />
         <span style={{ color: '#71717a', width: 110 }}>github/core</span>
         <span style={{ color: '#3f3f46' }}>p2</span>
-        <span style={{ color: '#f7f7f8' }}>PR #482 reviewed by maya — approved</span>
+        <span style={{ color: '#f7f7f8' }}>PR #482 reviewed by maya · approved</span>
     </div>
     <div style={{ marginTop: 4 }}>
         <span style={{ color: '#4ade80' }}>$</span>
@@ -84,7 +84,7 @@ emitsignal listen [topic|expression] [flags]
 
 **Filter with a full expression:**
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd>emitsignal listen 'priority&gt;=4 AND tag:prod AND NOT tag:resolved'</Cmd>
     <Arrow>
         connected · filter priority&gt;=4 AND tag:prod AND NOT tag:resolved
@@ -94,7 +94,7 @@ emitsignal listen [topic|expression] [flags]
 
 **Pipe to jq:**
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd>emitsignal listen -f json | jq -r '.title'</Cmd>
     <Out color="#f7f7f8">High memory on api-02</Out>
     <Out color="#f7f7f8">TypeError spike</Out>
@@ -107,7 +107,7 @@ emitsignal listen [topic|expression] [flags]
 
 **Run a command on every matching event:**
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd wrap>{`emitsignal listen --priority >=5 --exec 'notify-send "$ES_TITLE" "$ES_BODY"'`}</Cmd>
     <Arrow>
         connected · exec mode · priority&gt;=5

--- a/packages/emitsignal-docs/cli/publish.mdx
+++ b/packages/emitsignal-docs/cli/publish.mdx
@@ -50,12 +50,12 @@ emitsignal publish <topic> [body] [flags]
 
 ## Examples
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmt># the one-liner from the brief</Cmt>
     <Cmd>emitsignal publish deploy/prod -p4 -m "api-gateway → v2.14.3"</Cmd>
     <Ok>published → deploy/prod · 3 subscribers · 142ms</Ok>
     <Sp />
-    <Cmt># pipe stdin — output of the previous job becomes the body</Cmt>
+    <Cmt># pipe stdin, so output of the previous job becomes the body</Cmt>
     <Cmd>pytest -q | emitsignal publish ci/web -p2 -t tests</Cmd>
     <Ok>published → ci/web · "247 passed in 12.84s" · 88ms</Ok>
     <Sp />
@@ -77,7 +77,7 @@ ship    = "publish deploy/prod -p4"
 alert   = "publish alerts/prod -p5 -t oncall"
 ```
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd>emitsignal ship -m "v2.14.3 deployed"</Cmd>
     <Ok>published → deploy/prod · 3 subscribers · 112ms</Ok>
 </Term>

--- a/packages/emitsignal-docs/cli/quickstart.mdx
+++ b/packages/emitsignal-docs/cli/quickstart.mdx
@@ -7,7 +7,7 @@ import { Arrow, Caret, Cmd, Ok, Out, Sp, Term } from '../snippets/terminal.jsx';
 
 <Steps>
     <Step title="Install and log in">
-        <Term title="emitsignal — zsh">
+        <Term>
             <Cmd>brew install emitsignal/tap/emitsignal</Cmd>
             <Ok>emitsignal 1.0.0 installed</Ok>
             <Sp />
@@ -17,7 +17,7 @@ import { Arrow, Caret, Cmd, Ok, Out, Sp, Term } from '../snippets/terminal.jsx';
     </Step>
 
     <Step title="Subscribe to a topic">
-        <Term title="emitsignal — zsh">
+        <Term>
             <Cmd>emitsignal subscribe deploy/prod</Cmd>
             <Ok>subscribed → deploy/prod · p≥1 · push</Ok>
         </Term>
@@ -27,7 +27,7 @@ import { Arrow, Caret, Cmd, Ok, Out, Sp, Term } from '../snippets/terminal.jsx';
     </Step>
 
     <Step title="Publish from anywhere">
-        <Term title="emitsignal — zsh">
+        <Term>
             <Cmd>emitsignal publish deploy/prod -p4 -m "shipped v2.14.3"</Cmd>
             <Ok>published → deploy/prod · 1 subscriber · 96ms</Ok>
         </Term>
@@ -37,7 +37,7 @@ import { Arrow, Caret, Cmd, Ok, Out, Sp, Term } from '../snippets/terminal.jsx';
     </Step>
 
     <Step title="Watch it live in the terminal">
-        <Term title="emitsignal — zsh">
+        <Term>
             <Cmd>emitsignal listen --priority &gt;=2</Cmd>
             <Arrow>connected · 1 subscription · filter priority&gt;=2 · ctrl-c to quit</Arrow>
             <Out color="#f7f7f8">
@@ -49,7 +49,7 @@ import { Arrow, Caret, Cmd, Ok, Out, Sp, Term } from '../snippets/terminal.jsx';
 
         Or open the full-screen inbox:
 
-        <Term title="emitsignal — zsh">
+        <Term>
             <Cmd>emitsignal tui</Cmd>
             <Arrow>launching full-screen inbox…<Caret /></Arrow>
         </Term>

--- a/packages/emitsignal-docs/cli/sdk.mdx
+++ b/packages/emitsignal-docs/cli/sdk.mdx
@@ -3,7 +3,7 @@ title: 'SDK'
 description: 'Every CLI verb maps 1:1 to an HTTP endpoint and to the typed SDK. Same auth, same filter grammar.'
 ---
 
-The CLI is a thin wrapper over the HTTP API. Everything it can do, the SDK can do —
+The CLI is a thin wrapper over the HTTP API. Everything it can do, the SDK can do,
 and the filter grammar is identical in both.
 
 ## HTTP API
@@ -50,7 +50,7 @@ await es.publish('deploy/prod', {
     message: `api-gateway → v2.14.3`,
 });
 
-// Stream — same filter grammar as the CLI
+// Stream, using the same filter grammar as the CLI
 for await (const ev of es.listen('priority>=2')) {
     console.log(ev.title);
 }

--- a/packages/emitsignal-docs/cli/subscribe.mdx
+++ b/packages/emitsignal-docs/cli/subscribe.mdx
@@ -19,7 +19,7 @@ Aliased to `sub` / `unsub` for convenience.
 </ParamField>
 
 <ParamField body="--mute, -m" type="duration">
-    Subscribe but silence delivery for a duration — e.g. `8h`, `1d`. You still receive events; they
+    Subscribe but silence delivery for a duration, e.g. `8h`, `1d`. You still receive events; they
     just don't trigger notifications.
 </ParamField>
 
@@ -33,7 +33,7 @@ Aliased to `sub` / `unsub` for convenience.
 
 ## Examples
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd>emitsignal subscribe alerts/prod -p4</Cmd>
     <Ok>subscribed → alerts/prod · p≥4 · push</Ok>
     <Sp />
@@ -62,7 +62,7 @@ Aliased to `sub` / `unsub` for convenience.
 By default, subscriptions route to all registered delivery targets (push, email, etc.)
 based on your account settings. Use `--targets` to override per subscription:
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd>emitsignal subscribe ci/builds --targets slack</Cmd>
     <Ok>subscribed → ci/builds · p≥1 · slack</Ok>
 </Term>

--- a/packages/emitsignal-docs/cli/webhooks.mdx
+++ b/packages/emitsignal-docs/cli/webhooks.mdx
@@ -9,7 +9,7 @@ import { Arrow, Cmd, Cmt, Ok, Out, Sp, Term } from '../snippets/terminal.jsx';
 emitsignal webhooks <create | list | listen | tail | set-template | delete> [flags]
 ```
 
-Every webhook endpoint gets a public URL — `https://api.emitsignal.com/h/<slug>`.
+Every webhook endpoint gets a public URL: `https://api.emitsignal.com/h/<slug>`.
 Point any service that speaks webhooks at it, and each inbound `POST` is published
 to a topic (channel) and fans out to your subscribers in real time. Attach an
 optional template to turn a provider's raw payload into a clean title and body,
@@ -35,7 +35,8 @@ provider can post to the endpoint.
 ## Create an endpoint
 
 <ParamField body="--channel, -c" type="topic" required>
-    Topic that inbound deliveries are published to. Required — deliveries must have somewhere to go.
+    Topic that inbound deliveries are published to. Required, since deliveries must have somewhere
+    to go.
 </ParamField>
 
 <ParamField body="--source, -s" type="github | grafana | stripe | vercel | custom" default="custom">
@@ -52,7 +53,7 @@ provider can post to the endpoint.
 </ParamField>
 
 <ParamField body="--secret" type="string">
-    Signing secret issued by the sending provider. Setting it turns on signature verification — see
+    Signing secret issued by the sending provider. Setting it turns on signature verification. See
     [Verifying the sender](#verifying-the-sender).
 </ParamField>
 
@@ -61,7 +62,7 @@ provider can post to the endpoint.
     type="none | github | stripe | svix | hmac | token"
     default="matches --source"
 >
-    Signature scheme to enforce. Defaults to whatever the chosen `--source` normally signs with —
+    Signature scheme to enforce. Defaults to whatever the chosen `--source` normally signs with:
     `github`, `stripe`, and `svix` need nothing more than `--secret`. `grafana` and `vercel` infer
     `token` and `hmac`, which also need `--verification-config`.
 </ParamField>
@@ -72,10 +73,10 @@ provider can post to the endpoint.
 </ParamField>
 
 <ParamField body="--json" type="flag">
-    Machine-readable output — includes the endpoint `id` and full URL.
+    Machine-readable output, including the endpoint `id` and full URL.
 </ParamField>
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmt># create a verified endpoint for GitHub, publishing to ci/deploys</Cmt>
     <Cmd wrap>
         emitsignal webhooks create -n deploy-hook -s github -c ci/deploys --secret $GH_HOOK_SECRET
@@ -95,7 +96,7 @@ provider can post to the endpoint.
         &nbsp;&nbsp;verify&nbsp;&nbsp;&nbsp;&nbsp;
         <span style={{ color: '#4ade80' }}>github</span>
     </Out>
-    <Ok>webhook created — point your service at the endpoint above</Ok>
+    <Ok>webhook created · point your service at the endpoint above</Ok>
 </Term>
 
 ## Verifying the sender
@@ -106,7 +107,7 @@ against the raw request body before anything is published; failures are rejected
 `401` and show up in `webhooks listen` with a red status and the reason in place of the
 payload.
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmt># scheme inferred from --source</Cmt>
     <Cmd wrap>
         emitsignal webhooks create -s stripe -c billing/stripe --secret $STRIPE_WEBHOOK_SECRET
@@ -120,20 +121,20 @@ payload.
 </Term>
 
 <Note>
-    The secret is write-only. It is encrypted at rest and never returned by the API — `--json`
+    The secret is write-only. It is encrypted at rest and never returned by the API, so `--json`
     output carries only `verification` and a `hasSecret` boolean. Keep your own copy at the
     provider.
 </Note>
 
 ## List endpoints
 
-The first column is the endpoint `id` — pass it to `set-template` and `delete`.
+The first column is the endpoint `id`. Pass it to `set-template` and `delete`.
 
 <ParamField body="--json" type="flag">
     Machine-readable output.
 </ParamField>
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd>emitsignal webhooks list</Cmd>
     <Out color="#f7f7f8">
         {
@@ -175,7 +176,7 @@ inline snippet of the payload.
     (`listen` only) Emit each delivery as a JSON object instead of a formatted line.
 </ParamField>
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd>emitsignal webhooks listen</Cmd>
     <Arrow>tailing webhooks · ● templated · ○ raw · filter:all sources · ctrl-c to quit</Arrow>
     <Sp />
@@ -213,7 +214,7 @@ placeholders resolved against the incoming payload.
     "body": "{{ head_commit.message }}",
     "priority": "4",
     "tags": "github, {{ ref }}",
-    "title": "{{ repository.full_name }} — {{ pusher.name }} pushed"
+    "title": "{{ repository.full_name }} · {{ pusher.name }} pushed"
 }
 ```
 
@@ -235,14 +236,14 @@ an array (`commits.*.message`). Missing paths render as an empty string.
     Remove the template and revert the endpoint to raw passthrough.
 </ParamField>
 
-<Term title="emitsignal — zsh">
-    <Cmt># attach a template — applied to new deliveries going forward</Cmt>
+<Term>
+    <Cmt># attach a template, applied to new deliveries going forward</Cmt>
     <Cmd wrap>emitsignal webhooks set-template clx8f2a0b00deploy01 --file template.json</Cmd>
-    <Ok>template saved — new deliveries to clx8f2a0b00deploy01 will render with it</Ok>
+    <Ok>template saved · new deliveries to clx8f2a0b00deploy01 will render with it</Ok>
     <Sp />
     <Cmt># revert to forwarding the raw payload</Cmt>
     <Cmd>emitsignal webhooks set-template clx8f2a0b00deploy01 --clear</Cmd>
-    <Ok>template cleared — clx8f2a0b00deploy01 now forwards raw payloads</Ok>
+    <Ok>template cleared · clx8f2a0b00deploy01 now forwards raw payloads</Ok>
 </Term>
 
 ## Delete an endpoint
@@ -250,7 +251,7 @@ an array (`commits.*.message`). Missing paths render as an empty string.
 Removes the endpoint and its delivery history. The `/h/<slug>` URL immediately
 starts returning `404`.
 
-<Term title="emitsignal — zsh">
+<Term>
     <Cmd>emitsignal webhooks delete clx8f2a0b00deploy01</Cmd>
     <Ok>deleted webhook clx8f2a0b00deploy01</Ok>
 </Term>

--- a/packages/emitsignal-docs/snippets/terminal.jsx
+++ b/packages/emitsignal-docs/snippets/terminal.jsx
@@ -7,7 +7,7 @@ export const Term = ({
     dense = false,
     pad = true,
     style,
-    title = 'emitsignal — zsh',
+    title = 'emitsignal · zsh',
 }) => {
     return (
         <div style={{ margin: '16px 0' }}>
@@ -109,7 +109,7 @@ export const Cmd = ({ children, prompt = true, wrap = false }) => {
     // Mintlify's MDX pipeline runs remark-smartypants over plain markdown text
     // (which is what <Cmd>...</Cmd> children are, unless authored as a JS expression),
     // rewriting straight quotes/dashes into typographic ones. That breaks copy-paste
-    // into a shell, so undo it here — every substitution smartypants makes is
+    // into a shell, so undo it here. Every substitution smartypants makes is
     // unambiguous to reverse in a shell-command context.
     const deSmarten = (str) =>
         str.replace(/[‘’]/g, "'").replace(/[“”]/g, '"').replace(/[–—]/g, '--').replace(/…/g, '...');

--- a/packages/emitsignal-docs/snippets/tui.jsx
+++ b/packages/emitsignal-docs/snippets/tui.jsx
@@ -58,7 +58,7 @@ export const CliTuiDemo = () => (
                         marginLeft: -54,
                     }}
                 >
-                    emitsignal tui — zsh
+                    emitsignal tui · zsh
                 </span>
             </div>
 
@@ -404,7 +404,7 @@ export const CliTuiDemo = () => (
                                         whiteSpace: 'nowrap',
                                     }}
                                 >
-                                    High memory on api-02 — mem.used &gt; 92%
+                                    High memory on api-02 · mem.used &gt; 92%
                                 </span>
                             </div>
                             <div
@@ -518,7 +518,7 @@ export const CliTuiDemo = () => (
                                         whiteSpace: 'nowrap',
                                     }}
                                 >
-                                    PR #482 reviewed by maya — approved
+                                    PR #482 reviewed by maya · approved
                                 </span>
                             </div>
                             <div


### PR DESCRIPTION
Removes em-dashes from every page in `packages/emitsignal-docs`. Rebased onto current `main` after #75 merged, since that PR landed before this pass was finished.

Sentences were rewritten rather than hyphen-swapped: colons before a list or definition, semicolons between linked clauses, full stops where two thoughts were jammed together. In terminal output and code comments, where the dash acted as a separator rather than punctuation, it became `·`, which is what the CLI itself prints.

Window chrome is handled too. `snippets/terminal.jsx` now defaults to `title = 'emitsignal · zsh'`, and the 37 explicit `title="emitsignal — zsh"` props duplicating that default across the CLI pages are gone. `snippets/tui.jsx` matches.

The second commit covers `api/publish.mdx`, which landed on `main` after the original pass and reintroduced three em-dashes.

## Deliberate exceptions

1. `snippets/terminal.jsx:115` still contains an em-dash inside a regex:

   ```jsx
   str.replace(/[‘’]/g, "'").replace(/[“”]/g, '"').replace(/[–—]/g, '--').replace(/…/g, '...');
   ```

   That is the `deSmarten` helper undoing Mintlify's smartypants transform so commands stay copy-pasteable into a shell. Removing the em-dash from that character class would break the fix.

2. Numeric ranges keep their en-dash: `1–5`, `1–200`. Different character, standard typography for ranges.

Docs-only; no runtime code touched.