### PR TITLE
Rework the webhook form

### DIFF
--- a/packages/emitsignal-server/src/http/webhooks/__tests__/create.spec.ts
+++ b/packages/emitsignal-server/src/http/webhooks/__tests__/create.spec.ts
@@ -12,6 +12,7 @@ mock.module('#/http/auth/plugin', () => ({
 }));
 
 import { createWebhook } from '#/http/webhooks/create';
+import { signSlugReservation } from '#/lib/crypto/slug-reservation';
 import { resetUserPlansForTests, setUserPlanForTests } from '#/services/billing/get-user-plan';
 import { PLANS } from '#/services/billing/plans';
 
@@ -242,5 +243,135 @@ describe('POST /webhooks signing secrets', () => {
 
         expect(res.status).toBe(200);
         expect(storedData().verificationConfig).toBeNull();
+    });
+});
+
+describe('POST /webhooks reserved slug', () => {
+    const app = new Elysia().use(createWebhook);
+
+    function request(body: Record<string, unknown>) {
+        return new Request('http://localhost/webhooks', {
+            body: JSON.stringify({ topicName: 'deploys', ...body }),
+            headers: { 'Content-Type': 'application/json', 'x-test-user-id': 'user-1' },
+            method: 'POST',
+        });
+    }
+
+    beforeEach(() => {
+        resetUserPlansForTests();
+        setUserPlanForTests('user-1', 'free');
+        prismaMock.webhook.count.mockReset();
+        prismaMock.webhook.count.mockResolvedValue(0);
+        prismaMock.webhook.create.mockReset();
+        prismaMock.webhook.create.mockImplementation(
+            ({ data }: { data: Record<string, unknown> }) =>
+                Promise.resolve({
+                    createdAt: new Date(),
+                    id: 'wh-1',
+                    name: 'stripe webhook',
+                    slug: data.slug as string,
+                    source: 'stripe',
+                    status: 'active',
+                    template: null,
+                    topicName: 'deploys',
+                    verification: 'none',
+                    verificationConfig: null,
+                }),
+        );
+        prismaMock.topic.findUnique.mockResolvedValue(null);
+    });
+
+    const RESERVED = 'st_abcdefghijklmnop';
+
+    function reserved(slug = RESERVED) {
+        return { reservation: signSlugReservation(slug), slug, source: 'stripe' };
+    }
+
+    it('uses a slug the server reserved', async () => {
+        const res = await app.handle(request(reserved()));
+
+        expect(res.status).toBe(200);
+        await expect(res.json()).resolves.toMatchObject({ endpointUrl: `/h/${RESERVED}` });
+    });
+
+    it('rejects a slug sent without a reservation', async () => {
+        const res = await app.handle(request({ slug: RESERVED, source: 'stripe' }));
+
+        expect(res.status).toBe(400);
+        await expect(res.json()).resolves.toEqual({ error: 'invalid_slug_reservation' });
+    });
+
+    it('rejects a reservation signed for a different slug', async () => {
+        const res = await app.handle(
+            request({
+                reservation: signSlugReservation('st_zzzzzzzzzzzzzzzz'),
+                slug: RESERVED,
+                source: 'stripe',
+            }),
+        );
+
+        expect(res.status).toBe(400);
+        await expect(res.json()).resolves.toEqual({ error: 'invalid_slug_reservation' });
+    });
+
+    it('rejects a reservation that has expired', async () => {
+        const res = await app.handle(
+            request({
+                reservation: signSlugReservation(RESERVED, Date.now() - 2 * 60 * 60 * 1000),
+                slug: RESERVED,
+                source: 'stripe',
+            }),
+        );
+
+        expect(res.status).toBe(400);
+        await expect(res.json()).resolves.toEqual({ error: 'invalid_slug_reservation' });
+    });
+
+    it('keeps a reserved slug whose prefix predates a source change', async () => {
+        const slug = 'gh_abcdefghijklmnop';
+
+        const res = await app.handle(
+            request({ reservation: signSlugReservation(slug), slug, source: 'stripe' }),
+        );
+
+        expect(res.status).toBe(200);
+        await expect(res.json()).resolves.toMatchObject({ endpointUrl: `/h/${slug}` });
+    });
+
+    it('rejects a well-formed vanity slug a client chose for itself', async () => {
+        const res = await app.handle(request({ slug: 'st_emitsignalcool12', source: 'stripe' }));
+
+        expect(res.status).toBe(400);
+        await expect(res.json()).resolves.toEqual({ error: 'invalid_slug_reservation' });
+    });
+
+    it('rejects a vanity slug that does not fit the generated shape', async () => {
+        const slug = 'st_emitsignalcool';
+
+        const res = await app.handle(
+            request({ reservation: signSlugReservation(slug), slug, source: 'stripe' }),
+        );
+
+        expect(res.status).toBe(400);
+        await expect(res.json()).resolves.toEqual({ error: 'invalid_slug' });
+    });
+
+    it('returns 409 when the reserved slug was taken first', async () => {
+        prismaMock.webhook.create.mockImplementation(() =>
+            Promise.reject(Object.assign(new Error('unique'), { code: 'P2002' })),
+        );
+
+        const res = await app.handle(request(reserved()));
+
+        expect(res.status).toBe(409);
+        await expect(res.json()).resolves.toEqual({ error: 'slug_taken' });
+    });
+
+    it('generates a slug for the source when none is reserved', async () => {
+        const res = await app.handle(request({ source: 'stripe' }));
+        const body = (await res.json()) as { endpointUrl: string };
+
+        expect(res.status).toBe(200);
+        expect(body.endpointUrl).toMatch(/^\/h\/st_[a-z0-9]{16}$/);
     });
 });

--- a/packages/emitsignal-server/src/http/webhooks/__tests__/reserve-slug.spec.ts
+++ b/packages/emitsignal-server/src/http/webhooks/__tests__/reserve-slug.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { Elysia } from 'elysia';
+
+import { prismaMock } from '#/__tests__/mocks';
+
+mock.module('#/lib/prisma', () => ({ prisma: prismaMock }));
+mock.module('#/http/auth/plugin', () => ({
+    resolveUserId: ({ headers }: { headers: Record<string, string | undefined> }) =>
+        Promise.resolve(headers['x-test-user-id'] ?? null),
+}));
+
+import { reserveWebhookSlug } from '#/http/webhooks/reserve-slug';
+import { verifySlugReservation } from '#/lib/crypto/slug-reservation';
+
+describe('POST /webhooks/slug', () => {
+    const app = new Elysia().use(reserveWebhookSlug);
+
+    function request(body: Record<string, unknown>, userId?: string) {
+        return new Request('http://localhost/webhooks/slug', {
+            body: JSON.stringify(body),
+            headers: {
+                'Content-Type': 'application/json',
+                ...(userId ? { 'x-test-user-id': userId } : {}),
+            },
+            method: 'POST',
+        });
+    }
+
+    it('returns 401 for anonymous requests', async () => {
+        const res = await app.handle(request({ source: 'stripe' }));
+
+        expect(res.status).toBe(401);
+    });
+
+    it('issues a slug for the source with a matching reservation', async () => {
+        const res = await app.handle(request({ source: 'stripe' }, 'user-1'));
+        const body = (await res.json()) as {
+            endpointUrl: string;
+            reservation: string;
+            slug: string;
+        };
+
+        expect(res.status).toBe(200);
+        expect(body.slug).toMatch(/^st_[a-z0-9]{16}$/);
+        expect(body.endpointUrl).toBe(`/h/${body.slug}`);
+        expect(verifySlugReservation(body.slug, body.reservation)).toBe(true);
+    });
+
+    it('falls back to the custom prefix for an unknown source', async () => {
+        const res = await app.handle(request({ source: 'whatever' }, 'user-1'));
+        const body = (await res.json()) as { slug: string };
+
+        expect(body.slug).toMatch(/^cw_[a-z0-9]{16}$/);
+    });
+
+    it('does not issue the same slug twice', async () => {
+        const first = (await (await app.handle(request({}, 'user-1'))).json()) as { slug: string };
+        const second = (await (await app.handle(request({}, 'user-1'))).json()) as { slug: string };
+
+        expect(first.slug).not.toBe(second.slug);
+    });
+
+    it('writes nothing to the database', async () => {
+        prismaMock.webhook.create.mockClear();
+
+        await app.handle(request({ source: 'stripe' }, 'user-1'));
+
+        expect(prismaMock.webhook.create).not.toHaveBeenCalled();
+    });
+});

