### PR TITLE
ci: send the npm token via NPM_CONFIG_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,9 +108,17 @@ jobs:
                   fi
 
             # ── Track A: npm ────────────────────────────────────────────────
+            # NPM_CONFIG_TOKEN rather than a written .npmrc: a secret carrying a stray
+            # newline silently produced an empty `_authToken=` line, which bun reports as
+            # "missing authentication" — indistinguishable from an unset secret.
             - name: Publish to npm
               run: |
-                  echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > "$HOME/.npmrc"
+                  NPM_CONFIG_TOKEN="$(printf '%s' "$NPM_TOKEN" | tr -d '[:space:]')"
+                  if [ -z "$NPM_CONFIG_TOKEN" ]; then
+                      echo "::error::NPM_TOKEN is empty or whitespace-only"
+                      exit 1
+                  fi
+                  export NPM_CONFIG_TOKEN
                   bun publish --access public
               env:
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Every release since release-please took over has failed at `Publish to npm` with:

```
error: missing authentication (run `bunx npm login`)
```

`v1.5.0` through `v1.11.1` were tagged but never published — npm still serves `1.4.0` — and because the step aborts the job, the standalone binaries and the Homebrew formula were skipped for those releases too.

## Cause

The step wrote `//registry.npmjs.org/:_authToken=${NPM_TOKEN}` into `$HOME/.npmrc`. The stored secret carries a leading newline, so line 1 became `…_authToken=` with an empty value and the token landed orphaned on line 2, where npmrc ignores it. Actions masks each line of a multi-line secret separately, so the log still printed `NPM_TOKEN: ***` and the secret looked healthy.

Testing the variants against bun 1.3.13 on Linux, only that one shape produces this error — a leading space, surrounding quotes, CRLF endings, or a malformed registry key all still transmit a token and come back `401 Unauthorized`. That distinction matters: `missing authentication` means bun found no token at all, which is why rotating the npm token changed nothing and why the token's page reads "Last used: never".

## Change

Pass the token through `NPM_CONFIG_TOKEN` instead of writing an npmrc file, stripping whitespace first and failing fast when the result is empty. Verified in a `oven/bun:1.3.13` container: the same newline-prefixed value reproduces the failure on the old path and authenticates on the new one, and a genuinely empty secret now fails with a clear message rather than one that mimics an unset token.

The secret still needs re-setting without the stray newline; this makes the workflow tolerate it either way.
