### PR TITLE
refactor(mobile): move the message share action into an ellipsis menu

### DIFF
--- a/packages/emitsignal-mobile/app/messages/[id].tsx
+++ b/packages/emitsignal-mobile/app/messages/[id].tsx
@@ -1,5 +1,4 @@
 import { buildCurlExample } from '@emitsignal/shared/publish-example';
-import { externalUrlLabel } from '@emitsignal/shared/url';
 import { useQuery } from '@tanstack/react-query';
 import { router, useLocalSearchParams } from 'expo-router';
 import { useState } from 'react';
@@ -8,8 +7,8 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { AttachmentPreview } from '@/components/attachment-preview';
 import { WChip, WCode, WDot } from '@/components/base-theme';
+import { MessageActionsMenu } from '@/components/message-actions-menu';
 import { MessageMedia } from '@/components/message-media';
-import { MessageShareButton } from '@/components/message-share-button';
 import { ScreenHeader } from '@/components/screen-header';
 import { SkeletonMessageDetail } from '@/components/skeleton';
 import { IconSymbol } from '@/components/ui/icon-symbol';
@@ -93,7 +92,7 @@ export default function MessageDetailScreen() {
         <SafeAreaView edges={['top']} style={styles.root}>
             <ScreenHeader
                 altName={message.topicName}
-                right={<MessageShareButton messageId={message.id} title={message.title} />}
+                right={<MessageActionsMenu messageId={message.id} title={message.title} />}
                 subtitle={relativeTime(message.createdAt)}
                 title={message.topicName ?? 'message'}
             />
@@ -174,34 +173,16 @@ export default function MessageDetailScreen() {
                                 }
 
                                 if (action.type === 'view') {
-                                    const host = externalUrlLabel(action.url);
-
                                     return (
                                         <Pressable
                                             key={i}
                                             onPress={() => action.url && handleView(action.url)}
                                             style={styles.actionBtn}
                                         >
-                                            <IconSymbol
-                                                color={palette.fg}
-                                                name="arrow.up.right.square"
-                                                size={14}
-                                            />
-
-                                            <View style={styles.actionLabel}>
-                                                <Text style={styles.actionText}>
-                                                    {action.label ?? 'View'}
-                                                </Text>
-
-                                                {host ? (
-                                                    <Text
-                                                        numberOfLines={1}
-                                                        style={styles.actionHost}
-                                                    >
-                                                        {host}
-                                                    </Text>
-                                                ) : null}
-                                            </View>
+                                            <IconSymbol color={palette.fg} name="globe" size={14} />
+                                            <Text style={styles.actionText}>
+                                                {action.label ?? 'View'}
+                                            </Text>
                                         </Pressable>
                                     );
                                 }
@@ -317,13 +298,6 @@ const createStyles = (palette: Palette) =>
             justifyContent: 'center',
             paddingVertical: 10,
         },
-        actionHost: {
-            color: palette.fgDim,
-            fontFamily: Fonts.mono,
-            fontSize: 10,
-            marginTop: 1,
-        },
-        actionLabel: { alignItems: 'center' },
         actionPrimary: { backgroundColor: palette.violet, borderColor: palette.violet },
         actionPrimaryText: { color: palette.bg, fontSize: 12.5, fontWeight: '600' },
         actions: { flexDirection: 'row', gap: 8, marginTop: 14 },

--- a/packages/emitsignal-mobile/components/message-actions-menu.tsx
+++ b/packages/emitsignal-mobile/components/message-actions-menu.tsx
@@ -3,13 +3,13 @@ import * as Haptics from 'expo-haptics';
 import { useState } from 'react';
 import { Modal, Pressable, Share, StyleSheet, Text, View } from 'react-native';
 
-import { IconSymbol } from '@/components/ui/icon-symbol';
+import { type ActionMenuItem, NativeActionMenu } from '@/components/ui/native-action-menu';
 import { Fonts, type Palette } from '@/constants/theme';
 import { useThemedStyles } from '@/hooks/use-themed-styles';
 import { api, WEB_URL } from '@/lib/api';
 import { apiErrorMessage } from '@/lib/api-error';
 
-interface MessageShareButtonProps {
+interface MessageActionsMenuProps {
     messageId: string;
     title: string;
 }
@@ -19,8 +19,8 @@ interface Refusal {
     topicName: string;
 }
 
-export function MessageShareButton({ messageId, title }: MessageShareButtonProps) {
-    const { palette, styles } = useThemedStyles(createStyles);
+export function MessageActionsMenu({ messageId, title }: MessageActionsMenuProps) {
+    const { styles } = useThemedStyles(createStyles);
     const [busy, setBusy] = useState(false);
     const [refusal, setRefusal] = useState<null | Refusal>(null);
     const [error, setError] = useState<null | string>(null);
@@ -80,6 +80,10 @@ export function MessageShareButton({ messageId, title }: MessageShareButtonProps
         }
     };
 
+    const menuItems: ActionMenuItem[] = [
+        { icon: 'square.and.arrow.up', label: 'Share', onPress: () => void share() },
+    ];
+
     const dismiss = () => {
         setRefusal(null);
         setError(null);
@@ -87,14 +91,7 @@ export function MessageShareButton({ messageId, title }: MessageShareButtonProps
 
     return (
         <>
-            <Pressable
-                accessibilityLabel="Share this message"
-                disabled={busy}
-                onPress={share}
-                style={styles.shareBtn}
-            >
-                <IconSymbol color={palette.fg} name="square.and.arrow.up" size={16} />
-            </Pressable>
+            <NativeActionMenu accessibilityLabel="Message actions" items={menuItems} />
 
             <Modal
                 animationType="fade"
@@ -166,14 +163,6 @@ const createStyles = (palette: Palette) =>
             paddingVertical: 11,
         },
         saveText: { color: palette.bg, fontSize: 13, fontWeight: '700' },
-        shareBtn: {
-            alignItems: 'center',
-            backgroundColor: palette.bgElev,
-            borderRadius: 8,
-            height: 32,
-            justifyContent: 'center',
-            width: 32,
-        },
         sheetActions: { flexDirection: 'row', gap: 10, marginTop: 18 },
         sheetBackdrop: {
             alignItems: 'center',


### PR DESCRIPTION
## What

- The message detail header no longer shows a bare share icon. It now uses the same ellipsis `NativeActionMenu` as the topic screen (native SwiftUI `Menu` on iOS, RN modal dropdown elsewhere), with **Share** as the first item — cleaner, and scalable as more message actions land.
- `components/message-share-button.tsx` → `components/message-actions-menu.tsx` (`MessageShareButton` → `MessageActionsMenu`). The private-topic refusal / "Make public" modal is unchanged.
- Reverted the destination host line under the "View" action button: back to the globe icon and the label alone.

## Verification

- `bunx tsc --noEmit` — clean
- `bunx expo lint` — clean (one pre-existing `useMemo` deps warning in `topic-actions-menu.tsx`)