### PR TITLE
feat(website): signal OG template for shared messages, and sign /api/og urls

### DIFF
--- a/packages/emitsignal-docker/.env.example
+++ b/packages/emitsignal-docker/.env.example
@@ -5,6 +5,12 @@
 #   openssl rand -base64 32
 BETTER_AUTH_SECRET=
 
+# Required. Signs the /api/og image URLs so only the website can render branded
+# OG cards. If unset the website falls back to a dev secret that is committed to
+# the repo, and anyone can put arbitrary text on an EmitSignal-branded image.
+#   openssl rand -base64 32
+OG_SIGNING_SECRET=
+
 # ── Database (production) ─────────────────────────────────────────────────────
 # Required for production compose. Used as POSTGRES_PASSWORD and in DATABASE_URL.
 POSTGRES_PASSWORD=

--- a/packages/emitsignal-docker/docker-compose.dev.yml
+++ b/packages/emitsignal-docker/docker-compose.dev.yml
@@ -184,6 +184,7 @@ services:
                    cd /app/packages/emitsignal-website &&
                    bunx vite dev --port 5173 --host"
         environment:
+            OG_SIGNING_SECRET: 'emitsignal-dev-og-secret'
             VITE_API_URL: 'http://localhost:5100'
             VITE_SENTRY_DSN: '${VITE_SENTRY_DSN:-}'
             VITE_SENTRY_ENABLED: '${VITE_SENTRY_ENABLED:-false}'

--- a/packages/emitsignal-docker/docker-compose.yml
+++ b/packages/emitsignal-docker/docker-compose.yml
@@ -249,6 +249,7 @@ services:
                 VITE_SENTRY_DSN: '${VITE_SENTRY_DSN:-}'
                 VITE_SENTRY_ENABLED: '${VITE_SENTRY_ENABLED:-false}'
         environment:
+            OG_SIGNING_SECRET: '${OG_SIGNING_SECRET}'
             # Same DSN as the client build (VITE_SENTRY_DSN): SSR and browser
             # are the same Sentry project, distinguished automatically by SDK name.
             SENTRY_DSN: '${VITE_SENTRY_DSN:-}'

--- a/packages/emitsignal-website/.env.example
+++ b/packages/emitsignal-website/.env.example
@@ -10,3 +10,7 @@ VITE_SENTRY_DSN=
 VITE_SENTRY_ENABLED=false
 
 VITE_SITE_URL=https://emitsignal.com
+
+# Secret used to sign /api/og URLs. Set this in production, or anyone can
+# generate branded OG images on your domain.
+OG_SIGNING_SECRET=

--- a/packages/emitsignal-website/src/lib/api-server-fns.ts
+++ b/packages/emitsignal-website/src/lib/api-server-fns.ts
@@ -7,6 +7,8 @@ import { getRequestHeader } from '@tanstack/react-start/server';
 import type { ApiKey } from '#/hooks/use-api-keys';
 
 import { API_URL } from '#/lib/api';