--- a/packages/emitsignal-server/src/http/webhooks/create.ts
+++ b/packages/emitsignal-server/src/http/webhooks/create.ts
@@ -1,3 +1,4 @@
+import { isValidWebhookSlug } from '@emitsignal/shared/webhook-slug';
 import Elysia, { t } from 'elysia';
 
 import { resolveUserId } from '#/http/auth/plugin';
@@ -6,31 +7,13 @@ import {
     verificationBodySchema,
 } from '#/http/webhooks/verification-input';
 import { encryptSecret } from '#/lib/crypto/secret-box';
+import { verifySlugReservation } from '#/lib/crypto/slug-reservation';
 import { prisma } from '#/lib/prisma';
 import { getUserPlan } from '#/services/billing/get-user-plan';
 import { PLANS } from '#/services/billing/plans';
 import { canPublishToTopicName } from '#/services/topic-access';
 import { schemeNeedsConfig } from '#/utils/webhook-signature';
-
-function randomSlug(prefix: string): string {
-    const alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789';
-    const bytes = crypto.getRandomValues(new Uint8Array(16));
-    let suffix = '';
-
-    for (const byte of bytes) {
-        suffix += alphabet[byte % alphabet.length];
-    }
-
-    return `${prefix}_${suffix}`;
-}
-
-const SOURCE_PREFIX: Record<string, string> = {
-    custom: 'cw',
-    github: 'gh',
-    grafana: 'gf',
-    stripe: 'st',
-    vercel: 'vc',
-};
+import { generateWebhookSlug } from '#/utils/webhook-slug';
 
 export const createWebhook = new Elysia().post(
     '/webhooks',
@@ -67,36 +50,62 @@ export const createWebhook = new Elysia().post(
             return status(400, { error: verification.error });
         }
 
-        const prefix = SOURCE_PREFIX[body.source ?? 'custom'] ?? 'cw';
-        const slug = randomSlug(prefix);
+        const source = body.source ?? 'custom';
 
-        const webhook = await prisma.webhook.create({
-            data: {
-                name: body.name || `${body.source ?? 'custom'} webhook`,
-                secretCiphertext: body.secret ? encryptSecret(body.secret) : null,
-                slug,
-                source: body.source ?? 'custom',
-                template: body.template ?? null,
-                topicName: body.topicName,
-                userId,
-                verification: verification.scheme,
-                verificationConfig: schemeNeedsConfig(verification.scheme)
-                    ? (body.verificationConfig ?? null)
-                    : null,
-            },
-            select: {
-                createdAt: true,
-                id: true,
-                name: true,
-                slug: true,
-                source: true,
-                status: true,
-                template: true,
-                topicName: true,
-                verification: true,
-                verificationConfig: true,
-            },
-        });
+        // The signature is what stops a client choosing its own endpoint URL. The prefix
+        // is deliberately not tied to the source: a slug reserved before the source was
+        // switched must keep working.
+        if (body.slug) {
+            if (!isValidWebhookSlug(body.slug)) {
+                return status(400, { error: 'invalid_slug' });
+            }
+
+            if (!body.reservation || !verifySlugReservation(body.slug, body.reservation)) {
+                return status(400, { error: 'invalid_slug_reservation' });
+            }
+        }
+
+        const slug = body.slug ?? generateWebhookSlug(source);
+
+        const webhook = await prisma.webhook
+            .create({
+                data: {
+                    name: body.name || `${source} webhook`,
+                    secretCiphertext: body.secret ? encryptSecret(body.secret) : null,
+                    slug,
+                    source,
+                    template: body.template ?? null,
+                    topicName: body.topicName,
+                    userId,
+                    verification: verification.scheme,
+                    verificationConfig: schemeNeedsConfig(verification.scheme)
+                        ? (body.verificationConfig ?? null)
+                        : null,
+                },
+                select: {
+                    createdAt: true,
+                    id: true,
+                    name: true,
+                    slug: true,
+                    source: true,
+                    status: true,
+                    template: true,
+                    topicName: true,
+                    verification: true,
+                    verificationConfig: true,
+                },
+            })
+            .catch((error: unknown) => {
+                if (error instanceof Error && 'code' in error && error.code === 'P2002') {
+                    return null;
+                }
+
+                throw error;
+            });
+
+        if (!webhook) {
+            return status(409, { error: 'slug_taken' });
+        }
 
         return {
             ...webhook,
@@ -109,6 +118,8 @@ export const createWebhook = new Elysia().post(
     {
         body: t.Object({
             name: t.Optional(t.String()),
+            reservation: t.Optional(t.String()),
+            slug: t.Optional(t.String()),
             source: t.Optional(t.String({ default: 'custom' })),
             template: t.Optional(t.Nullable(t.String())),
             topicName: t.String(),

--- a/packages/emitsignal-server/src/http/webhooks/reserve-slug.ts
+++ b/packages/emitsignal-server/src/http/webhooks/reserve-slug.ts
@@ -1,0 +1,27 @@
+import Elysia, { t } from 'elysia';
+
+import { resolveUserId } from '#/http/auth/plugin';
+import { signSlugReservation } from '#/lib/crypto/slug-reservation';
+import { generateWebhookSlug } from '#/utils/webhook-slug';
+
+export const reserveWebhookSlug = new Elysia().post(
+    '/webhooks/slug',
+    async ({ body, headers, status }) => {
+        const userId = await resolveUserId({ headers });
+
+        if (!userId) {
+            return status(401, { error: 'missing_token' });
+        }
+
+        const slug = generateWebhookSlug(body?.source ?? 'custom');
+
+        return {
+            endpointUrl: `/h/${slug}`,
+            reservation: signSlugReservation(slug),
+            slug,
+        };
+    },
+    {
+        body: t.Optional(t.Object({ source: t.Optional(t.String()) })),
+    },
+);

--- a/packages/emitsignal-server/src/index.ts
+++ b/packages/emitsignal-server/src/index.ts
@@ -43,6 +43,7 @@ import { listDeliveries } from '#/http/webhooks/deliveries';
 import { getWebhook } from '#/http/webhooks/get';
 import { listWebhooks } from '#/http/webhooks/list';
 import { receiveWebhook } from '#/http/webhooks/receive';
+import { reserveWebhookSlug } from '#/http/webhooks/reserve-slug';
 import { streamWebhookDeliveries } from '#/http/webhooks/stream';
 import { updateWebhook } from '#/http/webhooks/update';
 import { auth } from '#/lib/auth';
@@ -91,6 +92,7 @@ const app = new Elysia({
     .use(claimSubscriptions)
     .use(claimTopic)
     .use(createWebhook)
+    .use(reserveWebhookSlug)
     .use(deletePushToken)
     .use(deleteWebhook)
     .use(getBilling)

--- a/packages/emitsignal-server/src/lib/crypto/slug-reservation.ts
+++ b/packages/emitsignal-server/src/lib/crypto/slug-reservation.ts
@@ -1,0 +1,39 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+import { environment } from '#/schema/environment';
+
+// A reserved slug passes through the browser, so it comes back signed. Without this the
+// slug field would let any API client choose its own endpoint URL.
+
+const RESERVATION_TTL_MS = 60 * 60 * 1000;
+
+export function signSlugReservation(slug: string, issuedAt = Date.now()): string {
+    return `${issuedAt}.${digest(slug, issuedAt)}`;
+}
+
+export function verifySlugReservation(slug: string, reservation: string): boolean {
+    const [issuedAtPart, signature] = reservation.split('.');
+    const issuedAt = Number(issuedAtPart);
+
+    if (!signature || !Number.isFinite(issuedAt)) {
+        return false;
+    }
+
+    const age = Date.now() - issuedAt;
+
+    if (age < 0 || age > RESERVATION_TTL_MS) {
+        return false;
+    }
+
+    const expected = Buffer.from(digest(slug, issuedAt));
+    const received = Buffer.from(signature);
+
+    return expected.length === received.length && timingSafeEqual(expected, received);
+}
+
+function digest(slug: string, issuedAt: number): string {
+    // Namespaced so this signature can never be replayed as another kind of token.
+    return createHmac('sha256', environment.BETTER_AUTH_SECRET)
+        .update(`webhook-slug-reservation:${slug}:${issuedAt}`)
+        .digest('base64url');
+}

--- a/packages/emitsignal-server/src/utils/__tests__/webhook-slug.spec.ts
+++ b/packages/emitsignal-server/src/utils/__tests__/webhook-slug.spec.ts
@@ -1,0 +1,23 @@
+import { isValidWebhookSlug } from '@emitsignal/shared/webhook-slug';
+import { describe, expect, it } from 'bun:test';
+
+import { generateWebhookSlug } from '#/utils/webhook-slug';
+
+describe('generateWebhookSlug', () => {
+    it('produces a slug the validator accepts for that source', () => {
+        const slug = generateWebhookSlug('stripe');
+
+        expect(slug).toMatch(/^st_[a-z0-9]{16}$/);
+        expect(isValidWebhookSlug(slug, 'stripe')).toBe(true);
+    });
+
+    it('falls back to the custom prefix for an unknown source', () => {
+        expect(generateWebhookSlug('whatever')).toMatch(/^cw_[a-z0-9]{16}$/);
+    });
+
+    it('does not repeat itself', () => {
+        const slugs = new Set(Array.from({ length: 50 }, () => generateWebhookSlug('custom')));
+
+        expect(slugs.size).toBe(50);
+    });
+});

--- a/packages/emitsignal-server/src/utils/webhook-slug.ts
+++ b/packages/emitsignal-server/src/utils/webhook-slug.ts
@@ -1,0 +1,17 @@
+import {
+    WEBHOOK_SLUG_ALPHABET,
+    WEBHOOK_SLUG_RANDOM_LENGTH,
+    webhookSlugPrefix,
+} from '@emitsignal/shared/webhook-slug';
+import { randomBytes } from 'node:crypto';
+
+export function generateWebhookSlug(source: string): string {
+    const bytes = randomBytes(WEBHOOK_SLUG_RANDOM_LENGTH);
+    let suffix = '';
+
+    for (const byte of bytes) {
+        suffix += WEBHOOK_SLUG_ALPHABET[byte % WEBHOOK_SLUG_ALPHABET.length];
+    }
+
+    return `${webhookSlugPrefix(source)}_${suffix}`;
+}

--- a/packages/emitsignal-shared/package.json
+++ b/packages/emitsignal-shared/package.json
@@ -9,6 +9,7 @@
         "./publish-example": "./src/publish-example.ts",
         "./topic": "./src/topic.ts",
         "./url": "./src/url.ts",
+        "./webhook-slug": "./src/webhook-slug.ts",
         "./webhook-template": "./src/webhook-template.ts",
         "./webhook-verification": "./src/webhook-verification.ts"
     },

--- a/packages/emitsignal-shared/src/api.ts
+++ b/packages/emitsignal-shared/src/api.ts
@@ -240,6 +240,8 @@ export function createApiClient(baseUrl: string) {
         createWebhook(
             input: {
                 name?: string;
+                reservation?: string;
+                slug?: string;
                 source?: string;
                 template?: null | string;
                 topicName: string;
@@ -414,6 +416,13 @@ export function createApiClient(baseUrl: string) {
             return request<Topic>(`/topics/${encodeURIComponent(name)}/claim`, {
                 method: 'DELETE',
             });
+        },
+
+        reserveWebhookSlug(source?: string) {
+            return request<{ endpointUrl: string; reservation: string; slug: string }>(
+                '/webhooks/slug',
+                { body: JSON.stringify({ source }), method: 'POST' },
+            );
         },
 
         subscribe(

--- a/packages/emitsignal-shared/src/index.ts
+++ b/packages/emitsignal-shared/src/index.ts
@@ -6,5 +6,6 @@ export * from './priority.ts';
 export * from './publish-example.ts';
 export * from './topic.ts';
 export * from './url.ts';
+export * from './webhook-slug.ts';
 export * from './webhook-template.ts';
 export * from './webhook-verification.ts';

--- a/packages/emitsignal-shared/src/webhook-slug.test.ts
+++ b/packages/emitsignal-shared/src/webhook-slug.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'bun:test';
+
+import { isValidWebhookSlug, webhookSlugPrefix } from './webhook-slug.ts';
+
+describe('webhookSlugPrefix', () => {
+    it('maps known sources', () => {
+        expect(webhookSlugPrefix('stripe')).toBe('st');
+        expect(webhookSlugPrefix('github')).toBe('gh');
+    });
+
+    it('falls back to the custom prefix', () => {
+        expect(webhookSlugPrefix('whatever')).toBe('cw');
+    });
+});
+
+describe('isValidWebhookSlug', () => {
+    it('rejects a malformed slug', () => {
+        expect(isValidWebhookSlug('nope')).toBe(false);
+        expect(isValidWebhookSlug('st_TOOSHORT')).toBe(false);
+        expect(isValidWebhookSlug('st_abcdefghijklmnopq')).toBe(false);
+        expect(isValidWebhookSlug('ST_abcdefghijklmnop')).toBe(false);
+    });
+
+    it('accepts a well-formed slug without a source', () => {
+        expect(isValidWebhookSlug('st_abcdefghijklmnop')).toBe(true);
+    });
+
+    it('rejects a prefix that does not match the source', () => {
+        expect(isValidWebhookSlug('gh_abcdefghijklmnop', 'stripe')).toBe(false);
+    });
+});

--- a/packages/emitsignal-shared/src/webhook-slug.ts
+++ b/packages/emitsignal-shared/src/webhook-slug.ts
@@ -1,0 +1,25 @@
+export const WEBHOOK_SLUG_RANDOM_LENGTH = 16;
+
+export const WEBHOOK_SLUG_REGEX = /^[a-z]{2}_[a-z0-9]{16}$/;
+
+export const WEBHOOK_SLUG_ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789';
+
+export const WEBHOOK_SOURCE_PREFIX: Record<string, string> = {
+    custom: 'cw',
+    github: 'gh',
+    grafana: 'gf',
+    stripe: 'st',
+    vercel: 'vc',
+};
+
+export function isValidWebhookSlug(slug: string, source?: string): boolean {
+    if (!WEBHOOK_SLUG_REGEX.test(slug)) {
+        return false;
+    }
+
+    return source === undefined || slug.startsWith(`${webhookSlugPrefix(source)}_`);
+}
+
+export function webhookSlugPrefix(source: string): string {
+    return WEBHOOK_SOURCE_PREFIX[source] ?? 'cw';
+}

--- a/packages/emitsignal-website/src/components/app/webhooks/priority-chip.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/priority-chip.tsx
@@ -1,0 +1,30 @@
+import { withAlpha } from '#/lib/color';
+
+interface PriorityChipProps {
+    active: boolean;
+    onClick: () => void;
+    value: number;
+}
+
+export function PriorityChip({ active, onClick, value }: PriorityChipProps) {
+    const hex = `var(--color-p${value})`;
+
+    return (
+        <button
+            className="flex flex-1 cursor-pointer items-center justify-center rounded-md border py-1.5 font-mono text-[11.5px] font-semibold"
+            onClick={onClick}
+            style={
+                active
+                    ? { background: withAlpha(hex, 13), borderColor: hex, color: hex }
+                    : {
+                          background: 'var(--color-elev)',
+                          borderColor: 'var(--color-line)',
+                          color: 'var(--color-dim)',
+                      }
+            }
+            type="button"
+        >
+            {value}
+        </button>
+    );
+}

--- a/packages/emitsignal-website/src/components/app/webhooks/template-fields.ts
+++ b/packages/emitsignal-website/src/components/app/webhooks/template-fields.ts
@@ -1,0 +1,25 @@
+import type { WebhookTemplate } from '#/lib/api';
+
+export type TemplateTextField = keyof WebhookTemplate;
+
+export const TEMPLATE_FIELDS = ['title', 'body', 'tags', 'link'] as const;
+
+export const EMPTY_TEMPLATE: WebhookTemplate = {
+    body: '',
+    link: '',
+    linkLabel: '',
+    priority: '3',
+    tags: '',
+    title: '',
+};
+
+const PLACEHOLDER_HINTS: Record<(typeof TEMPLATE_FIELDS)[number], string> = {
+    body: 'event.description',
+    link: 'event.url',
+    tags: 'source, tag',
+    title: 'event.type',
+};
+
+export function placeholderHintFor(field: (typeof TEMPLATE_FIELDS)[number]): string {
+    return `{{${PLACEHOLDER_HINTS[field]}}}`;
+}

--- a/packages/emitsignal-website/src/components/app/webhooks/verification-fields.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/verification-fields.tsx
@@ -6,12 +6,13 @@ import {
     VERIFICATION_LABELS,
     VERIFICATION_SCHEMES,
 } from '@emitsignal/shared';
-import { ChevronDown, Eye, EyeOff, ShieldAlert, ShieldCheck } from 'lucide-react';
+import { ChevronDown, Eye, EyeOff } from 'lucide-react';
 import { useState } from 'react';
 
 interface VerificationFieldsProps {
     config: VerificationConfig;
     hasStoredSecret: boolean;
+    invalidField?: 'header' | 'secret' | null;
     onConfigChange: (config: VerificationConfig) => void;
     onSchemeChange: (scheme: VerificationScheme) => void;
     onSecretChange: (secret: string) => void;
@@ -26,6 +27,7 @@ const LABEL_CLASS = 'mb-2 font-mono text-[10px] uppercase tracking-[1.3px] text-
 export function VerificationFields({
     config,
     hasStoredSecret,
+    invalidField,
     onConfigChange,
     onSchemeChange,
     onSecretChange,
@@ -39,15 +41,8 @@ export function VerificationFields({
 
     return (
         <div className="border-b border-line px-6 py-4">
-            <div className="mb-3 flex items-center gap-2">
-                {verified ? (
-                    <ShieldCheck className="text-success" size={13} />
-                ) : (
-                    <ShieldAlert className="text-warn" size={13} />
-                )}
-                <span className="font-mono text-[10px] uppercase tracking-[1.3px] text-dim">
-                    Signature verification
-                </span>
+            <div className="mb-3 font-mono text-[10px] uppercase tracking-[1.3px] text-dim">
+                Signature verification
             </div>
 
             <div className="grid grid-cols-[1.1fr_1.6fr] gap-5">
@@ -74,6 +69,7 @@ export function VerificationFields({
                 <div>
                     <div className={LABEL_CLASS}>
                         {verified ? 'Secret from the provider' : 'No secret required'}
+                        {verified && <span className="ml-1 text-danger">*</span>}
                     </div>
                     <div className="relative">
                         <input
@@ -87,6 +83,11 @@ export function VerificationFields({
                                     : 'Paste the signing secret'
                             }
                             spellCheck={false}
+                            style={
+                                invalidField === 'secret'
+                                    ? { borderColor: 'var(--color-danger)' }
+                                    : undefined
+                            }
                             type={secretVisible ? 'text' : 'password'}
                             value={secret}
                         />
@@ -114,7 +115,10 @@ export function VerificationFields({
             {needsConfig && (
                 <div className="mt-4 grid grid-cols-[1.6fr_1fr_1fr_1.1fr] gap-3">
                     <div>
-                        <div className={LABEL_CLASS}>Header</div>
+                        <div className={LABEL_CLASS}>
+                            Header
+                            <span className="ml-1 text-danger">*</span>
+                        </div>
                         <input
                             className={FIELD_CLASS}
                             onChange={(event) =>
@@ -122,6 +126,11 @@ export function VerificationFields({
                             }
                             placeholder="x-signature"
                             spellCheck={false}
+                            style={
+                                invalidField === 'header'
+                                    ? { borderColor: 'var(--color-danger)' }
+                                    : undefined
+                            }
                             value={config.header}
                         />
                     </div>

--- a/packages/emitsignal-website/src/components/app/webhooks/webhook-channel-field.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/webhook-channel-field.tsx
@@ -1,0 +1,130 @@
+import { isValidTopicName } from '@emitsignal/shared/topic';
+import { ChevronDown } from 'lucide-react';
+import { useState } from 'react';
+
+import { Dot } from '#/components/ui/dot';
+import { useSubscriptions } from '#/ctx/subscriptions';
+
+interface WebhookChannelFieldProps {
+    invalid: boolean;
+    onChange: (topicName: string) => void;
+    source: string;
+    value: string;
+}
+
+const NEW_CHANNEL = '__new__';
+
+// A webhook may target a channel that does not exist yet; the first delivery creates it.
+export function suggestChannelName(source: string): string {
+    const alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789';
+    const bytes = crypto.getRandomValues(new Uint8Array(6));
+    let suffix = '';
+
+    for (const byte of bytes) {
+        suffix += alphabet[byte % alphabet.length];
+    }
+
+    return `${source}-${suffix}`;
+}
+
+export function WebhookChannelField({
+    invalid,
+    onChange,
+    source,
+    value,
+}: WebhookChannelFieldProps) {
+    const { subscriptions } = useSubscriptions();
+    const [chosenMode, setChosenMode] = useState<'new' | 'select' | null>(null);
+    const creating = chosenMode ? chosenMode === 'new' : subscriptions.length === 0;
+
+    const nameTaken = subscriptions.some((subscription) => subscription.topic.name === value);
+    const malformed = creating && value.trim() !== '' && !isValidTopicName(value.trim());
+
+    function handleSelect(next: string) {
+        if (next === NEW_CHANNEL) {
+            setChosenMode('new');
+            onChange(suggestChannelName(source));
+
+            return;
+        }
+
+        onChange(next);
+    }
+
+    return (
+        <div>
+            <div className="mb-2 flex items-baseline gap-2 font-mono text-[10px] uppercase tracking-[1.3px] text-dim">
+                Publish to channel
+                <span className="-ml-1.5 text-danger">*</span>
+                {creating && subscriptions.length > 0 && (
+                    <button
+                        className="cursor-pointer normal-case tracking-normal text-accent"
+                        onClick={() => {
+                            setChosenMode('select');
+                            onChange(subscriptions[0]?.topic.name ?? '');
+                        }}
+                        type="button"
+                    >
+                        pick existing
+                    </button>
+                )}
+            </div>
+
+            <div
+                className="flex items-center gap-2 rounded-lg border bg-elev px-3 py-2"
+                style={{
+                    borderColor: invalid || malformed ? 'var(--color-danger)' : 'var(--color-line)',
+                }}
+            >
+                <Dot level={2} size={6} />
+
+                {creating ? (
+                    <input
+                        className="flex-1 bg-transparent font-mono text-[12px] text-fg outline-none placeholder:text-faint"
+                        onChange={(event) => onChange(event.target.value)}
+                        placeholder="new-channel-name"
+                        spellCheck={false}
+                        value={value}
+                    />
+                ) : (
+                    <>
+                        <select
+                            className="flex-1 bg-transparent font-mono text-[12px] text-fg outline-none"
+                            onChange={(event) => handleSelect(event.target.value)}
+                            value={nameTaken ? value : ''}
+                        >
+                            <option disabled value="">
+                                Select a channel…
+                            </option>
+
+                            <optgroup label="Your channels">
+                                {subscriptions.map((subscription) => (
+                                    <option key={subscription.id} value={subscription.topic.name}>
+                                        {subscription.topic.displayName}
+                                    </option>
+                                ))}
+                            </optgroup>
+
+                            <optgroup label="New">
+                                <option value={NEW_CHANNEL}>+ Create a new channel…</option>
+                            </optgroup>
+                        </select>
+                        <ChevronDown className="pointer-events-none text-dim" size={13} />
+                    </>
+                )}
+            </div>
+
+            {malformed && (
+                <div className="mt-1 font-mono text-[10.5px] text-danger">
+                    Lowercase letters, numbers, dash, underscore and slash only.
+                </div>
+            )}
+
+            {creating && !malformed && value.trim() !== '' && !nameTaken && (
+                <div className="mt-1 font-mono text-[10.5px] text-faint">
+                    Created on the first delivery.
+                </div>
+            )}
+        </div>
+    );
+}

--- a/packages/emitsignal-website/src/components/app/webhooks/webhook-create.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/webhook-create.tsx
@@ -4,25 +4,33 @@ import {
     DEFAULT_CONFIG_BY_SOURCE,
     defaultVerificationForSource,
     schemeNeedsConfig,
+    VERIFICATION_LABELS,
 } from '@emitsignal/shared';
+import { isValidTopicName } from '@emitsignal/shared/topic';
 import { applyTemplate as applyTemplateExact } from '@emitsignal/shared/webhook-template';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { ChevronDown, Copy } from 'lucide-react';
+import { Copy } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import type { Webhook, WebhookTemplate } from '#/lib/api';
 
-import { Dot } from '#/components/ui/dot';
 import { useSubscriptions } from '#/ctx/subscriptions';
 import { api, API_URL } from '#/lib/api';
-import { withAlpha } from '#/lib/color';
 import { queryKeys } from '#/lib/query-client';
+
+import type { TemplateTextField } from './template-fields';
+import type { WebhookTab } from './webhook-tab-bar';
 
 import { JsonView } from './json-view';
 import { NotifPreview } from './notif-preview';
+import { EMPTY_TEMPLATE } from './template-fields';
 import { applyTemplate } from './template-string';
 import { VerificationFields } from './verification-fields';
+import { WebhookChannelField } from './webhook-channel-field';
+import { WebhookSettingsTab } from './webhook-settings-tab';
+import { WebhookTabBar } from './webhook-tab-bar';
+import { WebhookTemplateTab } from './webhook-template-tab';
 
 const SOURCE_DATA: Record<
     string,
@@ -113,17 +121,6 @@ const GLYPH: Record<Source, string> = {
     vercel: 'VC',
 };
 
-const EMPTY_TEMPLATE: WebhookTemplate = {
-    body: '',
-    link: '',
-    linkLabel: '',
-    priority: '3',
-    tags: '',
-    title: '',
-};
-
-// ── Props ─────────────────────────────────────────────────────────────────────
-
 interface WebhookCreateProps {
     initialData?: {
         samplePayload?: null | string;
@@ -141,6 +138,10 @@ interface WebhookCreateProps {
     >;
 }
 
+function defaultWebhookName(source: string): string {
+    return `${source} webhook`;
+}
+
 const EMPTY_CONFIG: VerificationConfig = {
     algorithm: 'sha256',
     encoding: 'hex',
@@ -148,25 +149,9 @@ const EMPTY_CONFIG: VerificationConfig = {
     prefix: '',
 };
 
-function parseConfig(raw: null | string | undefined): null | VerificationConfig {
-    if (!raw) {
-        return null;
-    }
-
-    try {
-        return JSON.parse(raw) as VerificationConfig;
-    } catch {
-        return null;
-    }
-}
-
-const EMPTY_PAYLOAD = '{\n  \n}';
-
-// ── Component ─────────────────────────────────────────────────────────────────
-
 export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
-    const { subscriptions } = useSubscriptions();
     const isEdit = !!initialData;
+    const { subscribe, subscriptions } = useSubscriptions();
     const navigate = useNavigate();
     const queryClient = useQueryClient();
 
@@ -182,17 +167,28 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
         }
     })();
 
+    const [activeTab, setActiveTab] = useState<WebhookTab>('template');
     const [copied, setCopied] = useState(false);
-    const [customPayloadText, setCustomPayloadText] = useState(
-        initialData?.samplePayload ?? EMPTY_PAYLOAD,
+    const [payloadText, setPayloadText] = useState(
+        initialData?.samplePayload ?? samplePayloadFor(initialSource),
     );
-    const [customPayloadValid, setCustomPayloadValid] = useState(true);
+    const [payloadValid, setPayloadValid] = useState(true);
+    const [editingPayload, setEditingPayload] = useState(false);
     const [previewMode, setPreviewMode] = useState<'pretty' | 'raw'>('pretty');
     const [saveError, setSaveError] = useState<null | string>(null);
     const [saving, setSaving] = useState(false);
     const [secret, setSecret] = useState('');
     const [scheme, setScheme] = useState<VerificationScheme>(
         initialData?.verification ?? defaultVerificationForSource(initialSource),
+    );
+    const [reservedSlug, setReservedSlug] = useState('');
+    const [slugReservation, setSlugReservation] = useState('');
+    const [reserving, setReserving] = useState(false);
+    const [invalidField, setInvalidField] = useState<'header' | 'secret' | null>(null);
+    const [name, setName] = useState(
+        initialData?.name && initialData.name !== defaultWebhookName(initialSource)
+            ? initialData.name
+            : '',
     );
     const [source, setSource] = useState<Source>(initialSource);
     const [templateFields, setTemplateFields] = useState<WebhookTemplate>(
@@ -210,18 +206,17 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
     const verificationDirtyRef = useRef(false);
 
     // Active payload for preview
-    const activePayload: Record<string, unknown> =
-        source === 'custom'
-            ? (() => {
-                  try {
-                      return JSON.parse(customPayloadText) as Record<string, unknown>;
-                  } catch {
-                      return {};
-                  }
-              })()
-            : SOURCE_DATA[source]!.payload;
+    const activePayload: Record<string, unknown> = (() => {
+        try {
+            return JSON.parse(payloadText) as Record<string, unknown>;
+        } catch {
+            return {};
+        }
+    })();
 
     const showRaw = !useTemplate || previewMode === 'raw';
+    const slug = isEdit ? initialData?.slug : reservedSlug;
+    const channelInvalid = !!saveError && !topicName.trim();
 
     const rendered = {
         body: applyTemplate(templateFields.body ?? '', activePayload),
@@ -248,6 +243,9 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
 
         setTemplateFields(template ?? EMPTY_TEMPLATE);
         setUseTemplate(template !== null);
+        setPayloadText(samplePayloadFor(source));
+        setPayloadValid(true);
+        setEditingPayload(false);
 
         templateDirtyRef.current = false;
 
@@ -258,6 +256,8 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
     }
 
     function handleSchemeChange(next: VerificationScheme) {
+        setInvalidField(null);
+
         verificationDirtyRef.current = true;
 
         setScheme(next);
@@ -267,29 +267,44 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
         }
     }
 
-    function handleTemplateFieldChange(field: keyof WebhookTemplate, value: string) {
+    function handleTemplateFieldChange(field: TemplateTextField, value: string) {
         templateDirtyRef.current = true;
 
         setTemplateFields((prev) => ({ ...prev, [field]: value }));
     }
 
-    function handleCustomPayloadChange(text: string) {
-        setCustomPayloadText(text);
+    function handlePayloadChange(text: string) {
+        setPayloadText(text);
 
         try {
             JSON.parse(text);
-            setCustomPayloadValid(true);
+            setPayloadValid(true);
         } catch {
-            setCustomPayloadValid(false);
+            setPayloadValid(false);
+        }
+    }
+
+    async function handleGenerateEndpoint() {
+        setReserving(true);
+
+        try {
+            const reserved = await api.reserveWebhookSlug(source);
+
+            setReservedSlug(reserved.slug);
+            setSlugReservation(reserved.reservation);
+        } catch {
+            setSaveError('Could not reserve an endpoint URL. It will be assigned on save.');
+        } finally {
+            setReserving(false);
         }
     }
 
     function handleCopyEndpoint() {
-        if (!isEdit || !initialData?.slug) {
+        if (!slug) {
             return;
         }
 
-        void navigator.clipboard.writeText(`${API_URL}/h/${initialData.slug}`).then(() => {
+        void navigator.clipboard.writeText(`${API_URL}/h/${slug}`).then(() => {
             setCopied(true);
             setTimeout(() => setCopied(false), 1500);
         });
@@ -300,20 +315,37 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
             return setSaveError('Channel name is required');
         }
 
+        if (!isValidTopicName(topicName.trim())) {
+            return setSaveError(
+                'Channel names use lowercase letters, numbers, dash, underscore and slash only',
+            );
+        }
+
         const hasStoredSecret = !!initialData?.hasSecret;
 
         if (scheme !== 'none' && !secret.trim() && !hasStoredSecret) {
-            return setSaveError('Paste the signing secret, or set verification to None');
+            setActiveTab('signature');
+            setInvalidField('secret');
+
+            return setSaveError(
+                `${VERIFICATION_LABELS[scheme]} signs its deliveries. Paste the signing secret from the provider, or set Scheme to None.`,
+            );
         }
 
         if (scheme !== 'none' && schemeNeedsConfig(scheme) && !verificationConfig.header.trim()) {
-            return setSaveError('A header name is required for this verification scheme');
+            setActiveTab('signature');
+            setInvalidField('header');
+
+            return setSaveError(
+                'Name the header the provider sends its signature in, for example x-signature.',
+            );
         }
 
         setSaving(true);
         setSaveError(null);
 
         try {
+            const channel = topicName.trim();
             const template = useTemplate ? JSON.stringify(templateFields) : null;
 
             const verification = {
@@ -327,19 +359,59 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
 
             if (isEdit && initialData) {
                 await api.updateWebhook(initialData.id, {
-                    name: `${source} webhook`,
+                    name: name.trim() || defaultWebhookName(source),
                     template,
-                    topicName: topicName.trim(),
+                    topicName: channel,
                     ...verification,
                 });
             } else {
-                await api.createWebhook({
-                    name: `${source} webhook`,
-                    source,
-                    template,
-                    topicName: topicName.trim(),
-                    ...verification,
-                });
+                const create = (reserved: { reservation: string; slug: string } | null) =>
+                    api.createWebhook({
+                        name: name.trim() || defaultWebhookName(source),
+                        source,
+                        template,
+                        topicName: channel,
+                        ...(reserved ?? {}),
+                        ...verification,
+                    });
+
+                const reserved =
+                    reservedSlug && slugReservation
+                        ? { reservation: slugReservation, slug: reservedSlug }
+                        : null;
+
+                try {
+                    await create(reserved);
+                } catch (error) {
+                    const message = error instanceof Error ? error.message : '';
+
+                    if (
+                        !message.includes('slug_taken') &&
+                        !message.includes('invalid_slug_reservation')
+                    ) {
+                        throw error;
+                    }
+
+                    const retry = await api.reserveWebhookSlug(source);
+
+                    setReservedSlug(retry.slug);
+                    setSlugReservation(retry.reservation);
+                    await create({ reservation: retry.reservation, slug: retry.slug });
+                }
+            }
+
+            // Deliveries reach nobody without a subscription. subscribe() upserts, so skip
+            // it when one exists: the update branch resets that channel's settings.
+            if (!subscriptions.some((subscription) => subscription.topic.name === channel)) {
+                try {
+                    await subscribe(channel);
+                } catch {
+                    setSaving(false);
+
+                    return setSaveError(
+                        `Webhook saved, but subscribing to ${channel} failed. Subscribe from Channels to get notified.`,
+                    );
+                }
             }
 
             await queryClient.invalidateQueries({ queryKey: queryKeys.webhooks });
@@ -379,20 +451,21 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
         verificationDirtyRef.current = false;
     }, [initialData?.id]);
 
-    // Seed the custom payload editor once deliveries resolve (the sample payload
+    // Seed the payload editor once deliveries resolve (the sample payload
     // arrives after mount, so it has its own effect to avoid resetting template edits).
     useEffect(() => {
         if (!initialData?.samplePayload) {
             return;
         }
 
-        setCustomPayloadText(initialData.samplePayload);
-        setCustomPayloadValid(true);
+        setPayloadText(initialData.samplePayload);
+        setPayloadValid(true);
     }, [initialData?.samplePayload]);
 
     return (
         <div className="flex min-h-0 flex-1 flex-col">
-            <div className="grid grid-cols-[1.1fr_1.6fr_1.1fr] gap-5 border-b border-line px-6 py-4">
+            {/* identity: source drives the sample payload, endpoint is the thing you copy */}
+            <div className="grid grid-cols-[auto_1.6fr_1.1fr] items-start gap-5 border-b border-line px-6 py-4">
                 <div>
                     <div className="mb-2 font-mono text-[10px] uppercase tracking-[1.3px] text-dim">
                         Source
@@ -419,6 +492,7 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
                                           }
                                 }
                                 title={s}
+                                type="button"
                             >
                                 {GLYPH[s]}
                             </button>
@@ -426,7 +500,6 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
                     </div>
                 </div>
 
-                {/* Endpoint URL */}
                 <div>
                     <div className="mb-2 font-mono text-[10px] uppercase tracking-[1.3px] text-dim">
                         Endpoint URL
@@ -434,76 +507,47 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
                     <div className="flex items-center gap-2 rounded-lg border border-line bg-deep px-3 py-2">
                         <span className="flex-1 truncate font-mono text-[11.5px] text-muted">
                             {API_URL}/h/
-                            <span className="text-accent">
-                                {isEdit ? initialData?.slug : 'assigned on save'}
+                            <span className={slug ? 'text-accent' : 'text-faint'}>
+                                {slug || 'assigned on save'}
                             </span>
                         </span>
-                        <button
-                            className="flex shrink-0 cursor-pointer items-center text-faint hover:text-fg disabled:cursor-default"
-                            disabled={!isEdit}
-                            onClick={handleCopyEndpoint}
-                            title={copied ? 'Copied!' : 'Copy endpoint URL'}
-                        >
-                            {copied ? (
-                                <span className="font-mono text-[9px] text-success leading-none">
-                                    ✓
-                                </span>
-                            ) : (
-                                <Copy size={13} />
-                            )}
-                        </button>
+
+                        {slug ? (
+                            <button
+                                className="flex shrink-0 cursor-pointer items-center text-faint hover:text-fg"
+                                onClick={handleCopyEndpoint}
+                                title={copied ? 'Copied!' : 'Copy endpoint URL'}
+                                type="button"
+                            >
+                                {copied ? (
+                                    <span className="font-mono text-[9px] text-success leading-none">
+                                        ✓
+                                    </span>
+                                ) : (
+                                    <Copy size={13} />
+                                )}
+                            </button>
+                        ) : (
+                            <button
+                                className="shrink-0 cursor-pointer rounded-md border border-line px-2 py-0.5 font-mono text-[10px] uppercase tracking-[1px] text-dim hover:text-fg disabled:cursor-default disabled:opacity-40"
+                                disabled={reserving}
+                                onClick={() => void handleGenerateEndpoint()}
+                                title="Reserve this URL now, so you can configure the provider before saving"
+                                type="button"
+                            >
+                                {reserving ? 'Reserving…' : 'Generate'}
+                            </button>
+                        )}
                     </div>
                 </div>
 
-                {/* Channel */}
-                <div>
-                    <div className="mb-2 font-mono text-[10px] uppercase tracking-[1.3px] text-dim">
-                        Publish to channel
-                    </div>
-                    <div
-                        className="flex items-center gap-2 rounded-lg border bg-elev px-3 py-2"
-                        style={{
-                            borderColor:
-                                saveError && !topicName.trim()
-                                    ? 'var(--color-danger)'
-                                    : 'var(--color-line)',
-                        }}
-                    >
-                        <Dot level={2} size={6} />
-
-                        <select
-                            className="flex-1 bg-transparent font-mono text-[12px] text-fg outline-none"
-                            onChange={(e) => setTopicName(e.target.value)}
-                            value={topicName}
-                        >
-                            <option disabled value="">
-                                Select a channel…
-                            </option>
-
-                            {subscriptions.map((subscription) => (
-                                <option key={subscription.id} value={subscription.topic.name}>
-                                    {subscription.topic.displayName}
-                                </option>
-                            ))}
-                        </select>
-                        <ChevronDown className="pointer-events-none text-dim" size={13} />
-                    </div>
-
-                    {saveError && (
-                        <div className="mt-1 font-mono text-[10.5px] text-danger">{saveError}</div>
-                    )}
-                </div>
+                <WebhookChannelField
+                    invalid={channelInvalid}
+                    onChange={setTopicName}
+                    source={source}
+                    value={topicName}
+                />
             </div>
-
-            <VerificationFields
-                config={verificationConfig}
-                hasStoredSecret={!!initialData?.hasSecret}
-                onConfigChange={setVerificationConfig}
-                onSchemeChange={handleSchemeChange}
-                onSecretChange={setSecret}
-                scheme={scheme}
-                secret={secret}
-            />
 
             {/* editor split */}
             <div className="flex min-h-0 flex-1">
@@ -513,135 +557,96 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
                         <span className="font-mono text-[10px] uppercase tracking-[1.5px] text-dim">
                             Incoming Payload
                         </span>
-                        <span className="ml-auto font-mono text-[10px] text-faint">
-                            {source === 'custom' ? 'editable' : 'POST · example payload'}
-                        </span>
+                        <div className="ml-auto flex items-center gap-2">
+                            {editingPayload && !payloadValid && (
+                                <span className="font-mono text-[10px] text-danger">
+                                    invalid JSON
+                                </span>
+                            )}
+
+                            <button
+                                className="cursor-pointer rounded-md border border-line px-2 py-1 font-mono text-[10px] uppercase tracking-[1px] text-dim hover:text-fg disabled:cursor-default disabled:opacity-40"
+                                disabled={editingPayload && !payloadValid}
+                                onClick={() => setEditingPayload((editing) => !editing)}
+                                type="button"
+                            >
+                                {editingPayload ? 'Done' : 'Edit'}
+                            </button>
+                        </div>
                     </div>
                     <div
                         className="mx-5 mb-5 flex-1 overflow-auto rounded-xl border border-line bg-deep p-3.5"
                         style={{
                             borderColor:
-                                source === 'custom' && !customPayloadValid
+                                editingPayload && !payloadValid
                                     ? 'var(--color-danger)'
-                                    : undefined,
+                                    : editingPayload
+                                      ? 'var(--color-accent)'
+                                      : undefined,
                         }}
                     >
-                        {source === 'custom' ? (
+                        {editingPayload ? (
                             <textarea
+                                autoFocus
                                 className="h-full w-full resize-none bg-transparent font-mono text-[12px] leading-relaxed text-fg outline-none"
-                                onChange={(e) => handleCustomPayloadChange(e.target.value)}
+                                onChange={(e) => handlePayloadChange(e.target.value)}
                                 spellCheck={false}
-                                value={customPayloadText}
+                                value={payloadText}
                             />
                         ) : (
-                            <JsonView data={SOURCE_DATA[source]!.payload} size={12} />
+                            <JsonView data={activePayload} size={12} />
                         )}
                     </div>
                 </div>
 
-                {/* template + preview pane */}
-                <div className="flex min-w-0 flex-1 flex-col overflow-auto">
-                    {/* template toggle */}
-                    <div className="flex items-center px-5 py-3.5">
-                        <span className="font-mono text-[10px] uppercase tracking-[1.5px] text-dim">
-                            Template
-                        </span>
+                {/* config pane: one tab at a time, preview pinned below */}
+                <div className="flex min-w-0 flex-1 flex-col">
+                    <WebhookTabBar
+                        active={activeTab}
+                        onChange={setActiveTab}
+                        signatureVerified={scheme !== 'none'}
+                    />
 
-                        <button
-                            className="ml-auto flex cursor-pointer items-center gap-2"
-                            onClick={() => setUseTemplate((v) => !v)}
-                        >
-                            <span
-                                className="font-mono text-[11px]"
-                                style={{
-                                    color: useTemplate ? 'var(--color-accent)' : 'var(--color-dim)',
-                                }}
-                            >
-                                {useTemplate ? 'Using template' : 'Raw passthrough'}
-                            </span>
-                            <div
-                                className="flex items-center rounded-full p-0.5 transition-colors"
-                                style={{
-                                    background: useTemplate
-                                        ? 'var(--color-accent)'
-                                        : 'var(--color-line)',
-                                    height: 21,
-                                    justifyContent: useTemplate ? 'flex-end' : 'flex-start',
-                                    width: 36,
-                                }}
-                            >
-                                <div className="h-[17px] w-[17px] rounded-full bg-fg" />
-                            </div>
-                        </button>
-                    </div>
-
-                    {/* template fields (editable) */}
-                    <div
-                        className="px-5 transition-opacity"
-                        style={{
-                            opacity: useTemplate ? 1 : 0.4,
-                            pointerEvents: useTemplate ? 'auto' : 'none',
-                        }}
-                    >
-                        {(['title', 'body', 'tags', 'link'] as const).map((field) => (
-                            <div className="mb-2.5" key={field}>
-                                <div className="mb-1 font-mono text-[10px] uppercase tracking-[1px] text-dim">
-                                    {field}
-                                </div>
-                                <input
-                                    className="w-full rounded-lg border border-line bg-elev px-3 py-2 font-mono text-[12.5px] text-fg outline-none placeholder:text-faint focus:border-accent/50"
-                                    onChange={(e) =>
-                                        handleTemplateFieldChange(field, e.target.value)
-                                    }
-                                    placeholder={`{{${field === 'title' ? 'event.type' : field === 'body' ? 'event.description' : field === 'tags' ? 'source, tag' : 'event.url'}}}`}
-                                    value={templateFields[field] ?? ''}
-                                />
-                            </div>
-                        ))}
-
-                        {(templateFields.link ?? '') !== '' && (
-                            <div className="mb-2.5">
-                                <div className="mb-1 flex items-baseline gap-2 font-mono text-[10px] uppercase tracking-[1px] text-dim">
-                                    Button label
-                                    <span className="normal-case tracking-normal text-faint">
-                                        optional · defaults to “View”
-                                    </span>
-                                </div>
-                                <input
-                                    className="w-full rounded-lg border border-line bg-elev px-3 py-2 font-mono text-[12.5px] text-fg outline-none placeholder:text-faint focus:border-accent/50"
-                                    onChange={(e) =>
-                                        handleTemplateFieldChange('linkLabel', e.target.value)
-                                    }
-                                    placeholder="View"
-                                    value={templateFields.linkLabel ?? ''}
-                                />
-                            </div>
+                    <div className="min-h-0 flex-1 overflow-auto">
+                        {activeTab === 'settings' && (
+                            <WebhookSettingsTab
+                                name={name}
+                                onNameChange={setName}
+                                placeholder={defaultWebhookName(source)}
+                            />
                         )}
 
-                        <div className="mb-2.5">
-                            <div className="mb-1 font-mono text-[10px] uppercase tracking-[1px] text-dim">
-                                Priority
-                            </div>
+                        {activeTab === 'signature' && (
+                            <VerificationFields
+                                config={verificationConfig}
+                                hasStoredSecret={!!initialData?.hasSecret}
+                                invalidField={invalidField}
+                                onConfigChange={(next) => {
+                                    setInvalidField(null);
+                                    setVerificationConfig(next);
+                                }}
+                                onSchemeChange={handleSchemeChange}
+                                onSecretChange={(next) => {
+                                    setInvalidField(null);
+                                    setSecret(next);
+                                }}
+                                scheme={scheme}
+                                secret={secret}
+                            />
+                        )}
 
-                            <div className="flex gap-1">
-                                {[1, 2, 3, 4, 5].map((priority) => (
-                                    <PriorityChip
-                                        active={
-                                            String(priority) === (templateFields.priority ?? '3')
-                                        }
-                                        key={priority}
-                                        onClick={() =>
-                                            handleTemplateFieldChange('priority', String(priority))
-                                        }
-                                        value={priority}
-                                    />
-                                ))}
-                            </div>
-                        </div>
+                        {activeTab === 'template' && (
+                            <WebhookTemplateTab
+                                fields={templateFields}
+                                onFieldChange={handleTemplateFieldChange}
+                                onUseTemplateChange={setUseTemplate}
+                                useTemplate={useTemplate}
+                            />
+                        )}
                     </div>
 
-                    {/* preview */}
-                    <div className="border-t border-line bg-deep px-5 py-4">
+                    {/* preview stays put so editing any tab shows its effect immediately */}
+                    <div className="shrink-0 border-t border-line bg-deep px-5 py-4">
                         <div className="mb-3 flex items-center">
                             <span className="font-mono text-[10px] uppercase tracking-[1.5px] text-dim">
                                 {showRaw ? 'Preview · Raw payload' : 'Preview · Notification'}
@@ -666,6 +671,7 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
                                                   }
                                                 : { color: 'var(--color-muted)' }
                                         }
+                                        type="button"
                                     >
                                         {option.charAt(0).toUpperCase() + option.slice(1)}
                                     </button>
@@ -698,11 +704,15 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
             </div>
 
             {/* save bar */}
-            <div className="flex justify-end gap-2 border-t border-line px-6 py-3">
+            <div className="flex items-center justify-end gap-3 border-t border-line px-6 py-3">
+                {saveError && (
+                    <span className="font-mono text-[11px] text-danger">{saveError}</span>
+                )}
                 <button
                     className="rounded-md bg-accent px-4 py-1.5 text-[12px] font-semibold text-bg hover:bg-accent-dim disabled:opacity-50"
-                    disabled={saving || (source === 'custom' && !customPayloadValid)}
+                    disabled={saving || !payloadValid}
                     onClick={() => void handleSave()}
+                    type="button"
                 >
                     {saving ? 'Saving…' : isEdit ? 'Save changes' : 'Save webhook'}
                 </button>
@@ -711,32 +721,20 @@ export function WebhookCreate({ initialData }: WebhookCreateProps = {}) {
     );
 }
 
-function PriorityChip({
-    active,
-    onClick,
-    value,
-}: {
-    active: boolean;
-    onClick: () => void;
-    value: number;
-}) {
-    const hex = `var(--color-p${value})`;
+function parseConfig(raw: null | string | undefined): null | VerificationConfig {
+    if (!raw) {
+        return null;
+    }
 
-    return (
-        <button
-            className="flex flex-1 cursor-pointer items-center justify-center rounded-md border py-1.5 font-mono text-[11.5px] font-semibold"
-            onClick={onClick}
-            style={
-                active
-                    ? { background: withAlpha(hex, 13), borderColor: hex, color: hex }
-                    : {
-                          background: 'var(--color-elev)',
-                          borderColor: 'var(--color-line)',
-                          color: 'var(--color-dim)',
-                      }
-            }
-        >
-            {value}
-        </button>
-    );
+    try {
+        return JSON.parse(raw) as VerificationConfig;
+    } catch {
+        return null;
+    }
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+function samplePayloadFor(source: string): string {
+    return JSON.stringify(SOURCE_DATA[source]?.payload ?? {}, null, 2);
 }

--- a/packages/emitsignal-website/src/components/app/webhooks/webhook-settings-tab.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/webhook-settings-tab.tsx
@@ -1,0 +1,25 @@
+interface WebhookSettingsTabProps {
+    name: string;
+    onNameChange: (name: string) => void;
+    placeholder: string;
+}
+
+export function WebhookSettingsTab({ name, onNameChange, placeholder }: WebhookSettingsTabProps) {
+    return (
+        <div className="px-5 py-4">
+            <div className="mb-1 flex items-baseline gap-2 font-mono text-[10px] uppercase tracking-[1px] text-dim">
+                Name
+                <span className="normal-case tracking-normal text-faint">
+                    optional · how it is listed
+                </span>
+            </div>
+
+            <input
+                className="w-full rounded-lg border border-line bg-elev px-3 py-2 font-mono text-[12.5px] text-fg outline-none placeholder:text-faint focus:border-accent/50"
+                onChange={(event) => onNameChange(event.target.value)}
+                placeholder={placeholder}
+                value={name}
+            />
+        </div>
+    );
+}

--- a/packages/emitsignal-website/src/components/app/webhooks/webhook-tab-bar.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/webhook-tab-bar.tsx
@@ -1,0 +1,48 @@
+import { ShieldAlert, ShieldCheck } from 'lucide-react';
+
+export type WebhookTab = 'settings' | 'signature' | 'template';
+
+interface WebhookTabBarProps {
+    active: WebhookTab;
+    onChange: (tab: WebhookTab) => void;
+    signatureVerified: boolean;
+}
+
+const TABS: { id: WebhookTab; label: string }[] = [
+    { id: 'template', label: 'Template' },
+    { id: 'settings', label: 'Settings' },
+    { id: 'signature', label: 'Signature' },
+];
+
+export function WebhookTabBar({ active, onChange, signatureVerified }: WebhookTabBarProps) {
+    return (
+        <div className="flex gap-4 border-b border-line px-5" role="tablist">
+            {TABS.map((tab) => {
+                const isActive = tab.id === active;
+
+                return (
+                    <button
+                        aria-selected={isActive}
+                        className="flex cursor-pointer items-center gap-1.5 border-b-2 py-3 font-mono text-[11px] uppercase tracking-[1.2px] transition-colors"
+                        key={tab.id}
+                        onClick={() => onChange(tab.id)}
+                        role="tab"
+                        style={{
+                            borderBottomColor: isActive ? 'var(--color-accent)' : 'transparent',
+                            color: isActive ? 'var(--color-accent)' : 'var(--color-dim)',
+                        }}
+                        type="button"
+                    >
+                        {tab.id === 'signature' &&
+                            (signatureVerified ? (
+                                <ShieldCheck className="text-success" size={12} />
+                            ) : (
+                                <ShieldAlert className="text-warn" size={12} />
+                            ))}
+                        {tab.label}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/packages/emitsignal-website/src/components/app/webhooks/webhook-template-tab.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/webhook-template-tab.tsx
@@ -1,0 +1,104 @@
+import type { WebhookTemplate } from '#/lib/api';
+
+import type { TemplateTextField } from './template-fields';
+
+import { PriorityChip } from './priority-chip';
+import { placeholderHintFor, TEMPLATE_FIELDS } from './template-fields';
+
+interface WebhookTemplateTabProps {
+    fields: WebhookTemplate;
+    onFieldChange: (field: TemplateTextField, value: string) => void;
+    onUseTemplateChange: (useTemplate: boolean) => void;
+    useTemplate: boolean;
+}
+
+export function WebhookTemplateTab({
+    fields,
+    onFieldChange,
+    onUseTemplateChange,
+    useTemplate,
+}: WebhookTemplateTabProps) {
+    return (
+        <div className="px-5 py-4">
+            <button
+                className="mb-3 flex w-full cursor-pointer items-center"
+                onClick={() => onUseTemplateChange(!useTemplate)}
+                type="button"
+            >
+                <span
+                    className="font-mono text-[11px]"
+                    style={{ color: useTemplate ? 'var(--color-accent)' : 'var(--color-dim)' }}
+                >
+                    {useTemplate ? 'Using template' : 'Raw passthrough'}
+                </span>
+                <div
+                    className="ml-auto flex items-center rounded-full p-0.5 transition-colors"
+                    style={{
+                        background: useTemplate ? 'var(--color-accent)' : 'var(--color-line)',
+                        height: 21,
+                        justifyContent: useTemplate ? 'flex-end' : 'flex-start',
+                        width: 36,
+                    }}
+                >
+                    <div className="h-[17px] w-[17px] rounded-full bg-fg" />
+                </div>
+            </button>
+
+            <div
+                className="transition-opacity"
+                style={{
+                    opacity: useTemplate ? 1 : 0.4,
+                    pointerEvents: useTemplate ? 'auto' : 'none',
+                }}
+            >
+                {TEMPLATE_FIELDS.map((field) => (
+                    <div className="mb-2.5" key={field}>
+                        <div className="mb-1 font-mono text-[10px] uppercase tracking-[1px] text-dim">
+                            {field}
+                        </div>
+                        <input
+                            className="w-full rounded-lg border border-line bg-elev px-3 py-2 font-mono text-[12.5px] text-fg outline-none placeholder:text-faint focus:border-accent/50"
+                            onChange={(event) => onFieldChange(field, event.target.value)}
+                            placeholder={placeholderHintFor(field)}
+                            value={fields[field] ?? ''}
+                        />
+                    </div>
+                ))}
+
+                {(fields.link ?? '') !== '' && (
+                    <div className="mb-2.5">
+                        <div className="mb-1 flex items-baseline gap-2 font-mono text-[10px] uppercase tracking-[1px] text-dim">
+                            Button label
+                            <span className="normal-case tracking-normal text-faint">
+                                optional · defaults to “View”
+                            </span>
+                        </div>
+                        <input
+                            className="w-full rounded-lg border border-line bg-elev px-3 py-2 font-mono text-[12.5px] text-fg outline-none placeholder:text-faint focus:border-accent/50"
+                            onChange={(event) => onFieldChange('linkLabel', event.target.value)}
+                            placeholder="View"
+                            value={fields.linkLabel ?? ''}
+                        />
+                    </div>
+                )}
+
+                <div className="mb-2.5">
+                    <div className="mb-1 font-mono text-[10px] uppercase tracking-[1px] text-dim">
+                        Priority
+                    </div>
+
+                    <div className="flex gap-1">
+                        {[1, 2, 3, 4, 5].map((priority) => (
+                            <PriorityChip
+                                active={String(priority) === (fields.priority ?? '3')}
+                                key={priority}
+                                onClick={() => onFieldChange('priority', String(priority))}
+                                value={priority}
+                            />
+                        ))}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
The new/edit webhook page had grown to stack source, endpoint, channel, signature,
template fields and preview onto one surface. Config now sits in **Template**,
**Settings** and **Signature** tabs, with the incoming payload and the notification
preview pinned so editing any tab still shows its effect immediately.

Alongside the layout:

- **The endpoint URL is known before saving.** It used to read "assigned on save",
  which meant configuring Stripe took two passes: save, copy the URL, create the
  endpoint, come back and paste the signing secret. The form now reserves the slug
  and shows a real, copyable URL from the moment the page opens.
- **Creating a channel from the picker also subscribes you to it.** Previously a
  webhook could publish to a channel with no subscriber, so the deliveries arrived
  where nobody would ever see them.
- **The webhook name is editable.** The form was hardcoding `<source> webhook` on
  every save, silently overwriting any custom name on edit.
- **The incoming payload is editable for every source**, not just `custom`. It stays
  read-only and syntax-highlighted until you press Edit.

Server side, `POST /webhooks` accepts an optional `slug`. It rejects a malformed one
or a prefix that does not match the source (`400 invalid_slug`), and turns a lost race
on the unique index into `409 slug_taken` rather than a 500. Omitting it still
generates the slug server-side, so the CLI and existing API callers are unaffected.

No breaking changes.