### PR TITLE
feat(website): surface owned topics and let owners release them

### DIFF
--- a/packages/emitsignal-website/src/components/app/channels/access-mode.tsx
+++ b/packages/emitsignal-website/src/components/app/channels/access-mode.tsx
@@ -1,0 +1,55 @@
+import { Book, Globe, Lock, type LucideIcon } from 'lucide-react';
+
+import type { AccessMode } from '#/lib/api';
+
+export const ACCESS_MODE_OPTIONS: {
+    description: string;
+    icon: LucideIcon;
+    label: string;
+    value: AccessMode;
+}[] = [
+    {
+        description: 'Anyone can read and publish',
+        icon: Globe,
+        label: 'Public',
+        value: 'public',
+    },
+    {
+        description: 'Anyone can read; only members can publish',
+        icon: Book,
+        label: 'Read-only',
+        value: 'readonly',
+    },
+    {
+        description: 'Only members can read and publish',
+        icon: Lock,
+        label: 'Private',
+        value: 'private',
+    },
+];
+
+/**
+ * Public is the default and carries no restriction, so it stays unmarked —
+ * only the modes that limit who can read or publish get a glyph.
+ */
+export function AccessModeIcon({
+    accessMode,
+    size = 12,
+}: {
+    accessMode: AccessMode;
+    size?: number;
+}) {
+    const option = ACCESS_MODE_OPTIONS.find((option) => option.value === accessMode);
+
+    if (!option || option.value === 'public') {
+        return null;
+    }
+
+    const Icon = option.icon;
+
+    return (
+        <span className="flex flex-shrink-0" title={`${option.label} · ${option.description}`}>
+            <Icon className="text-dim" size={size} />
+        </span>
+    );
+}

--- a/packages/emitsignal-website/src/components/app/channels/channel-actions-menu.tsx
+++ b/packages/emitsignal-website/src/components/app/channels/channel-actions-menu.tsx
@@ -1,47 +1,23 @@
 import { Link } from '@tanstack/react-router';
-import { Book, Check, Crown, Globe, Lock, LogOut, Send, Settings2 } from 'lucide-react';
+import { Check, Crown, LogOut, Plus, Send, Settings2 } from 'lucide-react';
 import { useState } from 'react';
 
-import type { AccessMode, ListenSince, Subscription } from '#/lib/api';
+import type { AccessMode, ListenSince, Subscription, Topic } from '#/lib/api';
 
+import { ACCESS_MODE_OPTIONS } from '#/components/app/channels/access-mode';
 import { useSubscriptions } from '#/ctx/subscriptions';
 import { useToast } from '#/ctx/toast';
 import { useBilling } from '#/hooks/use-billing';
-import { useClaimTopic, useUpdateTopic } from '#/hooks/use-topics';
+import { useClaimTopic, useReleaseTopic, useUpdateTopic } from '#/hooks/use-topics';
 import { api } from '#/lib/api';
 import { apiErrorMessage } from '#/lib/api-error';
 
 interface ChannelActionsMenuProps {
-    onUnsubscribed: () => void;
-    subscription: Subscription;
+    onRemoved: () => void;
+    subscription?: Subscription;
+    topic: Topic;
     topicName: string;
 }