+import { signedOgUrl } from '#/lib/og-signature';
+import { SITE_URL } from '#/lib/seo';
 
 export interface SessionResponse {
     user: {
@@ -17,6 +19,8 @@ export interface SessionResponse {
         onboarded?: boolean;
     };
 }
+
+export type SharedMessagePage = { ogImage: string } & SharedMessage;
 
 async function authedGet<TResponse>(path: string): Promise<TResponse> {
     const apiUrl = process.env.API_URL ?? API_URL;
@@ -36,7 +40,7 @@ async function authedGet<TResponse>(path: string): Promise<TResponse> {
 
 export const fetchSharedMessageServer = createServerFn()
     .validator((shareId: string) => shareId)
-    .handler(async ({ data: shareId }): Promise<null | SharedMessage> => {
+    .handler(async ({ data: shareId }): Promise<null | SharedMessagePage> => {
         const apiUrl = process.env.API_URL ?? API_URL;
 
         const response = await fetch(`${apiUrl}/share/${encodeURIComponent(shareId)}`);
@@ -45,7 +49,19 @@ export const fetchSharedMessageServer = createServerFn()
             return null;
         }
 
-        return (await response.json()) as SharedMessage;
+        const shared = (await response.json()) as SharedMessage;
+
+        const ogImage = signedOgUrl(SITE_URL, {
+            date: new Date(shared.message.createdAt).toISOString().slice(0, 10),
+            description: shared.message.body.slice(0, 200),
+            priority: String(shared.message.priority),
+            tags: shared.message.tags.join(','),
+            template: 'signal',
+            title: shared.message.title,
+            topic: shared.topic.name,
+        });
+
+        return { ...shared, ogImage };
     });
 
 export const fetchBillingServer = createServerFn().handler(() =>

--- a/packages/emitsignal-website/src/lib/blog-fns.ts
+++ b/packages/emitsignal-website/src/lib/blog-fns.ts
@@ -2,6 +2,10 @@ import { createServerFn } from '@tanstack/react-start';
 
 import type { PostFrontmatter, PostHeading, PostMeta } from './blog';
 
+import { AUTHORS } from './blog';
+import { signedOgUrl } from './og-signature';
+import { SITE_URL } from './seo';
+
 type MDXMetaModule = {
     frontmatter: PostFrontmatter;
     headings?: PostHeading[];
@@ -37,8 +41,22 @@ export type PostDetail = {
     frontmatter: PostFrontmatter;
     headings: PostHeading[];
     next: null | PostMeta;
+    ogImage: string;
     related: PostMeta[];
 };
+
+// Signed here, not in the route's head(), so the secret stays server-side.
+function postOgImage(frontmatter: PostFrontmatter): string {
+    return signedOgUrl(SITE_URL, {
+        author: AUTHORS[frontmatter.author].name,
+        category: frontmatter.category,
+        date: frontmatter.date,
+        description: frontmatter.excerpt,
+        readTime: String(frontmatter.readTime),
+        template: frontmatter.featured ? 'field' : 'editorial',
+        title: frontmatter.title,
+    });
+}
 
 export const fetchPostMeta = createServerFn()
     .validator((slug: string) => slug)
@@ -74,6 +92,7 @@ export const fetchPostMeta = createServerFn()
             frontmatter: meta.frontmatter,
             headings: meta.headings,
             next: next ?? null,
+            ogImage: postOgImage(meta.frontmatter),
             related: relatedPosts,
         };
     });

--- a/packages/emitsignal-website/src/lib/og-signature.ts
+++ b/packages/emitsignal-website/src/lib/og-signature.ts
@@ -3,7 +3,9 @@ import { createHmac } from 'node:crypto';
 const DEV_OG = 'emitsignal-dev-og-secret';
 
 export function ogSignature(parameters: URLSearchParams): string {
-    return createHmac('sha256', process.env.OG_SIGNING_SECRET ?? DEV_OG)
+    // `||`, not `??`: docker compose resolves an unset variable to an empty
+    // string, which would otherwise be used as the HMAC key.
+    return createHmac('sha256', process.env.OG_SIGNING_SECRET || DEV_OG)
         .update(canonicalQuery(parameters))
         .digest('hex')
         .slice(0, 16);

--- a/packages/emitsignal-website/src/lib/og-signature.ts
+++ b/packages/emitsignal-website/src/lib/og-signature.ts
@@ -1,0 +1,48 @@
+import { createHmac } from 'node:crypto';
+
+const DEV_OG = 'emitsignal-dev-og-secret';
+
+export function ogSignature(parameters: URLSearchParams): string {
+    return createHmac('sha256', process.env.OG_SIGNING_SECRET ?? DEV_OG)
+        .update(canonicalQuery(parameters))
+        .digest('hex')
+        .slice(0, 16);
+}
+
+export function signedOgUrl(siteUrl: string, parameters: Record<string, string>): string {
+    const query = new URLSearchParams(parameters);
+    query.sort();
+    query.set('sig', ogSignature(query));
+
+    return `${siteUrl}/api/og?${query.toString()}`;
+}
+
+export function verifyOgSignature(parameters: URLSearchParams): boolean {
+    return constantTimeEqual(parameters.get('sig') ?? '', ogSignature(parameters));
+}
+
+/**
+ * Params are sorted so the signer and the verifier always hash the same string,
+ * regardless of the order they were appended in.
+ */
+function canonicalQuery(parameters: URLSearchParams): string {
+    const unsigned = new URLSearchParams(parameters);
+    unsigned.delete('sig');
+    unsigned.sort();
+
+    return unsigned.toString();
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+    if (a.length !== b.length) {
+        return false;
+    }
+
+    let diff = 0;
+
+    for (let index = 0; index < a.length; index++) {
+        diff |= a.charCodeAt(index) ^ b.charCodeAt(index);
+    }
+
+    return diff === 0;
+}

--- a/packages/emitsignal-website/src/routes/api/og.tsx
+++ b/packages/emitsignal-website/src/routes/api/og.tsx
@@ -1,6 +1,10 @@
+import type { ReactElement } from 'react';
+
 import { Resvg } from '@resvg/resvg-js';
 import { createFileRoute } from '@tanstack/react-router';
 import satori from 'satori';
+
+import { hashTopicLevel, PRIORITY_HEX, priorityHex, priorityLabel } from '#/lib/priority';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -14,6 +18,15 @@ interface CardProps {
 }
 
 type FontEntry = { data: ArrayBuffer; name: string; weight: 400 | 700 };
+
+interface SignalCardProps {
+    date: string;
+    description: string;
+    priority: number;
+    tags: string[];
+    title: string;
+    topic: string;
+}
 
 // ─── Category palette (mirrors lib/blog.ts PostCategory + design tokens) ─────
 
@@ -535,6 +548,290 @@ function PulseMark({ color, size }: { color: string; size: number }) {
     );
 }
 
+function renderCard(
+    template: string,
+    props: CardProps,
+    searchParameters: URLSearchParams,
+): ReactElement {
+    if (template === 'signal') {
+        return (
+            <SignalCard
+                date={props.date}
+                description={props.description}
+                priority={Math.min(
+                    5,
+                    Math.max(1, Number(searchParameters.get('priority') ?? '3') || 3),
+                )}
+                tags={(bounded(searchParameters.get('tags'), 120) ?? '')
+                    .split(',')
+                    .map((tag) => tag.trim())
+                    .filter(Boolean)}
+                title={props.title}
+                topic={bounded(searchParameters.get('topic'), 60) ?? props.category}
+            />
+        );
+    }
+
+    if (template === 'field') {
+        return <FieldCard {...props} />;
+    }
+
+    return <EditorialCard {...props} />;
+}
+
+function SignalCard({ date, description, priority, tags, title, topic }: SignalCardProps) {
+    const accent = priorityHex(priority);
+    const topicColor = PRIORITY_HEX[hashTopicLevel(topic)];
+    const fs = adaptiveTitleSize(title, 54, 38);
+
+    return (
+        <div
+            style={{
+                background: '#000000',
+                display: 'flex',
+                flexDirection: 'column',
+                height: '100%',
+                overflow: 'hidden',
+                padding: '46px 56px',
+                position: 'relative',
+                width: '100%',
+            }}
+        >
+            {/* Priority glow — top-right */}
+            <div
+                style={{
+                    background: `radial-gradient(circle, ${accent} 0%, transparent 68%)`,
+                    height: 560,
+                    left: '58%',
+                    opacity: 0.28,
+                    position: 'absolute',
+                    top: '-180px',
+                    width: 560,
+                }}
+            />
+
+            {/* Dot grid texture */}
+            <div
+                style={{
+                    backgroundImage: `radial-gradient(#232427 1px, transparent 1px)`,
+                    backgroundSize: '26px 26px',
+                    height: '100%',
+                    left: 0,
+                    opacity: 0.5,
+                    position: 'absolute',
+                    top: 0,
+                    width: '100%',
+                }}
+            />
+
+            {/* Top bar */}
+            <div
+                style={{
+                    alignItems: 'center',
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    position: 'relative',
+                }}
+            >
+                <div
+                    style={{
+                        alignItems: 'center',
+                        color: '#f7f7f8',
+                        display: 'flex',
+                        fontFamily: 'Inter',
+                        fontSize: 20,
+                        fontWeight: 500,
+                        gap: 12,
+                        letterSpacing: -0.5,
+                    }}
+                >
+                    <PulseMark color="#a78bfa" size={26} />
+                    <span>emitsignal</span>
+                </div>
+                <div
+                    style={{
+                        alignItems: 'center',
+                        border: '1px solid #232427',
+                        borderRadius: 999,
+                        color: '#a1a1a6',
+                        display: 'flex',
+                        fontFamily: 'Inter',
+                        fontSize: 13,
+                        fontWeight: 700,
+                        gap: 8,
+                        letterSpacing: 2,
+                        padding: '7px 14px',
+                        textTransform: 'uppercase',
+                    }}
+                >
+                    <div
+                        style={{
+                            backgroundColor: '#4ade80',
+                            borderRadius: '50%',
+                            height: 7,
+                            width: 7,
+                        }}
+                    />
+                    Shared signal
+                </div>
+            </div>
+
+            {/* The message card */}
+            <div
+                style={{
+                    backgroundColor: '#0b0b0d',
+                    border: '1px solid #232427',
+                    borderRadius: 22,
+                    display: 'flex',
+                    flex: 1,
+                    flexDirection: 'column',
+                    marginTop: 30,
+                    overflow: 'hidden',
+                    padding: '34px 38px',
+                    position: 'relative',
+                }}
+            >
+                {/* Priority rail */}
+                <div
+                    style={{
+                        backgroundColor: accent,
+                        bottom: 0,
+                        left: 0,
+                        position: 'absolute',
+                        top: 0,
+                        width: 4,
+                    }}
+                />
+
+                {/* Topic row */}
+                <div style={{ alignItems: 'center', display: 'flex', gap: 14 }}>
+                    <AuthorAvatar color={topicColor} name={topic} size={44} />
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                        <span
+                            style={{
+                                color: '#f7f7f8',
+                                fontFamily: 'Inter',
+                                fontSize: 19,
+                                fontWeight: 700,
+                                letterSpacing: -0.3,
+                            }}
+                        >
+                            {topic}
+                        </span>
+                        <span style={{ color: '#71717a', fontFamily: 'Inter', fontSize: 14 }}>
+                            public topic · {fmtDate(date)}
+                        </span>
+                    </div>
+
+                    <div style={{ display: 'flex', flex: 1 }} />
+
+                    <div
+                        style={{
+                            alignItems: 'center',
+                            backgroundColor: `${accent}1f`,
+                            border: `1px solid ${accent}59`,
+                            borderRadius: 999,
+                            color: accent,
+                            display: 'flex',
+                            fontFamily: 'Inter',
+                            fontSize: 14,
+                            fontWeight: 700,
+                            gap: 8,
+                            letterSpacing: 1.2,
+                            padding: '8px 16px',
+                            textTransform: 'uppercase',
+                        }}
+                    >
+                        <div
+                            style={{
+                                backgroundColor: accent,
+                                borderRadius: '50%',
+                                height: 8,
+                                width: 8,
+                            }}
+                        />
+                        p{priority} · {priorityLabel(priority)}
+                    </div>
+                </div>
+
+                {/* Title + excerpt */}
+                <div
+                    style={{
+                        display: 'flex',
+                        flex: 1,
+                        flexDirection: 'column',
+                        gap: 16,
+                        justifyContent: 'center',
+                    }}
+                >
+                    <div
+                        style={{
+                            color: '#f7f7f8',
+                            fontFamily: 'Inter',
+                            fontSize: fs,
+                            fontWeight: 700,
+                            letterSpacing: -1.6,
+                            lineHeight: 1.08,
+                            maxWidth: 940,
+                        }}
+                    >
+                        {title}
+                    </div>
+                    <div
+                        style={{
+                            color: '#a1a1a6',
+                            fontFamily: 'Inter',
+                            fontSize: 19,
+                            lineHeight: 1.5,
+                            maxWidth: 900,
+                        }}
+                    >
+                        {truncate(description, 150)}
+                    </div>
+                </div>
+
+                {/* Tags */}
+                <div style={{ display: 'flex', gap: 10 }}>
+                    {tags.slice(0, 4).map((tag) => (
+                        <div
+                            key={tag}
+                            style={{
+                                backgroundColor: '#111114',
+                                border: '1px solid #232427',
+                                borderRadius: 8,
+                                color: '#a1a1a6',
+                                display: 'flex',
+                                fontFamily: 'Inter',
+                                fontSize: 14,
+                                padding: '6px 12px',
+                            }}
+                        >
+                            #{tag}
+                        </div>
+                    ))}
+                </div>
+            </div>
+
+            {/* Footer */}
+            <div
+                style={{
+                    alignItems: 'center',
+                    color: '#71717a',
+                    display: 'flex',
+                    fontFamily: 'Inter',
+                    fontSize: 15,
+                    justifyContent: 'space-between',
+                    marginTop: 18,
+                    position: 'relative',
+                }}
+            >
+                <span>Subscribe for push, email, or a live terminal stream.</span>
+                <span style={{ color: '#a78bfa' }}>es subscribe {topic}</span>
+            </div>
+        </div>
+    );
+}
+
 function truncate(text: string, max: number): string {
     return text.length > max ? text.slice(0, max).trimEnd() + '…' : text;
 }
@@ -564,11 +861,12 @@ export const Route = createFileRoute('/api/og')({
                 };
 
                 const template = searchParams.get('template') ?? 'editorial';
-                const Card = template === 'field' ? FieldCard : EditorialCard;
+
+                const card = renderCard(template, props, searchParams);
 
                 const fonts = await loadFonts();
 
-                const svg = await satori(<Card {...props} />, {
+                const svg = await satori(card, {
                     fonts,
                     height: 630,
                     width: 1200,

--- a/packages/emitsignal-website/src/routes/api/og.tsx
+++ b/packages/emitsignal-website/src/routes/api/og.tsx
@@ -4,6 +4,7 @@ import { Resvg } from '@resvg/resvg-js';
 import { createFileRoute } from '@tanstack/react-router';
 import satori from 'satori';
 
+import { verifyOgSignature } from '#/lib/og-signature';
 import { hashTopicLevel, PRIORITY_HEX, priorityHex, priorityLabel } from '#/lib/priority';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -843,6 +844,10 @@ export const Route = createFileRoute('/api/og')({
         handlers: {
             GET: async ({ request }) => {
                 const { searchParams } = new URL(request.url);
+
+                if (!verifyOgSignature(searchParams)) {
+                    return new Response('Invalid or missing signature', { status: 403 });
+                }
 
                 const props: CardProps = {
                     author: bounded(searchParams.get('author'), 80) ?? 'EmitSignal',

--- a/packages/emitsignal-website/src/routes/blog/$slug.tsx
+++ b/packages/emitsignal-website/src/routes/blog/$slug.tsx
@@ -25,16 +25,7 @@ export const Route = createFileRoute('/blog/$slug')({
         const path = `/blog/${params.slug}`;
         const title = `${frontmatter.title} - EmitSignal Blog`;
 
-        const ogImage =
-            `${SITE_URL}/api/og` +
-            `?author=${encodeURIComponent(author.name)}` +
-            `&category=${frontmatter.category}` +
-            `&date=${frontmatter.date}` +
-            `&description=${encodeURIComponent(description)}` +
-            `&readTime=${frontmatter.readTime}` +
-            `&template=${frontmatter.featured ? 'field' : 'editorial'}` +
-            `&title=${encodeURIComponent(frontmatter.title)}` +
-            `&views=${frontmatter.views}`;
+        const ogImage = data.ogImage;
 
         const articleSchema = {
             '@context': 'https://schema.org',

--- a/packages/emitsignal-website/src/routes/s/$shareId.tsx
+++ b/packages/emitsignal-website/src/routes/s/$shareId.tsx
@@ -45,10 +45,13 @@ export const Route = createFileRoute('/s/$shareId')({
 
         const ogImage =
             `${SITE_URL}/api/og` +
-            `?category=${encodeURIComponent(data.topic.name)}` +
+            `?date=${encodeURIComponent(new Date(data.message.createdAt).toISOString().slice(0, 10))}` +
             `&description=${encodeURIComponent(description)}` +
-            `&template=editorial` +
-            `&title=${encodeURIComponent(data.message.title)}`;
+            `&priority=${data.message.priority}` +
+            `&tags=${encodeURIComponent(data.message.tags.join(','))}` +
+            `&template=signal` +
+            `&title=${encodeURIComponent(data.message.title)}` +
+            `&topic=${encodeURIComponent(data.topic.name)}`;
 
         return buildSeoMeta({
             description,

--- a/packages/emitsignal-website/src/routes/s/$shareId.tsx
+++ b/packages/emitsignal-website/src/routes/s/$shareId.tsx
@@ -1,5 +1,3 @@
-import type { SharedMessage } from '@emitsignal/shared/api';
-
 import { shareUrl } from '@emitsignal/shared/share';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { Bell, Globe, Share2 } from 'lucide-react';
@@ -13,10 +11,10 @@ import { Dot } from '#/components/ui/dot';
 import { Logo } from '#/components/ui/logo';
 import { Pill } from '#/components/ui/pill';
 import { SubHeading } from '#/components/ui/sub-head';
-import { fetchSharedMessageServer } from '#/lib/api-server-fns';
+import { fetchSharedMessageServer, type SharedMessagePage } from '#/lib/api-server-fns';
 import { relativeTime } from '#/lib/format';
 import { priorityHex } from '#/lib/priority';
-import { buildSeoMeta, SITE_URL } from '#/lib/seo';
+import { buildSeoMeta } from '#/lib/seo';
 import { useSiteOrigin } from '#/lib/site-origin';
 
 const PRIORITY_LABELS: Record<number, string> = {
@@ -30,7 +28,7 @@ const PRIORITY_LABELS: Record<number, string> = {
 export const Route = createFileRoute('/s/$shareId')({
     component: SharePage,
     head: ({ loaderData, params }) => {
-        const data = loaderData as null | SharedMessage | undefined;
+        const data = loaderData as null | SharedMessagePage | undefined;
 
         if (!data) {
             return buildSeoMeta({
@@ -43,19 +41,9 @@ export const Route = createFileRoute('/s/$shareId')({
 
         const description = data.message.body.slice(0, 200);
 
-        const ogImage =
-            `${SITE_URL}/api/og` +
-            `?date=${encodeURIComponent(new Date(data.message.createdAt).toISOString().slice(0, 10))}` +
-            `&description=${encodeURIComponent(description)}` +
-            `&priority=${data.message.priority}` +
-            `&tags=${encodeURIComponent(data.message.tags.join(','))}` +
-            `&template=signal` +
-            `&title=${encodeURIComponent(data.message.title)}` +
-            `&topic=${encodeURIComponent(data.topic.name)}`;
-
         return buildSeoMeta({
             description,
-            image: ogImage,
+            image: data.ogImage,
             path: `/s/${params.shareId}`,
             title: `${data.message.title} — ${data.topic.name}`,
             type: 'article',
@@ -92,7 +80,7 @@ function NotPublic() {
 }
 
 function SharePage() {
-    const shared = Route.useLoaderData() as null | SharedMessage | undefined;
+    const shared = Route.useLoaderData() as null | SharedMessagePage | undefined;
     const { shareId } = Route.useParams();
     const { payload } = Route.useSearch();
     const origin = useSiteOrigin();


### PR DESCRIPTION
Shared signals at `/s/:shareId` were reusing the blog's editorial OG card, so a
shared message unfurled with a fake byline and a "5 min read". This adds a
template built for messages, and closes an abuse hole in the endpoint it goes
through.

## Signal OG template

`/api/og?template=signal` renders the topic, priority and body excerpt instead
of blog metadata: a priority-coloured left rail and background glow (P5 reads
red, P2 violet, from the shared `PRIORITY_HEX` palette), topic avatar and name,
a `P4 · HIGH` chip, adaptive title sizing, and up to four tag chips (the row is
omitted when a message has none).

## Signing

The endpoint rendered arbitrary caller-supplied text onto a branded card with no
auth, so anyone could mint official-looking EmitSignal images **on our own
domain** — an unfurl that passes every "is this the real domain" check a reader
might make. This was already true of the existing `editorial` and `field`
templates; the new template widened the surface rather than creating it.

URLs are now HMAC-signed and verified before any font load or render:

| Request | Result |
| --- | --- |
| Unsigned URL with attacker-chosen text | 403 |
| Forged or empty `sig` | 403 |
| Valid `sig`, title tampered with | 403 |
| Valid `sig` + `&bust=9` appended | 403 |
| Real blog / share page OG tag | 200 `image/png` |

Signing runs inside the `createServerFn` handlers rather than the routes'
`head()`, which is isomorphic — that keeps `OG_SIGNING_SECRET` off the client.
Verified against the production build: the client bundle contains no secret, no
`createHmac`, and no signing code.

This also closes a cheap DoS. Renders are ~96ms of blocking CPU each, and junk
query params used to be ignored while still producing a unique URL — trivially
cache-bustable. Appending a param now invalidates the signature.

Cost of the gate, measured on the production build:

| | Cost |
| --- | --- |
| `verifyOgSignature()` | 1.58 µs |
| Full render (satori + resvg) | ~96 ms |

A render costs ~61,000x more than the check that gates it, so verification adds
~0.0017% to a legitimate render. Per core that is ~10 renders/sec versus
~633,000 rejections/sec.

## Deploying

**Set `OG_SIGNING_SECRET` in the production `.env` before merging** —
`openssl rand -base64 32`. It is wired through to the `website` service in
`docker-compose.yml` and documented in the docker `.env.example`; the dev
compose file pins a literal dev value so `docker compose up` keeps working.

There is a dev fallback so an unconfigured checkout still runs, but that
constant lives in the source — production needs a real value or URLs stay
forgeable. Compose warns on startup when the variable is missing.

Note that compose resolves an *unset* variable to an empty string, which `??`
would have happily used as the HMAC key; the check now treats empty as unset.

## Notes

- Dropped the unused `views` param from the blog OG URL; the handler never read
  it and it would only have been signed dead weight.
- An invalid `date` still renders the literal text "Invalid Date". Now only
  reachable by someone who can sign, so it is cosmetic — left alone.

## Testing

`tsc`, `bun lint` and all 54 website tests pass at both commits. Attack and
legitimate paths in the table above were exercised against a running server;
signing was benchmarked against `node .output/server/index.mjs`.
