### PR TITLE
feat(mobile): show owner and access mode icons on the channel list

### DIFF
--- a/packages/emitsignal-mobile/app/(tabs)/channels.tsx
+++ b/packages/emitsignal-mobile/app/(tabs)/channels.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { AccessModeIcon, OwnerIcon } from '@/components/access-mode';
 import { ActivitySparkline, WDot, WLogo, WTopicAvatar } from '@/components/base-theme';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { Fonts, type Palette, PriorityColors } from '@/constants/theme';
@@ -187,7 +188,14 @@ function ChannelRow({
             <View style={{ flex: 1, minWidth: 0 }}>
                 <View style={styles.channelHeader}>
                     <WDot level={priority} size={5} />
-                    <Text style={styles.channelName}>{sub.topic.name}</Text>
+
+                    <Text numberOfLines={1} style={styles.channelName}>
+                        {sub.topic.name}
+                    </Text>
+
+                    {sub.topic.isOwner && <OwnerIcon />}
+
+                    <AccessModeIcon accessMode={sub.topic.accessMode} />
                 </View>
 
                 {description && (
@@ -224,6 +232,7 @@ const createStyles = (palette: Palette) =>
         },
         channelName: {
             color: palette.fg,
+            flexShrink: 1,
             fontFamily: Fonts.mono,
             fontSize: 13,
             fontWeight: '500',

--- a/packages/emitsignal-mobile/components/access-mode.tsx
+++ b/packages/emitsignal-mobile/components/access-mode.tsx
@@ -1,0 +1,84 @@
+import type { ReactElement } from 'react';
+
+import { StyleSheet, View } from 'react-native';
+
+import type { AccessMode } from '@/lib/api';
+
+import { IconSymbol } from '@/components/ui/icon-symbol';
+import { usePalette } from '@/hooks/use-palette';
+
+type AccessModeIconName = 'book' | 'globe' | 'lock';
+
+export const ACCESS_MODE_OPTIONS: {
+    description: string;
+    icon: AccessModeIconName;
+    label: string;
+    value: AccessMode;
+}[] = [
+    {
+        description: 'Anyone can read and publish',
+        icon: 'globe',
+        label: 'Public',
+        value: 'public',
+    },
+    {
+        description: 'Anyone can read; only members can publish',
+        icon: 'book',
+        label: 'Read-only',
+        value: 'readonly',
+    },
+    {
+        description: 'Only members can read and publish',
+        icon: 'lock',
+        label: 'Private',
+        value: 'private',
+    },
+];
+
+/**
+ * Public is the default and carries no restriction, so it stays unmarked —
+ * only the modes that limit who can read or publish get a glyph.
+ */
+export function AccessModeIcon({
+    accessMode,
+    size = 12,
+}: {
+    accessMode: AccessMode;
+    size?: number;
+}): null | ReactElement {
+    const palette = usePalette();
+
+    const option = ACCESS_MODE_OPTIONS.find((option) => option.value === accessMode);
+
+    if (!option || option.value === 'public') {
+        return null;
+    }
+
+    return (
+        <View
+            accessibilityLabel={`${option.label}. ${option.description}`}
+            accessibilityRole="image"
+            style={styles.badge}
+        >
+            <IconSymbol color={palette.fgDim} name={option.icon} size={size} />
+        </View>
+    );
+}
+
+export function OwnerIcon({ size = 12 }: { size?: number }): ReactElement {
+    const palette = usePalette();
+
+    return (
+        <View
+            accessibilityLabel="You own this topic"
+            accessibilityRole="image"
+            style={styles.badge}
+        >
+            <IconSymbol color={palette.fgDim} name="crown" size={size} />
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    badge: { flexShrink: 0 },
+});

--- a/packages/emitsignal-mobile/components/ui/icon-symbol.tsx
+++ b/packages/emitsignal-mobile/components/ui/icon-symbol.tsx
@@ -27,6 +27,7 @@ const MAPPING = {
     'bell.fill': 'notifications',
     'bell.slash': 'notifications-off',
     bolt: 'bolt',
+    book: 'menu-book',
     'camera.fill': 'photo-camera',
 
     'chart.bar': 'bar-chart',
@@ -37,6 +38,7 @@ const MAPPING = {
     'circle.fill': 'circle',
 
     clock: 'schedule',
+    crown: 'workspace-premium',
     'doc.on.doc': 'content-copy',
     'doc.text': 'description',
     ellipsis: 'more-horiz',
@@ -58,6 +60,7 @@ const MAPPING = {
     key: 'vpn-key',
     link: 'link',
     'list.bullet': 'list',
+    lock: 'lock',
     magnifyingglass: 'search',
     megaphone: 'campaign',
     'paperplane.fill': 'send',


### PR DESCRIPTION
## What

The website sidebar marks each channel with a crown when you own the topic and a book/lock glyph for read-only and private topics. The mobile channel list had no such indicator — this brings it to parity.

## Changes

- **`components/access-mode.tsx`** (new) — mirrors the website's `components/app/channels/access-mode.tsx`: the same `ACCESS_MODE_OPTIONS` (public / read-only / private, identical labels and descriptions), an `AccessModeIcon` that stays unmarked for `public`, and an `OwnerIcon` for the crown. Both read `usePalette().fgDim` to match the web `text-dim`, and expose the label plus description through `accessibilityLabel` since React Native has no `title` tooltip.
- **`app/(tabs)/channels.tsx`** — the row header renders the owner crown and the access-mode glyph after the topic name, in the same order as the web sidebar. The name gained `numberOfLines={1}` and `flexShrink: 1` so long names truncate instead of pushing the icons off the row.
- **`components/ui/icon-symbol.tsx`** — mapped `crown`, `book`, and `lock` (`globe` already existed).

No server or shared-type changes were needed: `GET /subscriptions` already returns `topic.isOwner` and `topic.accessMode`.

## Note

Material Icons has no crown glyph, so Android/web fall back to `workspace-premium` (a laurel badge); iOS renders the real SF Symbol. Shipping a vector crown asset would give exact parity if that matters.

## Testing

- `bunx tsc --noEmit` — clean
- `bunx expo lint` — only the pre-existing `topic-actions-menu.tsx` exhaustive-deps warning
- `bun format` — no changes
- Not yet verified visually in a simulator.