### PR TITLE
feat(website): collapsible sidebar and responsive dashboard layout

### DIFF
--- a/packages/emitsignal-website/src/components/app/channels/event-list.tsx
+++ b/packages/emitsignal-website/src/components/app/channels/event-list.tsx
@@ -63,7 +63,7 @@ export function EventList({
     }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
     return (
-        <div className="min-w-0 flex-1 overflow-auto border-r border-line">
+        <div className="min-w-0 flex-1 overflow-auto lg:border-r lg:border-line">
             <FilterRow
                 count={messages.length}
                 hasNextPage={hasNextPage}

--- a/packages/emitsignal-website/src/components/app/channels/routing-rail.tsx
+++ b/packages/emitsignal-website/src/components/app/channels/routing-rail.tsx
@@ -94,7 +94,7 @@ export function RoutingRail({ subscription }: Props) {
             : buildCliExample({ bin: 'es', message: example, topicName, wrap: true });
 
     return (
-        <aside className="w-[320px] shrink-0 overflow-auto p-5.5">
+        <aside className="hidden w-[320px] shrink-0 overflow-auto p-5.5 lg:block">
             {description && (
                 <div className="mb-4.5">
                     <SubHeading>DESCRIPTION</SubHeading>

--- a/packages/emitsignal-website/src/components/app/channels/stats-strip.tsx
+++ b/packages/emitsignal-website/src/components/app/channels/stats-strip.tsx
@@ -20,7 +20,7 @@ export function StatsStrip({ loading = false, metrics, subscription }: Props) {
     const max = Math.max(...volume, 1);
 
     return (
-        <div className="grid shrink-0 grid-cols-[repeat(4,1fr)_1.4fr] items-center gap-5.5 border-b border-line px-5.5 py-4.5">
+        <div className="grid shrink-0 grid-cols-2 items-center gap-4 border-b border-line px-4 py-3 sm:grid-cols-3 lg:grid-cols-[repeat(4,1fr)_1.4fr] lg:gap-5.5 lg:px-5.5 lg:py-4.5">
             <StatItem
                 label="last 24h"
                 loading={loading}
@@ -49,7 +49,7 @@ export function StatsStrip({ loading = false, metrics, subscription }: Props) {
                 value={subscription?.topic.displayName ?? '—'}
             />
 
-            <div>
+            <div className="col-span-2 sm:col-span-3 lg:col-span-1">
                 <p className="mb-1 font-mono text-[10px] uppercase tracking-[1.4px] text-dim">
                     VOLUME · 24H
                 </p>

--- a/packages/emitsignal-website/src/components/app/inbox/inbox-layout.test.tsx
+++ b/packages/emitsignal-website/src/components/app/inbox/inbox-layout.test.tsx
@@ -18,6 +18,7 @@ vi.mock('#/ctx/feed-style', () => ({ useFeedStyle: () => ({ feedStyle: 'comfy' }
 vi.mock('#/ctx/subscriptions', () => ({ useSubscriptions: () => ({ subscribe: vi.fn() }) }));
 vi.mock('#/ctx/toast', () => ({ useToast: () => vi.fn() }));
 vi.mock('#/ctx/debug-sections', () => ({ useDebugSections: () => ({ sections: {} }) }));
+vi.mock('#/ctx/sidebar', () => ({ useSidebar: () => ({ setMobileOpen: vi.fn() }) }));
 
 describe('InboxLayout first load', () => {
     beforeEach(() => {

--- a/packages/emitsignal-website/src/components/app/inbox/inbox-layout.tsx
+++ b/packages/emitsignal-website/src/components/app/inbox/inbox-layout.tsx
@@ -63,7 +63,9 @@ export function InboxLayout({ selectedId }: { selectedId: null | string }) {
                     onSelect={handleSelect}
                     selectedId={selectedId}
                 />
-                <InboxPreview loading={loading} message={selected} selectedId={selectedId} />
+                <div className="hidden min-w-0 flex-1 md:flex">
+                    <InboxPreview loading={loading} message={selected} selectedId={selectedId} />
+                </div>
             </div>
         </>
     );
@@ -160,7 +162,7 @@ function NotificationList({
 
     if (loading) {
         return (
-            <div className="w-[380px] shrink-0 overflow-hidden border-r border-line">
+            <div className="w-full shrink-0 overflow-hidden md:w-[300px] md:border-r md:border-line lg:w-[380px]">
                 <SkeletonMessageList />
             </div>
         );
@@ -168,14 +170,14 @@ function NotificationList({
 
     if (messages.length === 0) {
         return (
-            <div className="flex w-[380px] shrink-0 items-center justify-center border-r border-line p-4 font-mono text-[12px] text-dim">
+            <div className="flex w-full shrink-0 items-center justify-center p-4 font-mono text-[12px] text-dim md:w-[300px] md:border-r md:border-line lg:w-[380px]">
                 no messages yet · subscribe to a channel
             </div>
         );
     }
 
     return (
-        <div className="w-[380px] shrink-0 overflow-auto border-r border-line">
+        <div className="w-full shrink-0 overflow-auto md:w-[300px] md:border-r md:border-line lg:w-[380px]">
             {feedStyle === 'comfy' && (
                 <ComfyList messages={messages} onSelect={onSelect} selectedId={selectedId} />
             )}
@@ -293,7 +295,7 @@ function SubscribeButton() {
         <div className="flex items-center gap-1.5">
             <input
                 autoFocus
-                className="w-[180px] rounded-md border border-line bg-elev px-2.5 py-1.5 font-mono text-[12px] text-fg outline-none placeholder:text-dim"
+                className="w-[130px] rounded-md border border-line bg-elev px-2.5 py-1.5 font-mono text-[12px] text-fg outline-none placeholder:text-dim sm:w-[180px]"
                 maxLength={TOPIC_NAME_MAX_LENGTH}
                 onChange={(event) => setTopic(event.target.value)}
                 onKeyDown={(event) => {

--- a/packages/emitsignal-website/src/components/app/publish/compose-form.tsx
+++ b/packages/emitsignal-website/src/components/app/publish/compose-form.tsx
@@ -20,7 +20,7 @@ const SELECTED_PRIORITY = 4;
 
 export function ComposeForm() {
     return (
-        <div className="min-w-0 flex-1 overflow-auto border-r border-line p-7">
+        <div className="min-w-0 flex-1 overflow-auto p-4 md:p-7 lg:border-r lg:border-line">
             <SubHeading>topic</SubHeading>
             <div className="mb-5.5 flex items-center rounded-lg border border-accent/40 bg-elev px-3.5 py-2.5">
                 <span className="font-mono text-[13px] text-dim">emitsignal.com/</span>

--- a/packages/emitsignal-website/src/components/app/publish/preview-column.tsx
+++ b/packages/emitsignal-website/src/components/app/publish/preview-column.tsx
@@ -25,7 +25,7 @@ export function PreviewColumn({ body, priority, tags, title, topicName }: Props)
         : 'fill in topic to see curl example';
 
     return (
-        <aside className="w-[380px] shrink-0 overflow-auto bg-deep p-6">
+        <aside className="hidden w-[380px] shrink-0 overflow-auto bg-deep p-6 lg:block">
             <SubHeading>PREVIEW · android push</SubHeading>
             <div className="mb-5 rounded-2xl border border-line bg-elev p-3.5">
                 <div className="mb-2 flex items-center gap-2 font-mono text-[10px] text-dim">

--- a/packages/emitsignal-website/src/components/app/sidebar.tsx
+++ b/packages/emitsignal-website/src/components/app/sidebar.tsx
@@ -10,6 +10,8 @@ import {
     Lock,
     LogOut,
     type LucideIcon,
+    PanelLeftClose,
+    PanelLeftOpen,
     Plus,
     Settings,
     Terminal,
@@ -22,10 +24,12 @@ import { Avatar } from '#/components/ui/avatar';
 import { Dot } from '#/components/ui/dot';
 import { Logo } from '#/components/ui/logo';
 import { useSession } from '#/ctx/session';
+import { useSidebar } from '#/ctx/sidebar';
 import { useSubscriptions } from '#/ctx/subscriptions';
 import { useToast } from '#/ctx/toast';
 import { useBilling } from '#/hooks/use-billing';
 import { apiErrorMessage } from '#/lib/api-error';
+import { cn } from '#/lib/cn';
 import { hashTopicLevel } from '#/lib/priority';
 
 interface NavItem {
@@ -44,6 +48,7 @@ const ACTIVE =
 export function Sidebar() {
     const { billing } = useBilling();
     const { signOut, user } = useSession();
+    const { collapsed, mobileOpen, setMobileOpen, toggleCollapsed } = useSidebar();
     const { subscribe, subscriptions } = useSubscriptions();
     const navigate = useNavigate();
     const toast = useToast();
@@ -55,6 +60,10 @@ export function Sidebar() {
     const [subscribing, setSubscribing] = useState(false);
 
     const channelCount = subscriptions.length;
+
+    // The drawer always renders at full width, so `collapsed` may only ever
+    // hide things from `md` up — never on mobile.
+    const railHidden = collapsed ? 'md:hidden' : '';
 
     const NAV: NavItem[] = [
         { exact: true, icon: Bell, label: 'Inbox', to: '/app/inbox' },
@@ -96,107 +105,160 @@ export function Sidebar() {
     };
 
     return (
-        <aside className="flex w-[250px] shrink-0 flex-col gap-0.5 border-r border-line p-2.5 pt-4">
-            <div className="px-2.5 pb-3.5 pt-1">
-                <Logo pulse size={13} />
-            </div>
-
-            {NAV.map((item) => (
-                <SidebarLink item={item} key={item.to} />
-            ))}
-
-            <div className="mt-4.5 flex items-center px-2.5 pb-1.5">
-                <p className="font-mono text-[9.5px] tracking-[1.5px] text-dim">CHANNELS</p>
-                {adding ? (
-                    <div className="ml-auto flex items-center gap-1">
-                        <input
-                            autoFocus
-                            className="w-[90px] rounded border border-line bg-elev px-1.5 py-0.5 font-mono text-[10px] text-fg outline-none placeholder:text-dim"
-                            maxLength={TOPIC_NAME_MAX_LENGTH}
-                            onChange={(event) => setNewTopic(event.target.value)}
-                            onKeyDown={(event) => {
-                                if (event.key === 'Enter') handleSubscribe();
-                                if (event.key === 'Escape') setAdding(false);
-                            }}
-                            placeholder="topic/name"
-                            value={newTopic}
-                        />
-                        <button
-                            className="font-mono text-[10px] text-accent hover:text-fg disabled:opacity-50"
-                            disabled={!newTopic.trim() || subscribing}
-                            onClick={handleSubscribe}
-                        >
-                            {subscribing ? '…' : 'ok'}
-                        </button>
-                    </div>
-                ) : (
-                    <button
-                        className="ml-auto flex h-4 w-4 items-center justify-center rounded text-dim hover:text-fg"
-                        onClick={() => setAdding(true)}
-                    >
-                        <Plus size={12} />
-                    </button>
-                )}
-            </div>
-
-            {subscriptions.length === 0 && (
-                <p className="px-2.5 py-1 font-mono text-[10px] text-dim">no subscriptions yet</p>
+        <>
+            {mobileOpen && (
+                <div
+                    className="fixed inset-0 z-40 md:hidden"
+                    onClick={() => setMobileOpen(false)}
+                    style={{ backdropFilter: 'blur(3px)', background: 'var(--color-scrim)' }}
+                />
             )}
 
-            {subscriptions.slice(0, 6).map((subscription) => (
-                <Link
-                    className="flex items-center gap-2 rounded-md px-2.5 py-1 font-mono text-[11.5px] text-muted no-underline hover:bg-elev/60"
-                    key={subscription.id}
-                    search={{ priority: undefined, tags: [], topic: subscription.topic.name }}
-                    to="/app/channels"
-                >
-                    <Dot level={hashTopicLevel(subscription.topic.name)} size={5} />
-
-                    <span className="flex-1 truncate">{subscription.topic.name}</span>
-
-                    {subscription.topic.accessMode !== 'public' && (
-                        <Lock className="flex-shrink-0 text-dim" size={12} />
+            <aside
+                aria-label="Primary"
+                className={cn(
+                    'fixed inset-y-0 left-0 z-50 flex w-[250px] shrink-0 flex-col gap-0.5 overflow-y-auto border-r border-line bg-bg p-2.5 pt-4 transition-transform duration-200',
+                    'md:static md:z-auto md:translate-x-0 md:transition-[width]',
+                    mobileOpen ? 'translate-x-0' : '-translate-x-full',
+                    collapsed && 'md:w-[56px] md:px-1.5',
+                )}
+            >
+                <div
+                    className={cn(
+                        'flex items-center gap-2 px-2.5 pb-3.5 pt-1',
+                        collapsed && 'md:flex-col md:gap-2.5 md:px-0',
                     )}
-                </Link>
-            ))}
+                >
+                    <Logo labelClassName={railHidden} pulse size={13} />
 
-            <div className="mt-auto">
-                <div className="px-2.5 pb-2 pt-2.5">
-                    <ThemeToggle />
+                    <button
+                        aria-expanded={!collapsed}
+                        aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+                        className={cn(
+                            'ml-auto hidden h-6 w-6 cursor-pointer items-center justify-center rounded text-dim hover:bg-elev hover:text-fg md:flex',
+                            collapsed && 'md:ml-0',
+                        )}
+                        onClick={toggleCollapsed}
+                        title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+                        type="button"
+                    >
+                        {collapsed ? <PanelLeftOpen size={14} /> : <PanelLeftClose size={14} />}
+                    </button>
                 </div>
 
-                {user && (
-                    <div className="flex items-center gap-2.5 border-t border-line p-2.5">
-                        <Avatar
-                            name={user.name || user.email}
-                            rounded={100}
-                            size={30}
-                            src={user.image}
-                        />
+                {NAV.map((item) => (
+                    <SidebarLink collapsed={collapsed} item={item} key={item.to} />
+                ))}
 
-                        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-                            <div className="flex items-center gap-1.5">
-                                <span className="truncate text-[12.5px] font-medium text-fg">
-                                    {user.name || user.email.split('@')[0]}
-                                </span>
+                <div className={cn('mt-4.5 flex items-center px-2.5 pb-1.5', railHidden)}>
+                    <p className="font-mono text-[9.5px] tracking-[1.5px] text-dim">CHANNELS</p>
+                    {adding ? (
+                        <div className="ml-auto flex items-center gap-1">
+                            <input
+                                autoFocus
+                                className="w-[90px] rounded border border-line bg-elev px-1.5 py-0.5 font-mono text-[10px] text-fg outline-none placeholder:text-dim"
+                                maxLength={TOPIC_NAME_MAX_LENGTH}
+                                onChange={(event) => setNewTopic(event.target.value)}
+                                onKeyDown={(event) => {
+                                    if (event.key === 'Enter') handleSubscribe();
+                                    if (event.key === 'Escape') setAdding(false);
+                                }}
+                                placeholder="topic/name"
+                                value={newTopic}
+                            />
+                            <button
+                                className="font-mono text-[10px] text-accent hover:text-fg disabled:opacity-50"
+                                disabled={!newTopic.trim() || subscribing}
+                                onClick={handleSubscribe}
+                            >
+                                {subscribing ? '…' : 'ok'}
+                            </button>
+                        </div>
+                    ) : (
+                        <button
+                            aria-label="Subscribe to a channel"
+                            className="ml-auto flex h-4 w-4 items-center justify-center rounded text-dim hover:text-fg"
+                            onClick={() => setAdding(true)}
+                            title="Subscribe to a channel"
+                        >
+                            <Plus size={12} />
+                        </button>
+                    )}
+                </div>
 
-                                {plan && <PlanPill plan={plan} />}
+                {subscriptions.length === 0 && (
+                    <p className={cn('px-2.5 py-1 font-mono text-[10px] text-dim', railHidden)}>
+                        no subscriptions yet
+                    </p>
+                )}
+
+                {subscriptions.slice(0, 6).map((subscription) => (
+                    <Link
+                        className={cn(
+                            'flex items-center gap-2 rounded-md px-2.5 py-1 font-mono text-[11.5px] text-muted no-underline hover:bg-elev/60',
+                            railHidden,
+                        )}
+                        key={subscription.id}
+                        search={{ priority: undefined, tags: [], topic: subscription.topic.name }}
+                        to="/app/channels"
+                    >
+                        <Dot level={hashTopicLevel(subscription.topic.name)} size={5} />
+
+                        <span className="flex-1 truncate">{subscription.topic.name}</span>
+
+                        {subscription.topic.accessMode !== 'public' && (
+                            <Lock className="flex-shrink-0 text-dim" size={12} />
+                        )}
+                    </Link>
+                ))}
+
+                <div className="mt-auto">
+                    <div className={cn('px-2.5 pb-2 pt-2.5', collapsed && 'md:px-0')}>
+                        <ThemeToggle rail={collapsed} />
+                    </div>
+
+                    {user && (
+                        <div
+                            className={cn(
+                                'flex items-center gap-2.5 border-t border-line p-2.5',
+                                collapsed && 'md:flex-col md:gap-2 md:px-0',
+                            )}
+                        >
+                            <Avatar
+                                name={user.name || user.email}
+                                rounded={100}
+                                size={30}
+                                src={user.image}
+                            />
+
+                            <div className={cn('flex min-w-0 flex-1 flex-col gap-0.5', railHidden)}>
+                                <div className="flex items-center gap-1.5">
+                                    <span className="truncate text-[12.5px] font-medium text-fg">
+                                        {user.name || user.email.split('@')[0]}
+                                    </span>
+
+                                    {plan && <PlanPill plan={plan} />}
+                                </div>
+
+                                <span className="truncate text-[11px] text-dim">{user.email}</span>
                             </div>
 
-                            <span className="truncate text-[11px] text-dim">{user.email}</span>
+                            <button
+                                aria-label="Sign out"
+                                className={cn(
+                                    'cursor-pointer self-start rounded p-1 text-dim hover:bg-elev hover:text-fg',
+                                    collapsed && 'md:self-auto',
+                                )}
+                                onClick={handleSignOut}
+                                title="Sign out"
+                            >
+                                <LogOut size={14} />
+                            </button>
                         </div>
-
-                        <button
-                            className="cursor-pointer self-start rounded p-1 text-dim hover:bg-elev hover:text-fg"
-                            onClick={handleSignOut}
-                            title="Sign out"
-                        >
-                            <LogOut size={14} />
-                        </button>
-                    </div>
-                )}
-            </div>
-        </aside>
+                    )}
+                </div>
+            </aside>
+        </>
     );
 }
 
@@ -216,25 +278,33 @@ function PlanPill({ plan }: { plan: PlanName }) {
     );
 }
 
-function SidebarLink({ item }: { item: NavItem }) {
+function SidebarLink({ collapsed, item }: { collapsed: boolean; item: NavItem }) {
     const Icon = item.icon;
+
+    const railHidden = collapsed ? 'md:hidden' : '';
+    const railCentered = collapsed ? 'md:justify-center md:px-0' : '';
 
     return (
         <Link
             activeOptions={item.exact ? { exact: true } : undefined}
-            activeProps={{ className: ACTIVE }}
-            className={INACTIVE}
+            activeProps={{ className: cn(ACTIVE, railCentered) }}
+            className={cn(INACTIVE, railCentered)}
+            title={collapsed ? item.label : undefined}
             to={item.to as never}
         >
             {({ isActive }) => (
                 <>
-                    <Icon size={14} />
+                    <Icon className="shrink-0" size={14} />
 
-                    <span className="flex-1">{item.label}</span>
+                    <span className={cn('flex-1', railHidden)}>{item.label}</span>
 
                     {item.badge !== undefined && item.badge > 0 && (
                         <span
-                            className={`font-mono text-[10px] ${isActive ? 'text-accent' : 'text-dim'}`}
+                            className={cn(
+                                'font-mono text-[10px]',
+                                isActive ? 'text-accent' : 'text-dim',
+                                railHidden,
+                            )}
                         >
                             {item.badge}
                         </span>

--- a/packages/emitsignal-website/src/components/app/theme-toggle.tsx
+++ b/packages/emitsignal-website/src/components/app/theme-toggle.tsx
@@ -3,6 +3,7 @@ import { Monitor, Moon, Sun } from 'lucide-react';
 import type { ThemePreference } from '#/lib/theme';
 
 import { useTheme } from '#/ctx/theme';
+import { cn } from '#/lib/cn';
 
 const OPTIONS: { icon: typeof Sun; label: string; value: ThemePreference }[] = [
     { icon: Monitor, label: 'System theme', value: 'system' },
@@ -10,11 +11,17 @@ const OPTIONS: { icon: typeof Sun; label: string; value: ThemePreference }[] = [
     { icon: Moon, label: 'Dark theme', value: 'dark' },
 ];
 
-export function ThemeToggle() {
+/** `rail` stacks the options vertically at `md` and up, for the collapsed sidebar. */
+export function ThemeToggle({ rail = false }: { rail?: boolean }) {
     const { setTheme, theme } = useTheme();
 
     return (
-        <div className="flex items-center gap-0.5 rounded-md border border-line bg-elev/40 p-0.5">
+        <div
+            className={cn(
+                'flex items-center gap-0.5 rounded-md border border-line bg-elev/40 p-0.5',
+                rail && 'md:flex-col',
+            )}
+        >
             {OPTIONS.map(({ icon: Icon, label, value }) => {
                 const active = theme === value;
 
@@ -22,9 +29,11 @@ export function ThemeToggle() {
                     <button
                         aria-label={label}
                         aria-pressed={active}
-                        className={`flex h-6 flex-1 cursor-pointer items-center justify-center rounded ${
-                            active ? 'bg-accent/15 text-accent' : 'text-dim hover:text-fg'
-                        }`}
+                        className={cn(
+                            'flex h-6 flex-1 cursor-pointer items-center justify-center rounded',
+                            rail && 'md:w-full md:flex-none',
+                            active ? 'bg-accent/15 text-accent' : 'text-dim hover:text-fg',
+                        )}
                         key={value}
                         onClick={() => setTheme(value)}
                         title={label}

--- a/packages/emitsignal-website/src/components/app/toolbar.tsx
+++ b/packages/emitsignal-website/src/components/app/toolbar.tsx
@@ -1,5 +1,8 @@
 import type { ReactNode } from 'react';
 
+import { Menu } from 'lucide-react';
+
+import { useSidebar } from '#/ctx/sidebar';
 import { cn } from '#/lib/cn';
 
 interface ToolbarProps {
@@ -10,15 +13,30 @@ interface ToolbarProps {
 }
 
 export function Toolbar({ actions, className, subtitle, title }: ToolbarProps) {
+    const { setMobileOpen } = useSidebar();
+
     return (
         <div
             className={cn(
-                'flex h-12 shrink-0 items-center gap-3 border-b border-line px-4.5',
+                'flex h-12 shrink-0 items-center gap-2 border-b border-line px-4.5 sm:gap-3',
                 className,
             )}
         >
-            <span className="text-[14px] font-semibold">{title}</span>
-            {subtitle && <span className="font-mono text-[11px] text-dim">{subtitle}</span>}
+            <button
+                aria-label="Open navigation"
+                className="-ml-1.5 flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded text-dim hover:bg-elev hover:text-fg md:hidden"
+                onClick={() => setMobileOpen(true)}
+                type="button"
+            >
+                <Menu size={16} />
+            </button>
+
+            <span className="min-w-0 truncate text-[14px] font-semibold">{title}</span>
+            {subtitle && (
+                <span className="hidden shrink-0 font-mono text-[11px] text-dim sm:inline">
+                    {subtitle}
+                </span>
+            )}
             <div className="flex-1" />
             {actions}
         </div>

--- a/packages/emitsignal-website/src/components/app/webhooks/deliveries-log.tsx
+++ b/packages/emitsignal-website/src/components/app/webhooks/deliveries-log.tsx
@@ -115,7 +115,7 @@ export function DeliveriesLog({ webhookId }: { webhookId: string }) {
     return (
         <div className="flex min-h-0 flex-1">
             {/* list pane */}
-            <div className="w-[440px] shrink-0 overflow-auto border-r border-line">
+            <div className="hidden w-[440px] shrink-0 overflow-auto border-r border-line lg:block">
                 {deliveries.map((delivery) => {
                     const isActive = active?.id === delivery.id;
                     const summary = getSummary(delivery);

--- a/packages/emitsignal-website/src/components/ui/logo.tsx
+++ b/packages/emitsignal-website/src/components/ui/logo.tsx
@@ -3,11 +3,18 @@ import { cn } from '#/lib/cn';
 interface LogoProps {
     className?: string;
     label?: string;
+    labelClassName?: string;
     pulse?: boolean;
     size?: number;
 }
 
-export function Logo({ className, label = 'EmitSignal', pulse = false, size = 14 }: LogoProps) {
+export function Logo({
+    className,
+    label = 'EmitSignal',
+    labelClassName,
+    pulse = false,
+    size = 14,
+}: LogoProps) {
     return (
         <span
             className={cn('inline-flex items-center font-mono font-medium text-fg', className)}
@@ -24,7 +31,7 @@ export function Logo({ className, label = 'EmitSignal', pulse = false, size = 14
                     width: size * 0.55,
                 }}
             />
-            <span>{label}</span>
+            <span className={labelClassName}>{label}</span>
         </span>
     );
 }

--- a/packages/emitsignal-website/src/ctx/sidebar.test.tsx
+++ b/packages/emitsignal-website/src/ctx/sidebar.test.tsx
@@ -1,0 +1,90 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { SidebarState } from '#/lib/sidebar';
+
+import { SidebarProvider, useSidebar } from '#/ctx/sidebar';
+
+let href = '/app/inbox';
+
+vi.mock('@tanstack/react-router', () => ({
+    useRouterState: ({ select }: { select: (state: unknown) => unknown }) =>
+        select({ location: { href } }),
+}));
+
+function Probe() {
+    const { collapsed, mobileOpen, setMobileOpen, toggleCollapsed } = useSidebar();
+
+    return (
+        <>
+            <span data-testid="collapsed">{String(collapsed)}</span>
+            <span data-testid="mobile-open">{String(mobileOpen)}</span>
+            <button onClick={toggleCollapsed}>toggle</button>
+            <button onClick={() => setMobileOpen(true)}>open</button>
+        </>
+    );
+}
+
+function renderProvider(initialState: SidebarState = 'expanded') {
+    return render(
+        <SidebarProvider initialState={initialState}>
+            <Probe />
+        </SidebarProvider>,
+    );
+}
+
+describe('SidebarProvider', () => {
+    beforeEach(() => {
+        cleanup();
+
+        href = '/app/inbox';
+        document.cookie = '@emitsignal/sidebar=; path=/; max-age=0';
+    });
+
+    test('seeds the collapsed state from the loader', () => {
+        renderProvider('collapsed');
+
+        expect(screen.getByTestId('collapsed').textContent).toBe('true');
+    });
+
+    test('toggling persists the choice to the preference cookie', () => {
+        renderProvider();
+
+        fireEvent.click(screen.getByText('toggle'));
+
+        expect(screen.getByTestId('collapsed').textContent).toBe('true');
+        expect(document.cookie).toContain('@emitsignal/sidebar=collapsed');
+
+        fireEvent.click(screen.getByText('toggle'));
+
+        expect(document.cookie).toContain('@emitsignal/sidebar=expanded');
+    });
+
+    test('closes the mobile drawer on navigation', () => {
+        const { rerender } = renderProvider();
+
+        fireEvent.click(screen.getByText('open'));
+        expect(screen.getByTestId('mobile-open').textContent).toBe('true');
+
+        href = '/app/channels';
+        rerender(
+            <SidebarProvider initialState="expanded">
+                <Probe />
+            </SidebarProvider>,
+        );
+
+        expect(screen.getByTestId('mobile-open').textContent).toBe('false');
+    });
+
+    test('closes the mobile drawer on Escape', () => {
+        renderProvider();
+
+        fireEvent.click(screen.getByText('open'));
+
+        act(() => {
+            window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+        });
+
+        expect(screen.getByTestId('mobile-open').textContent).toBe('false');
+    });
+});

--- a/packages/emitsignal-website/src/ctx/sidebar.tsx
+++ b/packages/emitsignal-website/src/ctx/sidebar.tsx
@@ -1,0 +1,82 @@
+import { useRouterState } from '@tanstack/react-router';
+import { createContext, type ReactNode, useContext, useEffect, useState } from 'react';
+
+import { setPreferenceCookie } from '#/lib/cookies';
+import { SIDEBAR_STATE_KEY, type SidebarState } from '#/lib/sidebar';
+
+interface SidebarContextValue {
+    /** Desktop-only: the sidebar is reduced to an icon rail. Persisted. */
+    collapsed: boolean;
+    /** Below `md` the sidebar is an overlay drawer. Never persisted. */
+    mobileOpen: boolean;
+    setMobileOpen: (open: boolean) => void;
+    toggleCollapsed: () => void;
+}
+
+const SidebarContext = createContext<SidebarContextValue | undefined>(undefined);
+
+/**
+ * Dashboard-scoped sidebar provider. The collapse preference is stored in one
+ * cookie so the server renders the rail at the right width, while the mobile
+ * drawer is transient — it closes on navigation and on Escape.
+ */
+export function SidebarProvider({
+    children,
+    initialState,
+}: {
+    children: ReactNode;
+    initialState: SidebarState;
+}) {
+    const [collapsed, setCollapsed] = useState(initialState === 'collapsed');
+    const [mobileOpen, setMobileOpen] = useState(false);
+
+    const href = useRouterState({ select: (state) => state.location.href });
+
+    useEffect(() => {
+        setMobileOpen(false);
+    }, [href]);
+
+    useEffect(() => {
+        if (!mobileOpen) {
+            return;
+        }
+
+        const handleKey = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                setMobileOpen(false);
+            }
+        };
+
+        window.addEventListener('keydown', handleKey);
+
+        return () => window.removeEventListener('keydown', handleKey);
+    }, [mobileOpen]);
+
+    const toggleCollapsed = () => {
+        setCollapsed((previous) => {
+            const next = !previous;
+
+            if (typeof document !== 'undefined') {
+                setPreferenceCookie(SIDEBAR_STATE_KEY, next ? 'collapsed' : 'expanded');
+            }
+
+            return next;
+        });
+    };
+
+    return (
+        <SidebarContext.Provider value={{ collapsed, mobileOpen, setMobileOpen, toggleCollapsed }}>
+            {children}
+        </SidebarContext.Provider>
+    );
+}
+
+export function useSidebar(): SidebarContextValue {
+    const context = useContext(SidebarContext);
+
+    if (context === undefined) {
+        throw new Error('useSidebar must be used within a SidebarProvider');
+    }
+
+    return context;
+}

--- a/packages/emitsignal-website/src/lib/sidebar.server.ts
+++ b/packages/emitsignal-website/src/lib/sidebar.server.ts
@@ -1,0 +1,14 @@
+import { getCookie } from '@tanstack/react-start/server';
+
+import { isSidebarState, SIDEBAR_STATE_KEY, type SidebarState } from '#/lib/sidebar';
+
+/**
+ * Reads the sidebar collapse preference from the request cookie so the rail
+ * renders collapsed on first paint instead of flashing wide. Defaults to
+ * 'expanded'.
+ */
+export function getSidebarState(): SidebarState {
+    const value = getCookie(SIDEBAR_STATE_KEY);
+
+    return isSidebarState(value) ? value : 'expanded';
+}

--- a/packages/emitsignal-website/src/lib/sidebar.ts
+++ b/packages/emitsignal-website/src/lib/sidebar.ts
@@ -1,0 +1,27 @@
+export type SidebarState = 'collapsed' | 'expanded';
+
+/** Cookie key holding the user's desktop sidebar collapse preference. */
+export const SIDEBAR_STATE_KEY = '@emitsignal/sidebar';
+
+export function isSidebarState(value: unknown): value is SidebarState {
+    return value === 'collapsed' || value === 'expanded';
+}
+
+/** Reads the sidebar cookie on the client (server uses sidebar.server.ts). */
+export function readSidebarStateFromDocument(): SidebarState {
+    if (typeof document === 'undefined') {
+        return 'expanded';
+    }
+
+    for (const part of document.cookie.split(';')) {
+        const [name, ...rest] = part.trim().split('=');
+
+        if (name === SIDEBAR_STATE_KEY) {
+            const value = rest.join('=');
+
+            return isSidebarState(value) ? value : 'expanded';
+        }
+    }
+
+    return 'expanded';
+}

--- a/packages/emitsignal-website/src/routes/app.tsx
+++ b/packages/emitsignal-website/src/routes/app.tsx
@@ -5,6 +5,7 @@ import { Sidebar } from '#/components/app/sidebar';
 import { DebugSectionsProvider } from '#/ctx/debug-sections';
 import { FeedStyleProvider } from '#/ctx/feed-style';
 import { RealtimeProvider } from '#/ctx/realtime';
+import { SidebarProvider } from '#/ctx/sidebar';
 import { SubscriptionsProvider } from '#/ctx/subscriptions';
 import { ThemeProvider, useTheme } from '#/ctx/theme';
 import { ToastProvider } from '#/ctx/toast';
@@ -16,6 +17,8 @@ import { readFeedStyleFromDocument } from '#/lib/feed-style';
 import { getFeedStyle } from '#/lib/feed-style.server';
 import { queryKeys, sessionQueryOptions } from '#/lib/query-client';
 import { buildSeoMeta } from '#/lib/seo';
+import { readSidebarStateFromDocument } from '#/lib/sidebar';
+import { getSidebarState } from '#/lib/sidebar.server';
 import { readThemePreferenceFromDocument } from '#/lib/theme';
 import { getThemePreference } from '#/lib/theme.server';
 
@@ -26,6 +29,10 @@ const resolveInitialTheme = createIsomorphicFn()
 const resolveInitialFeedStyle = createIsomorphicFn()
     .server(() => getFeedStyle())
     .client(() => readFeedStyleFromDocument());
+
+const resolveInitialSidebarState = createIsomorphicFn()
+    .server(() => getSidebarState())
+    .client(() => readSidebarStateFromDocument());
 
 const resolveInitialDebugSections = createIsomorphicFn()
     .server(() => getDebugSections())
@@ -83,6 +90,7 @@ export const Route = createFileRoute('/app')({
         return {
             debugSections: resolveInitialDebugSections(),
             feedStyle: resolveInitialFeedStyle(),
+            sidebar: resolveInitialSidebarState(),
             theme: resolveInitialTheme(),
         };
     },
@@ -105,19 +113,21 @@ function DashboardShell() {
 }
 
 function WebShell() {
-    const { debugSections, feedStyle, theme } = Route.useLoaderData();
+    const { debugSections, feedStyle, sidebar, theme } = Route.useLoaderData();
 
     return (
         <ThemeProvider initialTheme={theme}>
             <FeedStyleProvider initialFeedStyle={feedStyle}>
                 <DebugSectionsProvider initialSections={debugSections}>
-                    <SubscriptionsProvider>
-                        <ToastProvider>
-                            <RealtimeProvider>
-                                <DashboardShell />
-                            </RealtimeProvider>
-                        </ToastProvider>
-                    </SubscriptionsProvider>
+                    <SidebarProvider initialState={sidebar}>
+                        <SubscriptionsProvider>
+                            <ToastProvider>
+                                <RealtimeProvider>
+                                    <DashboardShell />
+                                </RealtimeProvider>
+                            </ToastProvider>
+                        </SubscriptionsProvider>
+                    </SidebarProvider>
                 </DebugSectionsProvider>
             </FeedStyleProvider>
         </ThemeProvider>

--- a/packages/emitsignal-website/src/routes/app/keys.tsx
+++ b/packages/emitsignal-website/src/routes/app/keys.tsx
@@ -116,7 +116,7 @@ function KeysPage() {
                 title="API Keys"
             />
 
-            <div className="flex-1 overflow-auto px-5.5 py-5">
+            <div className="flex-1 overflow-auto px-4 py-4 sm:px-5.5 sm:py-5">
                 <div className="mb-[10px] flex items-baseline justify-between">
                     <SubHeading>KEYS{loading ? '' : ` · ${apiKeys.length}`}</SubHeading>
                     <span className="font-mono text-[10.5px] text-dim">

--- a/packages/emitsignal-website/src/routes/app/publish.tsx
+++ b/packages/emitsignal-website/src/routes/app/publish.tsx
@@ -101,7 +101,7 @@ function ComposePage() {
             )}
 
             <div className="flex min-h-0 flex-1">
-                <div className="min-w-0 flex-1 overflow-auto border-r border-line p-7">
+                <div className="min-w-0 flex-1 overflow-auto p-4 md:p-7 lg:border-r lg:border-line">
                     <SubHeading>topic</SubHeading>
                     <div className="mb-5.5">
                         <input

--- a/packages/emitsignal-website/src/routes/app/webhooks/index.tsx
+++ b/packages/emitsignal-website/src/routes/app/webhooks/index.tsx
@@ -42,7 +42,7 @@ function WebhooksPage() {
                 title="Webhooks"
             />
 
-            <div className="flex-1 overflow-auto px-5.5 py-5">
+            <div className="flex-1 overflow-auto px-4 py-4 sm:px-5.5 sm:py-5">
                 <p className="mb-5 max-w-xl text-[13.5px] leading-relaxed text-muted">
                     Inbound endpoints. Point any service at a webhook URL. With a{' '}
                     <span className="text-accent">template</span> it&apos;s pretty-printed into a


### PR DESCRIPTION
The `/app` shell hard-coded a 250px sidebar next to the outlet, and every inner page added its own fixed-width column (inbox 380px, routing rail 320px, publish preview 380px, deliveries log 440px, plus a 5-column stats strip). Minimum usable width was roughly 900px; below that the toolbar title wrapped and the panes clipped. Nothing under `src/components/app/**` or `src/routes/app/**` used a breakpoint except `settings-shell.tsx`.

## Collapsible sidebar

- New cookie-backed preference following the existing `theme` / `feed-style` trio exactly: `lib/sidebar.ts`, `lib/sidebar.server.ts`, `ctx/sidebar.tsx`, resolved isomorphically in the `/app` loader. The server reads the cookie, so a collapsed rail renders at the right width on first paint with no flash.
- Desktop collapses 250px to a 56px icon rail. Labels, badges, the `CHANNELS` section and the channel rows drop out; the theme toggle stacks vertically and the user footer reduces to the avatar. Hover hints use the existing `title` / `aria-label` convention rather than a new tooltip primitive.
- Below `md` the sidebar becomes an overlay drawer with a scrim, reusing the `fixed inset-0` + `var(--color-scrim)` look already used by the dialogs. It closes on navigation, Escape, and scrim click. The drawer always renders at full width with labels intact, so `collapsed` only ever applies from `md` up.
- `Toolbar` consumes `useSidebar()` directly, so all nine `/app` routes get the hamburger with no prop threading.
- `Logo` gained `labelClassName` and `ThemeToggle` gained `rail` so both collapse via CSS rather than JS.

## Responsive panes

Secondary columns hide below their breakpoint and the primary column takes the full width — no list/detail routing changes. Routing rail, publish preview and deliveries log hide below `lg`; the inbox preview hides below `md`; the stats strip reflows 2 to 3 to 5 columns with the sparkline spanning.

## Verification

Checked in Chrome against the dev server while signed in:

- 1440px is unchanged apart from the new toggle; the rail renders as intended.
- Server-rendered HTML contains `md:w-[56px]` straight from the cookie, so there is no collapse flash on reload.
- 1024px and 390px both report `scrollWidth === innerWidth` (no horizontal overflow).
- All four drawer-close paths confirmed programmatically.

`bun test` 44/44 (4 new in `ctx/sidebar.test.tsx`), plus lint, format and typecheck clean.

## Notes

- The keys and webhooks tables were left alone. Both are `fr`-based grids that compress rather than clip, and wrapping them in `overflow-x-auto` would clip the kebab popovers that depend on the current `overflow-visible`. Making those scroll properly needs a `min-width` plus moving the menus to a portal — worth a separate pass.
- `components/app/publish/compose-form.tsx` turns out to be dead code (`publish.tsx` inlines its own compose column). It is touched here for consistency, but the change is inert.