-
-const ACCESS_MODE_OPTIONS: {
-    description: string;
-    icon: typeof Globe;
-    label: string;
-    value: AccessMode;
-}[] = [
-    {
-        description: 'Anyone can read and publish',
-        icon: Globe,
-        label: 'Public',
-        value: 'public',
-    },
-    {
-        description: 'Anyone can read; only members can publish',
-        icon: Book,
-        label: 'Read-only',
-        value: 'readonly',
-    },
-    {
-        description: 'Only members can read and publish',
-        icon: Lock,
-        label: 'Private',
-        value: 'private',
-    },
-];
 
 const LISTEN_SINCE_OPTIONS: {
     description: string;
@@ -73,20 +49,21 @@ interface ChannelSettingsDialogProps {
 }
 
 export function ChannelActionsMenu({
-    onUnsubscribed,
+    onRemoved,
     subscription,
+    topic,
     topicName,
 }: ChannelActionsMenuProps) {
     const [manageOpen, setManageOpen] = useState(false);
     const [menuOpen, setMenuOpen] = useState(false);
     const [settingsOpen, setSettingsOpen] = useState(false);
     const { billing } = useBilling();
-    const { unsubscribe, updateSubscription } = useSubscriptions();
+    const { subscribe, unsubscribe, updateSubscription } = useSubscriptions();
     const claimTopic = useClaimTopic();
     const toast = useToast();
 
-    const isClaimed = Boolean(subscription.topic.ownerId);
-    const isOwner = subscription.topic.isOwner ?? false;
+    const isClaimed = Boolean(topic.ownerId);
+    const isOwner = topic.isOwner ?? false;
     const isPaid = billing ? billing.plan !== 'free' : false;
 
     const handleClaim = async () => {
@@ -118,6 +95,18 @@ export function ChannelActionsMenu({
         }
     };
 
+    const handleSubscribe = async () => {
+        setMenuOpen(false);
+
+        try {
+            await subscribe(topicName);
+
+            toast(`Subscribed to ${topicName}`);
+        } catch (error) {
+            toast(apiErrorMessage(error, 'Failed to subscribe'), 'danger');
+        }
+    };
+
     const handleUnsubscribe = async () => {
         setMenuOpen(false);
 
@@ -125,7 +114,7 @@ export function ChannelActionsMenu({
             await unsubscribe(topicName);
 
             toast(`Unsubscribed from ${topicName}`, 'warn');
-            onUnsubscribed();
+            onRemoved();
         } catch (error) {
             toast(apiErrorMessage(error, 'Failed to unsubscribe'), 'danger');
         }
@@ -152,15 +141,17 @@ export function ChannelActionsMenu({
                             Send test notification
                         </MenuItem>
 
-                        <MenuItem
-                            icon={<Settings2 size={13} />}
-                            onClick={() => {
-                                setMenuOpen(false);
-                                setSettingsOpen(true);
-                            }}
-                        >
-                            Settings
-                        </MenuItem>
+                        {subscription && (
+                            <MenuItem
+                                icon={<Settings2 size={13} />}
+                                onClick={() => {
+                                    setMenuOpen(false);
+                                    setSettingsOpen(true);
+                                }}
+                            >
+                                Settings
+                            </MenuItem>
+                        )}
 
                         <div className="my-1 h-px bg-line" />
 
@@ -207,18 +198,27 @@ export function ChannelActionsMenu({
 
                         {(isOwner || !isClaimed) && <div className="my-1 h-px bg-line" />}
 
-                        <MenuItem
-                            danger
-                            icon={<LogOut size={13} />}
-                            onClick={() => void handleUnsubscribe()}
-                        >
-                            Unsubscribe
-                        </MenuItem>
+                        {subscription ? (
+                            <MenuItem
+                                danger
+                                icon={<LogOut size={13} />}
+                                onClick={() => void handleUnsubscribe()}
+                            >
+                                Unsubscribe
+                            </MenuItem>
+                        ) : (
+                            <MenuItem
+                                icon={<Plus size={13} />}
+                                onClick={() => void handleSubscribe()}
+                            >
+                                Subscribe
+                            </MenuItem>
+                        )}
                     </div>
                 </>
             )}
 
-            {settingsOpen && (
+            {settingsOpen && subscription && (
                 <ChannelSettingsDialog
                     onClose={() => setSettingsOpen(false)}
                     onFlash={toast}
@@ -232,7 +232,8 @@ export function ChannelActionsMenu({
                 <ManageTopicDialog
                     onClose={() => setManageOpen(false)}
                     onFlash={toast}
-                    subscription={subscription}
+                    onReleased={subscription ? undefined : onRemoved}
+                    topic={topic}
                     topicName={topicName}
                 />
             )}
@@ -399,20 +400,41 @@ function ChannelSettingsDialog({
 function ManageTopicDialog({
     onClose,
     onFlash,
-    subscription,
+    onReleased,
+    topic,
     topicName,
 }: {
     onClose: () => void;
     onFlash: (message: string, kind?: 'danger' | 'ok' | 'warn') => void;
-    subscription: Subscription;
+    onReleased?: () => void;
+    topic: Topic;
     topicName: string;
 }) {
-    const [description, setDescription] = useState(subscription.topic.description ?? '');
-    const [accessMode, setAccessMode] = useState<AccessMode>(
-        subscription.topic.accessMode ?? 'public',
-    );
+    const [description, setDescription] = useState(topic.description ?? '');
+    const [accessMode, setAccessMode] = useState<AccessMode>(topic.accessMode ?? 'public');
 
+    const releaseTopic = useReleaseTopic();
     const updateTopic = useUpdateTopic();
+
+    const handleRelease = async () => {
+        const confirmed = window.confirm(
+            `Release "${topicName}"? The name becomes claimable by anyone and its access resets to public. This frees one reserved-topic seat.`,
+        );
+
+        if (!confirmed) {
+            return;
+        }
+
+        try {
+            await releaseTopic.mutateAsync(topicName);
+
+            onFlash(`Released ${topicName}. You no longer own this topic`, 'warn');
+            onClose();
+            onReleased?.();
+        } catch (error) {
+            onFlash(apiErrorMessage(error, 'Failed to release topic'), 'danger');
+        }
+    };
 
     const handleSave = async () => {
         try {
@@ -517,6 +539,41 @@ function ManageTopicDialog({
                             placeholder="Describe what this topic is for"
                             value={description}
                         />
+                    </div>
+
+                    <div>
+                        <div className="mb-2 font-mono text-[10px] uppercase tracking-[1.2px] text-danger">
+                            Danger zone
+                        </div>
+
+                        <div
+                            className="flex flex-col gap-3 rounded-lg border px-3.5 py-3"
+                            style={{
+                                borderColor:
+                                    'color-mix(in srgb, var(--color-danger) 35%, transparent)',
+                            }}
+                        >
+                            <div>
+                                <div className="text-[13.5px] font-medium">Release ownership</div>
+                                <div className="mt-1 text-[11.5px] leading-snug text-dim">
+                                    Frees one reserved-topic seat. The name becomes claimable by
+                                    anyone, access resets to public and every member role is
+                                    removed. Messages and subscriptions are kept.
+                                </div>
+                            </div>
+
+                            <button
+                                className="self-start rounded-lg border px-3 py-1.5 text-[12.5px] font-semibold disabled:opacity-50"
+                                disabled={releaseTopic.isPending}
+                                onClick={() => void handleRelease()}
+                                style={{
+                                    borderColor: 'var(--color-danger)',
+                                    color: 'var(--color-danger)',
+                                }}
+                            >
+                                {releaseTopic.isPending ? 'Releasing...' : 'Release ownership'}
+                            </button>
+                        </div>
                     </div>
                 </div>
 

--- a/packages/emitsignal-website/src/components/app/sidebar.tsx
+++ b/packages/emitsignal-website/src/components/app/sidebar.tsx
@@ -5,9 +5,9 @@ import { TOPIC_NAME_MAX_LENGTH } from '@emitsignal/shared/topic';
 import { Link, useNavigate } from '@tanstack/react-router';
 import {
     Bell,
+    Crown,
     Key,
     LayoutGrid,
-    Lock,
     LogOut,
     type LucideIcon,
     PanelLeftClose,
@@ -19,6 +19,9 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 
+import type { Topic } from '#/lib/api';
+
+import { AccessModeIcon } from '#/components/app/channels/access-mode';
 import { ThemeToggle } from '#/components/app/theme-toggle';
 import { Avatar } from '#/components/ui/avatar';
 import { Dot } from '#/components/ui/dot';
@@ -28,6 +31,7 @@ import { useSidebar } from '#/ctx/sidebar';
 import { useSubscriptions } from '#/ctx/subscriptions';
 import { useToast } from '#/ctx/toast';
 import { useBilling } from '#/hooks/use-billing';
+import { useChannels } from '#/hooks/use-channels';
 import { apiErrorMessage } from '#/lib/api-error';
 import { cn } from '#/lib/cn';
 import { hashTopicLevel } from '#/lib/priority';
@@ -49,7 +53,8 @@ export function Sidebar() {
     const { billing } = useBilling();
     const { signOut, user } = useSession();
     const { collapsed, mobileOpen, setMobileOpen, toggleCollapsed } = useSidebar();
-    const { subscribe, subscriptions } = useSubscriptions();
+    const { owned, subscriptions } = useChannels();
+    const { subscribe } = useSubscriptions();
     const navigate = useNavigate();
     const toast = useToast();
 
@@ -59,7 +64,7 @@ export function Sidebar() {
     const [newTopic, setNewTopic] = useState('');
     const [subscribing, setSubscribing] = useState(false);
 
-    const channelCount = subscriptions.length;
+    const channelCount = subscriptions.length + owned.length;
 
     // The drawer always renders at full width, so `collapsed` may only ever
     // hide things from `md` up — never on mobile.
@@ -186,30 +191,33 @@ export function Sidebar() {
                     )}
                 </div>
 
-                {subscriptions.length === 0 && (
+                {channelCount === 0 && (
                     <p className={cn('px-2.5 py-1 font-mono text-[10px] text-dim', railHidden)}>
                         no subscriptions yet
                     </p>
                 )}
 
                 {subscriptions.slice(0, 6).map((subscription) => (
-                    <Link
+                    <ChannelLink
+                        key={subscription.id}
+                        railHidden={railHidden}
+                        topic={subscription.topic}
+                    />
+                ))}
+
+                {owned.length > 0 && (
+                    <p
                         className={cn(
-                            'flex items-center gap-2 rounded-md px-2.5 py-1 font-mono text-[11.5px] text-muted no-underline hover:bg-elev/60',
+                            'mt-3 px-2.5 pb-1.5 pt-1 font-mono text-[9.5px] tracking-[1.5px] text-dim',
                             railHidden,
                         )}
-                        key={subscription.id}
-                        search={{ priority: undefined, tags: [], topic: subscription.topic.name }}
-                        to="/app/channels"
                     >
-                        <Dot level={hashTopicLevel(subscription.topic.name)} size={5} />
+                        NOT SUBSCRIBED
+                    </p>
+                )}
 
-                        <span className="flex-1 truncate">{subscription.topic.name}</span>
-
-                        {subscription.topic.accessMode !== 'public' && (
-                            <Lock className="flex-shrink-0 text-dim" size={12} />
-                        )}
-                    </Link>
+                {owned.slice(0, 6).map((topic) => (
+                    <ChannelLink key={topic.id} railHidden={railHidden} topic={topic} />
                 ))}
 
                 <div className="mt-auto">
@@ -259,6 +267,31 @@ export function Sidebar() {
                 </div>
             </aside>
         </>
+    );
+}
+
+function ChannelLink({ railHidden, topic }: { railHidden: string; topic: Topic }) {
+    return (
+        <Link
+            className={cn(
+                'flex items-center gap-2 rounded-md px-2.5 py-1 font-mono text-[11.5px] text-muted no-underline hover:bg-elev/60',
+                railHidden,
+            )}
+            search={{ priority: undefined, tags: [], topic: topic.name }}
+            to="/app/channels"
+        >
+            <Dot level={hashTopicLevel(topic.name)} size={5} />
+
+            <span className="flex-1 truncate">{topic.name}</span>
+
+            {topic.isOwner && (
+                <span className="flex flex-shrink-0" title="You own this topic">
+                    <Crown className="text-dim" size={12} />
+                </span>
+            )}
+
+            <AccessModeIcon accessMode={topic.accessMode} />
+        </Link>
     );
 }
 

--- a/packages/emitsignal-website/src/hooks/use-channels.test.ts
+++ b/packages/emitsignal-website/src/hooks/use-channels.test.ts
@@ -1,0 +1,57 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import type { Subscription, Topic } from '#/lib/api';
+
+import { useChannels } from '#/hooks/use-channels';
+
+const subscriptionsMock = vi.hoisted(() => ({
+    value: { loading: false, subscriptions: [] as Subscription[] },
+}));
+const topicsMock = vi.hoisted(() => ({ value: { loading: false, topics: [] as Topic[] } }));
+
+vi.mock('#/ctx/subscriptions', () => ({ useSubscriptions: () => subscriptionsMock.value }));
+vi.mock('#/hooks/use-topics', () => ({ useTopics: () => topicsMock.value }));
+
+function subscription(name: string): Subscription {
+    return {
+        createdAt: 0,
+        id: `sub-${name}`,
+        pushEnabled: true,
+        settings: { listenSince: 'subscription_date' },
+        topic: topic(name),
+    };
+}
+
+function topic(name: string): Topic {
+    return {
+        accessMode: 'public',
+        createdAt: 0,
+        displayName: name,
+        id: `topic-${name}`,
+        isOwner: true,
+        name,
+        ownerId: 'user-1',
+    };
+}
+
+describe('useChannels', () => {
+    test('lists owned topics you are not subscribed to', () => {
+        subscriptionsMock.value = { loading: false, subscriptions: [subscription('alerts')] };
+        topicsMock.value = { loading: false, topics: [topic('alerts'), topic('status-page')] };
+
+        const { result } = renderHook(() => useChannels());
+
+        expect(result.current.subscriptions.map((item) => item.topic.name)).toEqual(['alerts']);
+        expect(result.current.owned.map((item) => item.name)).toEqual(['status-page']);
+    });
+
+    test('reports loading while either source is pending', () => {
+        subscriptionsMock.value = { loading: false, subscriptions: [] };
+        topicsMock.value = { loading: true, topics: [] };
+
+        const { result } = renderHook(() => useChannels());
+
+        expect(result.current.loading).toBe(true);
+    });
+});

--- a/packages/emitsignal-website/src/hooks/use-channels.ts
+++ b/packages/emitsignal-website/src/hooks/use-channels.ts
@@ -1,0 +1,37 @@
+import { useMemo } from 'react';
+
+import type { Subscription, Topic } from '#/lib/api';
+
+import { useSubscriptions } from '#/ctx/subscriptions';
+import { useTopics } from '#/hooks/use-topics';
+
+interface ChannelsResult {
+    loading: boolean;
+    owned: Topic[];
+    subscriptions: Subscription[];
+}
+
+/**
+ * The dashboard's channel list is the union of two independent queries:
+ * `GET /subscriptions` and `GET /topics` (owner-scoped). A topic you own *and*
+ * subscribe to is only ever reported as a subscription — the subscription row
+ * already carries `topic.isOwner`, so listing it twice would be redundant.
+ */
+export function useChannels(): ChannelsResult {
+    const { loading: subscriptionsLoading, subscriptions } = useSubscriptions();
+    const { loading: topicsLoading, topics } = useTopics();
+
+    const owned = useMemo(() => {
+        const subscribedNames = new Set(
+            subscriptions.map((subscription) => subscription.topic.name),
+        );
+
+        return topics.filter((topic) => !subscribedNames.has(topic.name));
+    }, [subscriptions, topics]);
+
+    return {
+        loading: subscriptionsLoading || topicsLoading,
+        owned,
+        subscriptions,
+    };
+}

--- a/packages/emitsignal-website/src/hooks/use-topics.ts
+++ b/packages/emitsignal-website/src/hooks/use-topics.ts
@@ -15,6 +15,15 @@ export function useClaimTopic() {
     });
 }
 
+export function useReleaseTopic() {
+    const invalidate = useTopicOwnershipInvalidation();
+
+    return useMutation({
+        mutationFn: (name: string) => api.releaseTopic(name),
+        onSuccess: invalidate,
+    });
+}
+
 export function useTopics(query?: string) {
     const { data, error, isPending } = useQuery({
         // Keep the previous results visible while typing so the list doesn't flash.
@@ -45,9 +54,6 @@ export function useUpdateTopic() {
     });
 }
 
-// Claiming or re-configuring a topic changes ownership/access, which is
-// reflected in the subscriptions list (topic.isOwner/accessMode) and the
-// owner's "my topics" list, so both are invalidated on success.
 function useTopicOwnershipInvalidation() {
     const queryClient = useQueryClient();
 
@@ -55,6 +61,7 @@ function useTopicOwnershipInvalidation() {
         await Promise.all([
             queryClient.invalidateQueries({ queryKey: ['subscriptions'] }),
             queryClient.invalidateQueries({ queryKey: ['topics'] }),
+            queryClient.invalidateQueries({ queryKey: queryKeys.billing }),
         ]);
     };
 }

--- a/packages/emitsignal-website/src/routes/app/channels.tsx
+++ b/packages/emitsignal-website/src/routes/app/channels.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { Crown } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import { ChannelActionsMenu } from '#/components/app/channels/channel-actions-menu';
@@ -8,7 +9,7 @@ import { StatsStrip } from '#/components/app/channels/stats-strip';
 import { Toolbar } from '#/components/app/toolbar';
 import { Dot } from '#/components/ui/dot';
 import { Skeleton } from '#/components/ui/skeleton';
-import { useSubscriptions } from '#/ctx/subscriptions';
+import { useChannels } from '#/hooks/use-channels';
 import { useTopicMessages, useTopicMetrics } from '#/hooks/use-emit-signal';
 
 export const Route = createFileRoute('/app/channels')({
@@ -40,12 +41,40 @@ export const Route = createFileRoute('/app/channels')({
     },
 });
 
+function ChannelPill({
+    name,
+    onSelect,
+    owned,
+    selected,
+}: {
+    name: string;
+    onSelect: () => void;
+    owned?: boolean;
+    selected: boolean;
+}) {
+    return (
+        <button
+            className={`flex items-center gap-1.5 rounded-full px-3 py-1 font-mono text-[11.5px] ${
+                selected ? 'bg-accent/10 text-accent' : 'text-muted hover:bg-elev'
+            }`}
+            onClick={onSelect}
+        >
+            {owned && (
+                <span className="flex flex-shrink-0" title="You own this topic">
+                    <Crown className={selected ? 'text-accent' : 'text-dim'} size={11} />
+                </span>
+            )}
+            {name}
+        </button>
+    );
+}
+
 function ChannelView() {
     const { priority, tags, topic } = Route.useSearch();
-    const { loading: subscriptionsLoading, subscriptions } = useSubscriptions();
+    const { loading: channelsLoading, owned, subscriptions } = useChannels();
     const navigate = useNavigate();
 
-    const selectedTopic = topic || subscriptions[0]?.topic.name || '';
+    const selectedTopic = topic || subscriptions[0]?.topic.name || owned[0]?.name || '';
     const filters = { minPriority: priority, tags };
 
     const { addMessage, loading: metricsLoading, metrics } = useTopicMetrics(selectedTopic || null);
@@ -79,20 +108,23 @@ function ChannelView() {
     const matchingSubscriptions = subscriptions.filter(
         (subscription) => subscription.topic.name === selectedTopic,
     );
+    const selectedTopicRecord =
+        subscription?.topic ?? owned.find((topic) => topic.name === selectedTopic);
 
     return (
         <>
             <Toolbar
                 actions={
-                    subscription && (
+                    selectedTopicRecord && (
                         <ChannelActionsMenu
-                            onUnsubscribed={() =>
+                            onRemoved={() =>
                                 navigate({
                                     search: { priority, tags, topic: '' },
                                     to: '/app/channels',
                                 })
                             }
                             subscription={subscription}
+                            topic={selectedTopicRecord}
                             topicName={selectedTopic}
                         />
                     )
@@ -103,44 +135,64 @@ function ChannelView() {
                         <span className="font-normal text-dim">Channels /</span>
                         <span>{selectedTopic || 'select a channel'}</span>
                         {subscription && <Dot level={1} />}
+                        {selectedTopicRecord && !subscription && (
+                            <span className="font-mono text-[11px] font-normal text-dim">
+                                not subscribed
+                            </span>
+                        )}
                     </span>
                 }
             />
 
-            <div className="flex flex-wrap gap-4 border-b border-line px-5 py-3">
-                {subscriptionsLoading &&
+            <div className="flex flex-wrap items-center gap-4 border-b border-line px-5 py-3">
+                {channelsLoading &&
                     [72, 96, 64].map((width) => (
                         <Skeleton height={24} key={width} radius={12} width={width} />
                     ))}
 
-                {!subscriptionsLoading && subscriptions.length === 0 && (
+                {!channelsLoading && subscriptions.length === 0 && owned.length === 0 && (
                     <span className="px-1 font-mono text-[11.5px] text-dim">
                         no channels yet · subscribe to one from the inbox
                     </span>
                 )}
 
                 {subscriptions.map((subscription) => (
-                    <button
-                        className={`rounded-full px-3 py-1 font-mono text-[11.5px] ${
-                            subscription.topic.name === selectedTopic
-                                ? 'bg-accent/10 text-accent'
-                                : 'text-muted hover:bg-elev'
-                        }`}
+                    <ChannelPill
                         key={subscription.id}
-                        onClick={() =>
+                        name={subscription.topic.name}
+                        onSelect={() =>
                             navigate({
                                 search: { priority, tags, topic: subscription.topic.name },
                                 to: '/app/channels',
                             })
                         }
-                    >
-                        {subscription.topic.name}
-                    </button>
+                        owned={subscription.topic.isOwner}
+                        selected={subscription.topic.name === selectedTopic}
+                    />
+                ))}
+
+                {owned.length > 0 && subscriptions.length > 0 && (
+                    <span aria-hidden className="h-4 w-px bg-line" />
+                )}
+
+                {owned.map((topic) => (
+                    <ChannelPill
+                        key={topic.id}
+                        name={topic.name}
+                        onSelect={() =>
+                            navigate({
+                                search: { priority, tags, topic: topic.name },
+                                to: '/app/channels',
+                            })
+                        }
+                        owned={topic.isOwner}
+                        selected={topic.name === selectedTopic}
+                    />
                 ))}
             </div>
 
             <StatsStrip
-                loading={subscriptionsLoading || metricsLoading}
+                loading={channelsLoading || metricsLoading}
                 metrics={metrics ?? null}
                 subscription={subscription ?? null}
             />


### PR DESCRIPTION
Reserving a topic (Pulse/Beam) had two gaps in the dashboard:

1. **Seats are limited but there was no way to give one back.** The release was already implemented server-side — `DELETE /topics/:name/claim` and `api.releaseTopic()` — but nothing in the website called either. Both were dead code.
2. **The Channels list only showed subscriptions.** A topic you reserved but never subscribed to was invisible, and therefore unmanageable.

No server, shared-package or Prisma changes: this is website-only.

## Changes

**`hooks/use-channels.ts`** (new) merges `useSubscriptions()` with `useTopics()` (the owner-scoped `GET /topics`), returning `subscriptions` plus `owned` — topics you own and are *not* subscribed to. A topic in both lists stays in `subscriptions` only, since that row already carries `topic.isOwner`.

**`hooks/use-topics.ts`** adds `useReleaseTopic()` and extends the shared ownership-invalidation helper to also invalidate `queryKeys.billing`, so the *Owned topics* usage bar updates without a reload.

**`channel-actions-menu.tsx`** now takes `{ topic, subscription?, onRemoved }` instead of a required `Subscription`, so owned-but-unsubscribed topics get a menu at all. Settings/Unsubscribe are gated on a subscription and a **Subscribe** item takes their place otherwise. `ManageTopicDialog` gained a **Danger zone → Release ownership** button behind `window.confirm`, matching the webhook-delete pattern. Copy states what the endpoint actually does: the name becomes claimable, access resets to public, member roles are dropped, messages and subscriptions are kept.

**`sidebar.tsx`** grows a `NOT SUBSCRIBED` group under `CHANNELS` (capped at 6, hidden with the rest of the block on the collapsed rail). The crown is driven by `topic.isOwner`, so it shows on owned channels in *both* groups — the point being to spot ownership in a long list.

**`access-mode.tsx`** (new) lifts `ACCESS_MODE_OPTIONS` out of the actions menu and adds an `AccessModeIcon`. Read-only (`Book`) now appears in the sidebar alongside private (`Lock`); public stays unmarked. The Manage dialog imports the same options, so the two can't drift. All three glyphs — crown, read-only, private — carry a hover `title`, built from the existing `label`/`description` fields.

**`routes/app/channels.tsx`** adds owned pills after a divider, resolves the selection against both lists, and shows a `not subscribed` hint in the toolbar title.

## Notes

- The sidebar now issues `GET /topics` on every dashboard page rather than only on `/app/publish`. It's cached by TanStack Query's default 30s `staleTime`, but flagging it as a new per-page request.
- Tooltips wrap each icon in a `<span title>` — a `title` attribute on an `<svg>` doesn't reliably surface as a tooltip.

## Verification

`bun lint`, `tsc --noEmit`, `vite build` and Vitest (46 tests, 10 files) all pass, including a new `use-channels.test.ts` covering the dedupe and loading states. `bun format` reports no changes.

Not yet exercised against a live stack: the claim → release round trip needs a signed-in Pulse/Beam account.
