### PR TITLE
feat(website): rail-style OG card and a quieter share page

### DIFF
--- a/packages/emitsignal-website/src/routes/api/og.tsx
+++ b/packages/emitsignal-website/src/routes/api/og.tsx
@@ -580,10 +580,15 @@ function renderCard(
     return <EditorialCard {...props} />;
 }
 
+// ══════════════════════════════════════════════════════════════════════════════
+// C · SIGNAL
+// Shared-message card for /s/:shareId. Content sits directly on the ground with
+// a priority-coloured rail across the top edge — no panel, unlike the blog cards.
+// ══════════════════════════════════════════════════════════════════════════════
 function SignalCard({ date, description, priority, tags, title, topic }: SignalCardProps) {
     const accent = priorityHex(priority);
     const topicColor = PRIORITY_HEX[hashTopicLevel(topic)];
-    const fs = adaptiveTitleSize(title, 54, 38);
+    const fs = adaptiveTitleSize(title, 64, 46);
 
     return (
         <div
@@ -593,21 +598,32 @@ function SignalCard({ date, description, priority, tags, title, topic }: SignalC
                 flexDirection: 'column',
                 height: '100%',
                 overflow: 'hidden',
-                padding: '46px 56px',
+                padding: '58px 64px 54px',
                 position: 'relative',
                 width: '100%',
             }}
         >
-            {/* Priority glow — top-right */}
+            {/* Priority rail — the only chrome on the card */}
+            <div
+                style={{
+                    backgroundColor: accent,
+                    height: 8,
+                    left: 0,
+                    position: 'absolute',
+                    top: 0,
+                    width: '100%',
+                }}
+            />
+
             <div
                 style={{
                     background: `radial-gradient(circle, ${accent} 0%, transparent 68%)`,
-                    height: 560,
-                    left: '58%',
-                    opacity: 0.28,
+                    height: 620,
+                    left: '56%',
+                    opacity: 0.22,
                     position: 'absolute',
-                    top: '-180px',
-                    width: 560,
+                    top: '-140px',
+                    width: 620,
                 }}
             />
 
@@ -649,186 +665,125 @@ function SignalCard({ date, description, priority, tags, title, topic }: SignalC
                     <PulseMark color="#a78bfa" size={26} />
                     <span>emitsignal</span>
                 </div>
-                <div
-                    style={{
-                        alignItems: 'center',
-                        border: '1px solid #232427',
-                        borderRadius: 999,
-                        color: '#a1a1a6',
-                        display: 'flex',
-                        fontFamily: 'Inter',
-                        fontSize: 13,
-                        fontWeight: 700,
-                        gap: 8,
-                        letterSpacing: 2,
-                        padding: '7px 14px',
-                        textTransform: 'uppercase',
-                    }}
-                >
+                <div style={{ alignItems: 'center', display: 'flex', gap: 10 }}>
                     <div
                         style={{
-                            backgroundColor: '#4ade80',
+                            backgroundColor: accent,
                             borderRadius: '50%',
-                            height: 7,
-                            width: 7,
+                            height: 8,
+                            width: 8,
                         }}
                     />
-                    Shared signal
-                </div>
-            </div>
-
-            {/* The message card */}
-            <div
-                style={{
-                    backgroundColor: '#0b0b0d',
-                    border: '1px solid #232427',
-                    borderRadius: 22,
-                    display: 'flex',
-                    flex: 1,
-                    flexDirection: 'column',
-                    marginTop: 30,
-                    overflow: 'hidden',
-                    padding: '34px 38px',
-                    position: 'relative',
-                }}
-            >
-                {/* Priority rail */}
-                <div
-                    style={{
-                        backgroundColor: accent,
-                        bottom: 0,
-                        left: 0,
-                        position: 'absolute',
-                        top: 0,
-                        width: 4,
-                    }}
-                />
-
-                {/* Topic row */}
-                <div style={{ alignItems: 'center', display: 'flex', gap: 14 }}>
-                    <AuthorAvatar color={topicColor} name={topic} size={44} />
-                    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-                        <span
-                            style={{
-                                color: '#f7f7f8',
-                                fontFamily: 'Inter',
-                                fontSize: 19,
-                                fontWeight: 700,
-                                letterSpacing: -0.3,
-                            }}
-                        >
-                            {topic}
-                        </span>
-                        <span style={{ color: '#71717a', fontFamily: 'Inter', fontSize: 14 }}>
-                            public topic · {fmtDate(date)}
-                        </span>
-                    </div>
-
-                    <div style={{ display: 'flex', flex: 1 }} />
-
-                    <div
+                    <span
                         style={{
-                            alignItems: 'center',
-                            backgroundColor: `${accent}1f`,
-                            border: `1px solid ${accent}59`,
-                            borderRadius: 999,
                             color: accent,
-                            display: 'flex',
                             fontFamily: 'Inter',
                             fontSize: 14,
                             fontWeight: 700,
-                            gap: 8,
-                            letterSpacing: 1.2,
-                            padding: '8px 16px',
+                            letterSpacing: 2,
                             textTransform: 'uppercase',
                         }}
                     >
-                        <div
-                            style={{
-                                backgroundColor: accent,
-                                borderRadius: '50%',
-                                height: 8,
-                                width: 8,
-                            }}
-                        />
                         p{priority} · {priorityLabel(priority)}
-                    </div>
-                </div>
-
-                {/* Title + excerpt */}
-                <div
-                    style={{
-                        display: 'flex',
-                        flex: 1,
-                        flexDirection: 'column',
-                        gap: 16,
-                        justifyContent: 'center',
-                    }}
-                >
-                    <div
-                        style={{
-                            color: '#f7f7f8',
-                            fontFamily: 'Inter',
-                            fontSize: fs,
-                            fontWeight: 700,
-                            letterSpacing: -1.6,
-                            lineHeight: 1.08,
-                            maxWidth: 940,
-                        }}
-                    >
-                        {title}
-                    </div>
-                    <div
-                        style={{
-                            color: '#a1a1a6',
-                            fontFamily: 'Inter',
-                            fontSize: 19,
-                            lineHeight: 1.5,
-                            maxWidth: 900,
-                        }}
-                    >
-                        {truncate(description, 150)}
-                    </div>
-                </div>
-
-                {/* Tags */}
-                <div style={{ display: 'flex', gap: 10 }}>
-                    {tags.slice(0, 4).map((tag) => (
-                        <div
-                            key={tag}
-                            style={{
-                                backgroundColor: '#111114',
-                                border: '1px solid #232427',
-                                borderRadius: 8,
-                                color: '#a1a1a6',
-                                display: 'flex',
-                                fontFamily: 'Inter',
-                                fontSize: 14,
-                                padding: '6px 12px',
-                            }}
-                        >
-                            #{tag}
-                        </div>
-                    ))}
+                    </span>
                 </div>
             </div>
 
-            {/* Footer */}
+            {/* Topic line, title, excerpt */}
             <div
                 style={{
-                    alignItems: 'center',
-                    color: '#71717a',
                     display: 'flex',
-                    fontFamily: 'Inter',
-                    fontSize: 15,
-                    justifyContent: 'space-between',
-                    marginTop: 18,
+                    flex: 1,
+                    flexDirection: 'column',
+                    gap: 22,
+                    justifyContent: 'center',
                     position: 'relative',
                 }}
             >
-                <span>Subscribe for push, email, or a live terminal stream.</span>
-                <span style={{ color: '#a78bfa' }}>es subscribe {topic}</span>
+                <div style={{ alignItems: 'center', display: 'flex', gap: 12 }}>
+                    <TopicMark color={topicColor} name={topic} size={30} />
+                    <span
+                        style={{
+                            color: '#f7f7f8',
+                            fontFamily: 'Inter',
+                            fontSize: 19,
+                            fontWeight: 700,
+                            letterSpacing: -0.3,
+                        }}
+                    >
+                        {topic}
+                    </span>
+                    <span style={{ color: '#3f3f46', fontFamily: 'Inter', fontSize: 16 }}>·</span>
+                    <span style={{ color: '#71717a', fontFamily: 'Inter', fontSize: 16 }}>
+                        {fmtDate(date)}
+                    </span>
+                </div>
+
+                <div
+                    style={{
+                        color: '#f7f7f8',
+                        fontFamily: 'Inter',
+                        fontSize: fs,
+                        fontWeight: 700,
+                        letterSpacing: -2,
+                        lineHeight: 1.04,
+                        maxWidth: 1020,
+                    }}
+                >
+                    {title}
+                </div>
+
+                <div
+                    style={{
+                        color: '#a1a1a6',
+                        fontFamily: 'Inter',
+                        fontSize: 20,
+                        lineHeight: 1.5,
+                        maxWidth: 880,
+                    }}
+                >
+                    {truncate(description, 150)}
+                </div>
             </div>
+
+            {/* Tags */}
+            <div
+                style={{
+                    color: '#71717a',
+                    display: 'flex',
+                    fontFamily: 'Inter',
+                    fontSize: 16,
+                    gap: 14,
+                    position: 'relative',
+                }}
+            >
+                {tags.slice(0, 5).map((tag) => (
+                    <span key={tag}>#{tag}</span>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+function TopicMark({ color, name, size }: { color: string; name: string; size: number }) {
+    return (
+        <div
+            style={{
+                alignItems: 'center',
+                background: `linear-gradient(180deg, ${color}, ${color}77)`,
+                borderRadius: 8,
+                color: '#000000',
+                display: 'flex',
+                flexShrink: 0,
+                fontSize: size * 0.36,
+                fontWeight: 700,
+                height: size,
+                justifyContent: 'center',
+                letterSpacing: -0.3,
+                width: size,
+            }}
+        >
+            {avatarInitials(name)}
         </div>
     );
 }

--- a/packages/emitsignal-website/src/routes/s/$shareId.tsx
+++ b/packages/emitsignal-website/src/routes/s/$shareId.tsx
@@ -1,6 +1,6 @@
 import { shareUrl } from '@emitsignal/shared/share';
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { Bell, Globe, Share2 } from 'lucide-react';
+import { Bell, Globe, Share2, UserRound } from 'lucide-react';
 
 import { MessageArticle } from '#/components/app/inbox/message-article';
 import { ShareTargets } from '#/components/share/share-targets';
@@ -164,18 +164,30 @@ function SharePage() {
                         </h1>
 
                         <div className="mb-5.5 flex flex-wrap items-center gap-2.5 border-b border-line pb-5.5">
-                            <Avatar
-                                name={sender?.name ?? topic.name}
-                                rounded={100}
-                                size={26}
-                                src={sender?.image}
-                            />
-                            <span className="text-[13px] text-muted">
-                                Published by{' '}
-                                <span className="font-medium text-fg">
-                                    {sender?.name ?? 'a publisher'}
-                                </span>
-                            </span>
+                            {sender?.name ? (
+                                <>
+                                    <Avatar
+                                        name={sender.name}
+                                        rounded={100}
+                                        size={26}
+                                        src={sender.image}
+                                    />
+                                    <span className="text-[13px] text-muted">
+                                        Published by{' '}
+                                        <span className="font-medium text-fg">{sender.name}</span>
+                                    </span>
+                                </>
+                            ) : (
+                                <>
+                                    <span className="flex size-[26px] shrink-0 items-center justify-center rounded-full bg-elev text-dim">
+                                        <UserRound size={14} />
+                                    </span>
+                                    <span className="text-[13px] text-muted">
+                                        Published{' '}
+                                        <span className="font-medium text-fg">anonymously</span>
+                                    </span>
+                                </>
+                            )}
                             <span className="text-faint">·</span>
                             <span className="font-mono text-[11.5px] text-dim">
                                 {relativeTime(message.createdAt)}

--- a/packages/emitsignal-website/src/routes/s/$shareId.tsx
+++ b/packages/emitsignal-website/src/routes/s/$shareId.tsx
@@ -1,6 +1,6 @@
 import { shareUrl } from '@emitsignal/shared/share';
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { Bell, Globe, Share2, UserRound } from 'lucide-react';
+import { Globe, Share2, UserRound } from 'lucide-react';
 
 import { MessageArticle } from '#/components/app/inbox/message-article';
 import { ShareTargets } from '#/components/share/share-targets';
@@ -10,7 +10,6 @@ import { CopyButton } from '#/components/ui/copy-button';
 import { Dot } from '#/components/ui/dot';
 import { Logo } from '#/components/ui/logo';
 import { Pill } from '#/components/ui/pill';
-import { SubHeading } from '#/components/ui/sub-head';
 import { fetchSharedMessageServer, type SharedMessagePage } from '#/lib/api-server-fns';
 import { relativeTime } from '#/lib/format';
 import { priorityHex } from '#/lib/priority';
@@ -112,7 +111,6 @@ function SharePage() {
                 <Link className="no-underline" to="/">
                     <Logo pulse size={14} />
                 </Link>
-                <span className="truncate font-mono text-[11px] text-dim">/ s / {shareId}</span>
                 <div className="flex-1" />
                 <Link
                     className="rounded-md border border-accent px-3 py-1.5 text-[12px] font-semibold text-accent no-underline hover:bg-accent/10"
@@ -209,33 +207,6 @@ function SharePage() {
                         </span>
                     </div>
                 </article>
-
-                <section className="mt-5.5 rounded-[14px] border border-line bg-elev p-5 sm:p-6">
-                    <div className="flex flex-wrap items-center gap-3.5">
-                        <div className="min-w-[220px] flex-1">
-                            <div className="mb-1 text-[16px] font-semibold">
-                                Get <span className="font-mono text-accent">{topic.name}</span> as
-                                it ships
-                            </div>
-                            <p className="m-0 text-[12.5px] leading-[1.5] text-muted">
-                                Subscribe for push, email, or a live terminal stream. Public topic —
-                                no invite needed.
-                            </p>
-                        </div>
-                        <Link
-                            className="inline-flex items-center gap-2 rounded-lg bg-accent px-4 py-2.5 text-[13px] font-semibold text-bg no-underline hover:bg-accent-dim"
-                            to="/sign-in"
-                        >
-                            <Bell size={13} />
-                            Subscribe
-                        </Link>
-                    </div>
-
-                    <div className="mt-4">
-                        <SubHeading>OR FOLLOW IT FROM YOUR TERMINAL</SubHeading>
-                        <CodeBlock code={`es subscribe ${topic.name}`} />
-                    </div>
-                </section>
 
                 <div className="mt-5.5 flex items-center justify-center gap-2 font-mono text-[11px] text-dim">
                     <span>Shared with</span>

--- a/packages/emitsignal-website/src/routes/s/$shareId.tsx
+++ b/packages/emitsignal-website/src/routes/s/$shareId.tsx
@@ -1,6 +1,6 @@
 import { shareUrl } from '@emitsignal/shared/share';
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { Globe, Share2, UserRound } from 'lucide-react';
+import { ArrowUpRight, Globe, Share2, UserRound } from 'lucide-react';
 
 import { MessageArticle } from '#/components/app/inbox/message-article';
 import { ShareTargets } from '#/components/share/share-targets';
@@ -12,6 +12,7 @@ import { Logo } from '#/components/ui/logo';
 import { Pill } from '#/components/ui/pill';
 import { fetchSharedMessageServer, type SharedMessagePage } from '#/lib/api-server-fns';
 import { relativeTime } from '#/lib/format';
+import { DOCS_URL } from '#/lib/links';
 import { priorityHex } from '#/lib/priority';
 import { buildSeoMeta } from '#/lib/seo';
 import { useSiteOrigin } from '#/lib/site-origin';
@@ -214,6 +215,16 @@ function SharePage() {
                     <span className="hidden text-faint sm:inline">
                         · push notifications with one curl
                     </span>
+                    <span className="text-faint">·</span>
+                    <a
+                        className="inline-flex items-center gap-1 text-dim no-underline hover:text-accent"
+                        href={DOCS_URL}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                    >
+                        Read the docs
+                        <ArrowUpRight size={11} />
+                    </a>
                 </div>
             </main>
         </div>


### PR DESCRIPTION
Follow-up to #88, tightening the shared-signal page and its unfurl card.

## The OG card is now a rail, not a panel

The `signal` template dropped its elevated card. Content sits directly on the
black ground with the priority colour running as an 8px rail across the top
edge, so a shared signal stops looking like a card floating inside a card —
nothing else in EmitSignal frames content that way.

Also gone from the image, as noise rather than information: the `SHARED SIGNAL`
pill, the `es subscribe <topic>` line, and "Subscribe for push, email, or a live
terminal stream." Tags survive as plain monospace at the foot.

Rendered through the real signed endpoint at 1200x630, not mocked:

| Case | Result |
| --- | --- |
| P3, three tags | Matches the intended design |
| P5, two-line title + long excerpt | Red rail, wraps cleanly |
| P1, no tags at all | Degrades cleanly, no empty row |

The topic avatar keeps its `hashTopicLevel` colour rather than echoing the
priority, so it stays consistent with topic avatars elsewhere in the app.

## Share page

- **Anonymous publishers read as anonymous.** With no `sender`, the byline fell
  back to the *topic's* initials and the words "a publisher", so an unattributed
  publish looked like an account named after the topic. It now shows a neutral
  person icon and "Published anonymously".
- **Header carries the logo alone.** The `/ s / <shareId>` breadcrumb is gone.
- **The subscribe section is gone** for every visitor — heading, blurb, Subscribe
  button and the terminal snippet. It also removes a CTA that pointed at
  `/sign-in` regardless of whether you were already signed in.
- **The footer links to the docs**, which is now the page's only outbound nudge:
  *Shared with (mark) emitsignal - push notifications with one curl - Read the docs*.

## Testing

`tsc`, `bun lint`, prettier and all 54 website tests pass.

The OG card was verified by rendering real PNGs through the signed endpoint. The
share page changes were **not** verified in a browser — the route's loader needs
the API on `:5100`, which was not running locally, so the page falls back to its
"not public" state. They are structural JSX and typecheck clean, but deserve a
look once deployed.

## Not included

Caching `/api/og` was discussed and deliberately left aside. Renders are ~96ms of
blocking CPU and nothing between the internet and the Bun process holds a copy
today; the signing work means the key space is now bounded to one entry per
shared message plus one per blog post, so a small in-process LRU keyed on `sig`
would be the cheap win whenever it is wanted.
